### PR TITLE
PROD-2145 Fix Prod Build to use Prod Env Vars -> master

### DIFF
--- a/build-dev.sh
+++ b/build-dev.sh
@@ -1,2 +1,0 @@
-export REACT_APP_HOST_ENV=dev
-yarn react-app-rewired build

--- a/build-prod.sh
+++ b/build-prod.sh
@@ -1,2 +1,0 @@
-export REACT_APP_HOST_ENV=prod
-yarn react-app-rewired build

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "scripts": {
         "start": "sh start-ssl.sh",
         "start:bsouza": "sh start-ssl-bsouza.sh",
-        "build": "sh build-dev.sh",
-        "build:prod": "sh build-prod.sh",
+        "build": "yarn react-app-rewired build",
         "lint": "tslint 'src-ts/**/*.{ts,tsx}'",
         "lint:fix": "tslint 'src-ts/**/*.{ts,tsx}' --fix",
         "eslint": "eslint 'src/**/*.{js,jsx}'",

--- a/src-ts/config/environments/environment.config.ts
+++ b/src-ts/config/environments/environment.config.ts
@@ -8,7 +8,6 @@ import { EnvironmentConfigProd } from './environment.prod.config'
 
 function getEnvironmentConfig(): GlobalConfig {
 
-    console.debug('REACT_APP_HOST_ENV', process.env.REACT_APP_HOST_ENV)
     switch (process.env.REACT_APP_HOST_ENV) {
 
         case AppHostEnvironment.bsouza:

--- a/src-ts/lib/functions/logging-functions/logging.functions.ts
+++ b/src-ts/lib/functions/logging-functions/logging.functions.ts
@@ -4,8 +4,6 @@ import { GlobalConfig } from '../../global-config.model'
 
 export function initialize(config: GlobalConfig): void {
 
-    console.debug('init logging', config.LOGGING)
-
     // if we don't have a token and service,
     // logging isn't supported in this environment,
     // so don't initialize anything
@@ -13,7 +11,6 @@ export function initialize(config: GlobalConfig): void {
         return
     }
 
-    console.debug('logging env', config.ENV)
     datadogLogs.init({
         clientToken: config.LOGGING.PUBLIC_TOKEN,
         env: config.ENV,
@@ -21,7 +18,7 @@ export function initialize(config: GlobalConfig): void {
         silentMultipleInit: true,
     })
 
-    info(`initialized logging for ${config.ENV} test`)
+    info(`initialized logging for ${config.ENV}`)
 }
 
 export function error(message: string, messageContext?: object): void {

--- a/src-ts/tools/work/work-not-logged-in/WorkNotLoggedIn.tsx
+++ b/src-ts/tools/work/work-not-logged-in/WorkNotLoggedIn.tsx
@@ -65,7 +65,7 @@ const WorkNotLoggedIn: FC<{}> = () => {
                 <div className={styles.rightContent}>
 
                     <h2 className={styles.title}>
-                        TOPCODER put our great talent to work for you
+                        put our great talent to work for you
                     </h2>
 
                     <p className={styles.description}>


### PR DESCRIPTION
This fixes the build script to use the environment variables set by the build process instead of explicitly setting the value in the build script itself.

This also removes the addtl logging to troubleshoot this issue.