### PR TITLE
TCA-1015 fix course time estimate from course

### DIFF
--- a/src-ts/tools/learn/welcome/courses-card/CoursesCard.tsx
+++ b/src-ts/tools/learn/welcome/courses-card/CoursesCard.tsx
@@ -56,7 +56,7 @@ const CoursesCard: FC<CoursesCardProps> = (props: CoursesCardProps) => {
     }
 
     const completionTimeRange: TCACertificationCompletionTimeRange = useHoursEstimateToRange(
-        props.certification.completionHours,
+        props.certification.course.estimatedCompletionTimeValue,
     )
 
     return (


### PR DESCRIPTION
Switches orifin from where course cards on home read estimated time.

Covers multi tickets for same thing:
https://topcoder.atlassian.net/browse/TCA-1015
https://topcoder.atlassian.net/browse/TCA-1016
https://topcoder.atlassian.net/browse/TCA-1017