### PR TITLE
PROD-2583 - fix course outline overlap with content

### DIFF
--- a/src-ts/tools/learn/course-completed/CourseCompletedPage.module.scss
+++ b/src-ts/tools/learn/course-completed/CourseCompletedPage.module.scss
@@ -35,35 +35,6 @@
     }
 }
 
-.course-outline-pane {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    z-index: 1;
-
-    @include ltemd {
-        position: relative;
-        top: auto;
-        left: auto;
-        bottom: auto;
-    }
-}
-
-.course-outline-wrap {
-    width: 406px;
-
-    @include ltemd {
-        width: 100%;
-    }
-}
-
-.course-outline-title {
-    @extend .body-main-bold;
-    flex: 0 0 auto;
-    margin-bottom: $pad-xl;
-}
-
 .content-wrap {
     padding: $pad-mx 0 $pad-xxxxl;
     position: relative;

--- a/src-ts/tools/learn/course-completed/CourseCompletedPage.tsx
+++ b/src-ts/tools/learn/course-completed/CourseCompletedPage.tsx
@@ -12,8 +12,6 @@ import {
 } from '../../../lib'
 import {
     CertificationsProviderData,
-    CollapsiblePane,
-    CourseOutline,
     CoursesProviderData,
     CourseTitle,
     MyCertificationProgressProviderData,
@@ -84,22 +82,6 @@ const CourseCompletedPage: FC<{}> = () => {
                 <>
                     <Breadcrumb items={breadcrumb} />
                     <div className={styles['main-wrap']}>
-                        <div className={styles['course-outline-pane']}>
-                            <CollapsiblePane title='Course Outline'>
-                                <div className={styles['course-outline-wrap']}>
-                                    <div className={styles['course-outline-title']}>
-                                        {courseData?.title}
-                                    </div>
-                                    <CourseOutline
-                                        course={courseData}
-                                        ready={courseDataReady}
-                                        currentStep=''
-                                        progress={progress}
-                                    />
-                                </div>
-                            </CollapsiblePane>
-                        </div>
-
                         <div className={styles['course-frame']}>
                             <div className={styles['content-wrap']}>
                                 <h1>Congratulations!</h1>


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2583

Remove the course outline navigation on the course completed screen