### PR TITLE
PROD-2332 Incorrect web design price -> dev

### DIFF
--- a/src-ts/tools/work/work-lib/work-provider/work-functions/work-factory/work.factory.ts
+++ b/src-ts/tools/work/work-lib/work-provider/work-functions/work-factory/work.factory.ts
@@ -274,11 +274,6 @@ function getCost(challenge: Challenge, type: WorkType): number | undefined {
             const legacyDeviceCount: number | undefined = form?.basicInfo?.selectedDevice?.option?.length
             return priceConfig.getPrice(priceConfig, legacyPageCount, legacyDeviceCount)
 
-        case WorkType.design:
-            const pageCount: number = getCountFromString(findMetadata(challenge, ChallengeMetadataName.pageCount)?.value)
-            const deviceCount: number = getCountFromString(findMetadata(challenge, ChallengeMetadataName.deviceCount)?.value)
-            return priceConfig.getPrice(priceConfig, pageCount, deviceCount)
-
         default:
             return priceConfig.getPrice(priceConfig)
     }


### PR DESCRIPTION
## What's in this PR?
Removes piece of redundant code that was previously used to compute web design costs, but since the new web design no longer takes into consideration the number of pages and devices, it is no longer needed.

## Screenshot
The web design price still correctly shows as $499
![image](https://user-images.githubusercontent.com/105746013/176938403-222500a2-c4a5-4c81-844f-f3b345982aed.png)
