### PR TITLE
PROD-2620 clear cached challenge id on wok list page load

### DIFF
--- a/src-ts/tools/work/work-table/WorkTable.tsx
+++ b/src-ts/tools/work/work-table/WorkTable.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, FC, SetStateAction, useContext, useEffect, useState } from 'react'
 import { NavigateFunction, Params, useNavigate, useParams } from 'react-router-dom'
 
-import { cacheChallengeId } from '../../../../src/autoSaveBeforeLogin' // TODO: move to src-ts
+import { cacheChallengeId, clearCachedChallengeId } from '../../../../src/autoSaveBeforeLogin' // TODO: move to src-ts
 import {
     LoadingSpinner,
     routeContext,
@@ -81,6 +81,10 @@ const WorkTable: FC<{}> = () => {
         work,
         workStatusFilter,
     ])
+
+    useEffect(() => {
+        clearCachedChallengeId()
+    }, [])
 
     // if we couldn't find a workstatusfilter,
     // redirect to the dashboard


### PR DESCRIPTION
## What's in this PR?

- Clear cached challenge id when the work's list page is loaded
- If this is not removed then when the user clicks on any challenge in the work table then the cached challenge is loaded.