### PR TITLE
PROD-2325 Incorrect Legacy Web Price & Duration -> dev

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -117,7 +117,7 @@ export function getDataExplorationPriceAndTimelineEstimate() {
   };
 }
 
-export function getWebsiteDesignPriceAndTimelineEstimate() {  
+export function getWebsiteDesignPriceAndTimelineEstimate() {
   const total = workPriceDesign.getPrice(workPriceDesign);
   return {
     total,
@@ -187,8 +187,8 @@ export function getFindMeDataPriceAndTimelineEstimate() {
 }
 
 export function getDynamicPriceAndTimelineEstimate(formData) {
-  const numOfPages = formData?.pageDetails?.pages?.length || 1
-  const numOfDevices = formData?.basicInfo?.selectedDevice.option.length || 1
+  const numOfPages = formData?.form?.pageDetails?.pages?.length || 1
+  const numOfDevices = formData?.form?.basicInfo?.selectedDevice.option.length || 1
   return getDynamicPriceAndTimeline(numOfPages, numOfDevices);
 }
 


### PR DESCRIPTION
## What's in this PR?
Fixes the issue of the legacy web intake's price and duration not getting updated when selecting additional pages and devices by updating the reference to the form data.

## Screenshots
The price and duration gets updated from the default of $398/$199
![image](https://user-images.githubusercontent.com/105746013/176730168-242fcdaf-bbd1-400a-9639-3151a92a41bf.png)
