### PR TITLE
Fix Form Groups -> dev

### DIFF
--- a/src-ts/lib/contact-support-form/contact-support-form.config.ts
+++ b/src-ts/lib/contact-support-form/contact-support-form.config.ts
@@ -32,10 +32,6 @@ export const contactSupportFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     label: 'Last Name',
                     name: ContactSupportFormField.last,
@@ -46,10 +42,6 @@ export const contactSupportFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     label: 'Email',
                     name: ContactSupportFormField.email,
@@ -63,10 +55,6 @@ export const contactSupportFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     label: 'How can we help you?',
                     name: ContactSupportFormField.question,

--- a/src-ts/lib/form/form-groups/FormGroups.tsx
+++ b/src-ts/lib/form/form-groups/FormGroups.tsx
@@ -101,7 +101,7 @@ const FormGroups: (props: FormGroupsProps) => JSX.Element = (props: FormGroupsPr
     }
 
     const formGroups: Array<JSX.Element | undefined> = formDef?.groups?.map((element: FormGroup, index: number) => {
-        return <FormGroupItem key={`element-${index}`} group={element} renderFormInput={renderInputField} />
+        return <FormGroupItem key={`element-${index}`} group={element} renderFormInput={renderInputField} totalGroupCount={formDef.groups?.length || 0} />
     }) || []
 
     return (

--- a/src-ts/lib/form/form-groups/form-group-item/FormGroupItem.tsx
+++ b/src-ts/lib/form/form-groups/form-group-item/FormGroupItem.tsx
@@ -10,17 +10,19 @@ import styles from './FormGroupItem.module.scss'
 interface FormGroupItemProps {
     group: FormGroup
     renderFormInput: (input: FormInputModel, index: number) => JSX.Element | undefined
+    totalGroupCount: number
 }
 
 interface ItemRowProps {
     element?: JSX.Element,
     formInputs: Array<JSX.Element | undefined>,
+    hasMultipleGroups: boolean,
     instructions?: string | undefined,
     isMultiFieldGroup: boolean,
     title?: string,
 }
 
-const TwoColumnItem: React.FC<ItemRowProps> = ({ element, formInputs, instructions, isMultiFieldGroup, title}: ItemRowProps) => {
+const TwoColumnItem: React.FC<ItemRowProps> = ({ element, formInputs, hasMultipleGroups, instructions, isMultiFieldGroup, title }: ItemRowProps) => {
     return (
         <>
             <div className={cn(styles['form-group-item'], !isMultiFieldGroup && styles['single-field'])}>
@@ -30,7 +32,7 @@ const TwoColumnItem: React.FC<ItemRowProps> = ({ element, formInputs, instructio
                             <h3 className={styles['title']}>
                                 {title}
                             </h3>
-                            <div className={styles['group-item-instructions']} dangerouslySetInnerHTML={{__html: instructions || ''}}/>
+                            <div className={styles['group-item-instructions']} dangerouslySetInnerHTML={{ __html: instructions || '' }} />
                         </div>
                     )
                 }
@@ -39,12 +41,12 @@ const TwoColumnItem: React.FC<ItemRowProps> = ({ element, formInputs, instructio
                     {formInputs}
                 </div>
             </div>
-            <PageDivider />
+            <PageDivider styleNames={[!hasMultipleGroups ? 'spacingSmall' : '']} />
         </>
     )
 }
 
-const SingleColumnItem: React.FC<ItemRowProps> = ({formInputs, instructions, isMultiFieldGroup, title}: ItemRowProps) => {
+const SingleColumnItem: React.FC<ItemRowProps> = ({ formInputs, hasMultipleGroups, instructions, isMultiFieldGroup, title }: ItemRowProps) => {
     return (
         <>
             <div className={cn(styles['form-group-item'], styles['full-width-container'])}>
@@ -54,27 +56,28 @@ const SingleColumnItem: React.FC<ItemRowProps> = ({formInputs, instructions, isM
                             <h3 className={styles['title']}>
                                 {title}
                             </h3>
-                            <div className={styles['group-item-instructions']} dangerouslySetInnerHTML={{__html: instructions || ''}}/>
+                            <div className={styles['group-item-instructions']} dangerouslySetInnerHTML={{ __html: instructions || '' }} />
                         </>
                     )
                 }
                 <div className={styles['full-width-items']}>{formInputs}</div>
             </div>
-            <PageDivider />
+            <PageDivider styleNames={[!hasMultipleGroups ? 'spacingSmall' : '']} />
         </>
     )
 }
 
-const FromGroupItem: React.FC<FormGroupItemProps> = ({group, renderFormInput}: FormGroupItemProps) => {
+const FormGroupItem: React.FC<FormGroupItemProps> = ({ group, renderFormInput, totalGroupCount }: FormGroupItemProps) => {
     const { instructions, title, inputs, element }: FormGroup = group
 
     const formInputs: Array<JSX.Element | undefined> = inputs?.map((field: FormInputModel, index: number) => renderFormInput(field as FormInputModel, index)) || []
+    const hasMultipleGroups: boolean = totalGroupCount > 1
     const isMultiFieldGroup: boolean = !!(title || instructions)
     const isCardSet: boolean = !!(inputs && inputs.every(input => typeof input.cards !== 'undefined'))
 
     return isCardSet ?
-    <SingleColumnItem instructions={instructions} isMultiFieldGroup={isMultiFieldGroup} formInputs={formInputs} title={title} /> :
-    <TwoColumnItem element={element} instructions={instructions} isMultiFieldGroup={isMultiFieldGroup} formInputs={formInputs} title={title} />
+        <SingleColumnItem hasMultipleGroups={hasMultipleGroups} instructions={instructions} isMultiFieldGroup={isMultiFieldGroup} formInputs={formInputs} title={title} /> :
+        <TwoColumnItem hasMultipleGroups={hasMultipleGroups} element={element} instructions={instructions} isMultiFieldGroup={isMultiFieldGroup} formInputs={formInputs} title={title} />
 }
 
-export default FromGroupItem
+export default FormGroupItem

--- a/src-ts/lib/page-divider/PageDivider.module.scss
+++ b/src-ts/lib/page-divider/PageDivider.module.scss
@@ -10,3 +10,7 @@
         margin: $pad-xxl 0;
     }
 }
+
+.spacingSmall {
+    margin: $pad-lg 0;
+}

--- a/src-ts/tools/work/work-detail-header/WorkFeedback/work-feedback-form.config.ts
+++ b/src-ts/tools/work/work-detail-header/WorkFeedback/work-feedback-form.config.ts
@@ -25,10 +25,6 @@ export const workFeedbackFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     instructions: 'How easy was the platform to use?',
                     name: 'question-2',
@@ -39,10 +35,6 @@ export const workFeedbackFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     instructions: 'How likely are you to recommend Topcoder?',
                     name: 'question-3',
@@ -53,10 +45,6 @@ export const workFeedbackFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     hint: inputOptional,
                     label: 'What can we do to make your experience better?',

--- a/src-ts/utils/settings/account/change-password/change-password-form.config.ts
+++ b/src-ts/utils/settings/account/change-password/change-password-form.config.ts
@@ -46,10 +46,6 @@ export const changePasswordFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     autocomplete: FormInputAutocompleteOption.new,
                     dependentFields: [
@@ -73,10 +69,6 @@ export const changePasswordFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     autocomplete: FormInputAutocompleteOption.off,
                     dependentFields: [

--- a/src-ts/utils/settings/account/edit-name/edit-name-form.config.ts
+++ b/src-ts/utils/settings/account/edit-name/edit-name-form.config.ts
@@ -33,10 +33,6 @@ export const editNameFormDef: FormDefinition = {
                         },
                     ],
                 },
-            ],
-        },
-        {
-            inputs: [
                 {
                     autocomplete: FormInputAutocompleteOption.off,
                     label: 'Last Name',


### PR DESCRIPTION
## What's in this PR?
Fixes the form configs for the following four forms to contain only one group so that it doesn't add separation between each input field. Also fixes styling.
- Name change
- Password change
- Contact support
- Feedback

## Screenshots
![image](https://user-images.githubusercontent.com/105746013/181850720-420022a7-c3af-431d-98df-9326b34b1c11.png)

![image](https://user-images.githubusercontent.com/105746013/181850860-a12447e7-5577-48b5-8879-70711bb57bf5.png)

![image](https://user-images.githubusercontent.com/105746013/181850978-2e3b3d3d-f14d-4b9f-b6bf-2d879ad08bb5.png)

![image](https://user-images.githubusercontent.com/105746013/181851372-f0b1a190-c377-49ad-af49-7e08af9a07b6.png)
