### PR TITLE
PROD-2749 - fix navigation on fcc

### DIFF
--- a/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
+++ b/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
@@ -297,10 +297,11 @@ const FreeCodeCamp: FC<{}> = () => {
         if (lessonPath !== lessonParam) {
             setLessonParam(lessonPath)
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        certificationParam,
-        lessonParam,
-        moduleParam,
+        // DO NOT UPDATE THIS DEPS ARRAY!!
+        // we do not care about changes to the other deps
+        // !!only routeParams needs to trigger this effect!!
         routeParams,
     ])
 

--- a/src-ts/tools/learn/free-code-camp/fcc-frame/FccFrame.tsx
+++ b/src-ts/tools/learn/free-code-camp/fcc-frame/FccFrame.tsx
@@ -25,6 +25,7 @@ const FccFrame: FC<FccFrameProps> = (props: FccFrameProps) => {
     const frameRef: MutableRefObject<HTMLElement | any> = useRef()
     const frameIsReady: MutableRefObject<boolean> = useRef<boolean>(false)
     const { onFccLastLessonNavigation, onFccLessonChange, onFccLessonComplete }: FccFrameProps = props
+    const lessonUrl: string | undefined = props.lesson?.lessonUrl
 
     useEffect(() => {
         if (!frameRef.current || !props.lesson) {
@@ -35,12 +36,13 @@ const FccFrame: FC<FccFrameProps> = (props: FccFrameProps) => {
             Object.assign(frameRef.current, { src: `${EnvironmentConfig.LEARN_SRC}/${props.lesson.lessonUrl}` })
         } else {
             frameRef.current.contentWindow.postMessage(JSON.stringify({
-                data: { path: `/${props.lesson.lessonUrl}` },
+                data: { path: `/${lessonUrl}` },
                 event: 'fcc:url:update',
             }), '*')
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        props.lesson,
+        lessonUrl,
     ])
 
     useEffect(() => {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2749
Lesson not progressing to next step

The deps array for an useEffect doesn't need to always be exhaustive. I should have added the ignore rule for this from the beginning.

Eg. routeParams triggers the effect, and when this is called, the rest of the values are taken from current context anyway, so we're fine, we're not using deprecated values. But it is imperative that only routeParams is the one to trigger the effect.

I'll merge the fix for now so it is deployed and the UI is not stuck, but we can discuss later anyway.