### PR TITLE
TCA-488 Shorten Social Share URL -> develop

### DIFF
--- a/src-ts/tools/learn/course-certificate/certificate-view/CertificateView.tsx
+++ b/src-ts/tools/learn/course-certificate/certificate-view/CertificateView.tsx
@@ -56,14 +56,14 @@ const CertificateView: FC<CertificateViewProps> = (props: CertificateViewProps) 
         return `${user} - ${course?.title} Certification`
     }
 
-    const certificationTitle: string = getCertTitle(userName || props.profile.handle)
-
     const certUrl: string = getUserCertificateSsr(
         props.provider,
         props.certification,
         props.profile.handle,
         getCertTitle(props.profile.handle),
     )
+
+    const certificationTitle: string = getCertTitle(userName || props.profile.handle)
 
     const {
         certifications: [completedCertificate],


### PR DESCRIPTION
Twitter doesn't properly display the image for the cert if its URL is too long. This PR fixes that and makes the URL match what's displayed on the image.