### PR TITLE
TCA-1098 - make cert title as link ->

### DIFF
--- a/src-ts/tools/learn/learn-lib/tca-certification-progress-box/TCACertificationProgressBox.module.scss
+++ b/src-ts/tools/learn/learn-lib/tca-certification-progress-box/TCACertificationProgressBox.module.scss
@@ -55,6 +55,7 @@
 
 .externalLink {
     display: flex;
+    gap: $space-xs;
     height: 24px;
     align-items: center;
     color: $turq-160;
@@ -95,7 +96,7 @@
     }
 
 }
-    
+
 .wrap:global(.theme-sidebar) {
     background: $black-5;
     color: $tc-black;

--- a/src-ts/tools/learn/learn-lib/tca-certification-progress-box/TCACertificationProgressBox.tsx
+++ b/src-ts/tools/learn/learn-lib/tca-certification-progress-box/TCACertificationProgressBox.tsx
@@ -127,12 +127,12 @@ const TCACertificationProgressBox: FC<TCACertificationProgressBoxProps> = (props
                         This course is part of a topcoder certification:
                     </div>
                     <div className={classNames(styles.certTitle, 'body-main-bold')}>
-                        {certification.title}
-                        {!!certifProgress && (
-                            <Link className={styles.externalLink} to={certifUrl}>
+                        {!!certifProgress ? (
+                            <Link className={styles.externalLink} to={certifUrl} target='_blank'>
+                                {certification.title}
                                 <IconOutline.ExternalLinkIcon />
                             </Link>
-                        )}
+                        ) : certification.title}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1098

Makes the certification title in the TCA certification progress box (in course details page) as link