### PR TITLE
PROD-2419 Adds FCC app location to dev config

### DIFF
--- a/src-ts/config/environments/environment.dev.config.ts
+++ b/src-ts/config/environments/environment.dev.config.ts
@@ -5,7 +5,8 @@ import { EnvironmentConfigDefault } from './environment.default.config'
 
 export const EnvironmentConfigDev: GlobalConfig = {
     ...EnvironmentConfigDefault,
-    DISABLED_TOOLS: [ ],
+    DISABLED_TOOLS: [],
     ENV: AppHostEnvironment.dev,
+    LEARN_SRC: 'https://freecodecamp-mfe.topcoder-dev.com/',
     TAG_MANAGER_ID: 'GTM-W7B537Z',
 }


### PR DESCRIPTION
## What's in this PR?
Adds the LEARN_SRC env var to the dev config so that the deployed app points to the freeCodeCamp app via its CloudFront URL.