### PR TITLE
TCA-279 revert dev env to use dev GTM -> dev

### DIFF
--- a/src-ts/config/environments/environment.dev.config.ts
+++ b/src-ts/config/environments/environment.dev.config.ts
@@ -7,8 +7,7 @@ export const EnvironmentConfigDev: GlobalConfig = {
     ...EnvironmentConfigDefault,
     ANALYTICS: {
         SEGMENT_KEY: EnvironmentConfigDefault.ANALYTICS.SEGMENT_KEY,
-        TAG_MANAGER_ID: 'GTM-MXXQHG8',
-        // TAG_MANAGER_ID: 'GTM-W7B537Z',
+        TAG_MANAGER_ID: 'GTM-W7B537Z',
     },
     DISABLED_TOOLS: [],
     ENV: AppHostEnvironment.dev,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-279

This PR reverts the dev environment configuration so that it uses the dev GTM account.