### PR TITLE
PROD-2653 fix opacity of coming soon courses -> dev

### DIFF
--- a/src-ts/tools/learn/learn-lib/course-title/CourseTitle.module.scss
+++ b/src-ts/tools/learn/learn-lib/course-title/CourseTitle.module.scss
@@ -5,6 +5,7 @@
     display: flex;
     gap: $pad-lg;
     align-items: center;
+
     @include ltelg {
         gap: $pad-sm;
     }
@@ -14,6 +15,22 @@
             flex-direction: column;
             text-align: center;
             gap: $pad-lg;
+        }
+    }
+
+    :global(.badge-icon) {
+        svg {
+            @include icon-size(60);
+        }
+        &:global(.lg) {
+            svg {
+                @include icon-size(72);
+            }
+        }
+        &:global(.xl) {
+            svg {
+                @include icon-size(140);
+            }
         }
     }
 }
@@ -44,22 +61,6 @@
     @include ltemd {
         :global(.quote-small.xl) {
             margin-top: $pad-sm;
-        }
-    }
-}
-
-.badge-icon {
-    svg {
-        @include icon-size(60);
-    }
-    &:global(.lg) {
-        svg {
-            @include icon-size(72);
-        }
-    }
-    &:global(.xl) {
-        svg {
-            @include icon-size(140);
         }
     }
 }

--- a/src-ts/tools/learn/learn-lib/course-title/CourseTitle.tsx
+++ b/src-ts/tools/learn/learn-lib/course-title/CourseTitle.tsx
@@ -26,7 +26,7 @@ const CourseTitle: FC<CourseTitleProps> = (props: CourseTitleProps) => {
 
     return (
         <div className={classNames(styles['wrap'], props.size)}>
-            <div className={classNames(styles['badge-icon'], props.size)}>
+            <div className={classNames('badge-icon', props.size)}>
                 <LearnChallengeBadgeIcon />
             </div>
             <div className={styles['text']}>

--- a/src-ts/tools/learn/welcome/courses-card/CoursesCard.module.scss
+++ b/src-ts/tools/learn/welcome/courses-card/CoursesCard.module.scss
@@ -16,10 +16,11 @@
     }
 
     &:global(.soon) {
-        .badge-icon {
+        :global(.badge-icon) {
             opacity: 0.5;
         }
     }
+
     @include ltemd {
         padding: $pad-lg;
     }


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2653

Per Figma, https://www.figma.com/file/nrPRJLlKDqv44b6dkMFVLA/Learning-Paths-UX%2FUI-Design?node-id=1210%3A40611 , the badges for coming soon courses should be 50% opacity compared to the enabled courses.

![Screen Shot 2022-07-26 at 2 17 10 PM](https://user-images.githubusercontent.com/98542587/181113912-ba98992f-4771-4f71-a549-a33066d962e8.png)

