### PR TITLE
PROD-2679 - use query params for api calls

### DIFF
--- a/src-ts/lib/functions/xhr-functions/xhr.functions.ts
+++ b/src-ts/lib/functions/xhr-functions/xhr.functions.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
 import { tokenGetAsync, TokenModel } from '../token-functions'
 
@@ -48,12 +48,12 @@ export async function patchAsync<T, R>(url: string, data: T): Promise<R> {
     return output.data
 }
 
-export async function postAsync<T, R>(url: string, data: T): Promise<R> {
-    const output: AxiosResponse<R> = await xhrInstance.post(url, data)
+export async function postAsync<T, R>(url: string, data: T, config?: AxiosRequestConfig<T>): Promise<R> {
+    const output: AxiosResponse<R> = await xhrInstance.post(url, data, config)
     return output.data
 }
 
-export async function putAsync<T, R>(url: string, data: T): Promise<R> {
-    const output: AxiosResponse<R> = await xhrInstance.put(url, data)
+export async function putAsync<T, R>(url: string, data: T, config?: AxiosRequestConfig<T>): Promise<R> {
+    const output: AxiosResponse<R> = await xhrInstance.put(url, data, config)
     return output.data
 }

--- a/src-ts/tools/learn/learn-lib/user-certifications-provider/user-certifications-functions/user-certification-progress.store.ts
+++ b/src-ts/tools/learn/learn-lib/user-certifications-provider/user-certifications-functions/user-certification-progress.store.ts
@@ -21,7 +21,7 @@ export function startAsync(userId: number, certificationId: string, courseId: st
         `${userId}`,
         certificationId,
         courseId,
-    ), data)
+    ), {}, {params: data})
 }
 
 export function updateAsync(certificationProgressId: string, action: UserCertificationUpdateProgressActions, data: any): Promise<LearnUserCertificationProgress> {
@@ -29,5 +29,5 @@ export function updateAsync(certificationProgressId: string, action: UserCertifi
         'certification-progresses',
         certificationProgressId,
         action
-    ), data)
+    ), {}, {params: data})
 }


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2679

- use query params instead of body data when calling current-lesson & complete-lesson & start course