### PR TITLE
Ta fcc fix redirect issue on module completion

### DIFF
--- a/src-ts/tools/learn/learn-lib/lesson-provider/lesson.provider.tsx
+++ b/src-ts/tools/learn/learn-lib/lesson-provider/lesson.provider.tsx
@@ -18,7 +18,7 @@ export function useLessonProvider(
     })
 
     useEffect(() => {
-        let mounted: boolean = true;
+        let mounted: boolean = true
 
         if (!course || !module || !lesson) {
             setState((prevState) => ({
@@ -71,7 +71,7 @@ export function useLessonProvider(
             }))
         })
 
-        return () => {mounted = false};
+        return () => {mounted = false}
     }, [provider, course, module, lesson])
 
     return state


### PR DESCRIPTION
Fix an issue related to URL update on fcc.

Issue reproductions steps:
- complete last lesson from a module
- fcc navigates to next module
- main app receives lesson ready event
- main app updates both module & step url params
- this causes the lesson fetch to be called twice (once for module change, once for step change) which on it's own calls 2 url changes in the FCC iframe

All this is basically a normal flow of events with not so pleasant results. The fix is to make the hook to not update component state once it was unmounted.