### PR TITLE
TCA-1066

### DIFF
--- a/src-ts/tools/learn/tca-certificate/validate-certificate/ValidateTCACertificate.tsx
+++ b/src-ts/tools/learn/tca-certificate/validate-certificate/ValidateTCACertificate.tsx
@@ -168,7 +168,7 @@ const ValidateTCACertificate: FC<{}> = () => {
                         <div className={styles.wrap}>
                             <h2>
                                 {'What '}
-                                {profile.handle}
+                                {enrollment?.userName}
                                 {' Learned?'}
                             </h2>
                             <ul>{learningOutcomes}</ul>


### PR DESCRIPTION
Fixes user handle displayed instead of user's firstname in the What user learned title.