### PR TITLE
PROD-2374 Payment Error -> dev

### DIFF
--- a/src/services/payment.js
+++ b/src/services/payment.js
@@ -48,11 +48,10 @@ export async function processPayment(
     const url = `${config.API.V5}/customer-payments`;
     let response = await xhrPostAsync(url, body);
 
-    const customerPayment = response.data;
-    if (customerPayment.status === "requires_action") {
-      await stripe.handleCardAction(customerPayment.clientSecret);
+    if (response.status === "requires_action") {
+      await stripe.handleCardAction(response.clientSecret);
       response = await xhrPatchAsync(
-        `${config.API.V5}/customer-payments/${customerPayment.id}/confirm`,
+        `${config.API.V5}/customer-payments/${response.id}/confirm`,
         JSON.stringify({})
       );
     }


### PR DESCRIPTION
## What's in this PR?
Solves the issue of error being thrown when making a payment by removing the reference to the axios response.data which no longer exists after using xhrPostAsync. 

## Screenshots
Payment now goes through and user is redirected to Thank You page after a successful payment:
![image](https://user-images.githubusercontent.com/105746013/177380870-8cc40400-3792-4a49-9260-93a47ae49529.png)
