### PR TITLE
TCA-802 - fixes minor issues in cert details page -> dev

### DIFF
--- a/src-ts/tools/learn/certification-details/certification-curriculum/curriculum-cards/CurriculumCard.module.scss
+++ b/src-ts/tools/learn/certification-details/certification-curriculum/curriculum-cards/CurriculumCard.module.scss
@@ -108,6 +108,7 @@
 
     .cta {
         margin-left: auto;
+        justify-content: flex-end;
         @include ltelg {
             display: none;
         }

--- a/src-ts/tools/learn/certification-details/certification-curriculum/curriculum-cards/CurriculumCard.tsx
+++ b/src-ts/tools/learn/certification-details/certification-curriculum/curriculum-cards/CurriculumCard.tsx
@@ -71,9 +71,11 @@ const CurriculumCard: FC<CurriculumCardProps> = (props: CurriculumCardProps) => 
                 <div className={styles.bottomCta}>
                     {props.cta}
                 </div>
-                <div className={styles.statusBox}>
-                    {renderStatusCol()}
-                </div>
+                {props.status && (
+                    <div className={styles.statusBox}>
+                        {renderStatusCol()}
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
Fixes minor issues in cert details page:
- status icon showing in mobile pre-enrollment
![image](https://user-images.githubusercontent.com/2527433/218449828-6e041c19-ce86-48ab-8101-280ac5f6b20b.png)

- when there's not enough space in the card, float the buttons to the right:
![image](https://user-images.githubusercontent.com/2527433/218450002-148a9bb2-cb88-4d2c-a960-d772dbb72b58.png)
![image](https://user-images.githubusercontent.com/2527433/218450048-7a8c2d6a-b49e-4a59-ad13-fa2b37b9311b.png)
