### PR TITLE
PROD-2533 fix loading spinner styling -> dev

### DIFF
--- a/src-ts/lib/loading-spinner/LoadingSpinner.tsx
+++ b/src-ts/lib/loading-spinner/LoadingSpinner.tsx
@@ -16,7 +16,7 @@ export interface LoadingSpinnerProps {
 
 const LoadingSpinner: FC<LoadingSpinnerProps> = ({ show = false, className }: LoadingSpinnerProps) => {
     return (
-        <div className={classNames(styles['loading-spinner'], show ? 'show' : 'hide', className)}>
+        <div className={classNames(styles['loading-spinner'], styles[show ? 'show' : 'hide'], className)}>
             <PuffLoader color={'#2196f3'} loading={true} size={100} />
         </div>
     )


### PR DESCRIPTION
This fixes an issue where the show flag wasn't working on the LoadingSpinner bc the we weren't using they module style notation.