### PR TITLE
TCA-512 - add missing cert type gradients

### DIFF
--- a/src-ts/tools/learn/course-certificate/certificate-view/certificate/certificate-bg-pattern/CertificateBgPattern.module.scss
+++ b/src-ts/tools/learn/course-certificate/certificate-view/certificate/certificate-bg-pattern/CertificateBgPattern.module.scss
@@ -24,8 +24,17 @@
     &:global(.theme-qa) {
         background-image: $tc-qa-grad;
     }
+
     &:global(.theme-datascience) {
         background-image: $tc-datascience-grad;
+    }
+
+    &:global(.theme-interview) {
+        background-image: $tc-interview-grad;
+    }
+
+    &:global(.theme-security) {
+        background-image: $tc-security-grad;
     }
 
     > div {

--- a/src-ts/tools/learn/course-certificate/certificate-view/certificate/includes.scss
+++ b/src-ts/tools/learn/course-certificate/certificate-view/certificate/includes.scss
@@ -6,6 +6,8 @@ $tc-dev-grad: linear-gradient(84.92deg, #048467 2.08%, #064871 97.43%);
 $tc-design-grad: linear-gradient(84.92deg, #065D6E 2.08%, #06596E 2.09%, #3E3B91 97.43%);
 $tc-qa-grad: linear-gradient(84.92deg, #363D8C 2.08%, #723390 97.43%);
 $tc-datascience-grad: linear-gradient(84.92deg, #723390 2.08%, #8C384F 97.43%);
+$tc-interview-grad: linear-gradient(84.92deg, #048467 2.08%, #064871 33.85%, #6831A8 66.15%, #8C384D 97.43%);
+$tc-security-grad: linear-gradient(84.92deg, #048467 2.08%, #064871 97.43%);
 
 @mixin grad-text-color($grad) {
     background: $grad;


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-512

Adds new background patterns for the new types of certificates: security and interview prep.

NOTE: there's no figma for these, but I took the same approach as for the other badges/bg patterns and copied the color pattern from the badge to the certificate bg.

![image](https://user-images.githubusercontent.com/2527433/194884007-11f5adf1-a2a9-48f7-93e9-22595f6bd92d.png)

![image](https://user-images.githubusercontent.com/2527433/194884073-3716b793-eda9-4599-b109-d2fb6d01249a.png)
