### PR TITLE
TCA-1116 - order courses inside TCA certification -> dev

### DIFF
--- a/src-ts/tools/learn/certification-details/certification-curriculum/CertificationCurriculum.tsx
+++ b/src-ts/tools/learn/certification-details/certification-curriculum/CertificationCurriculum.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react'
-import { get } from 'lodash'
+import { get, orderBy } from 'lodash'
 
 import { IconOutline } from '../../../../lib'
 import {
@@ -7,6 +7,7 @@ import {
     LearnUserCertificationProgress,
     TCACertification,
     TCACertificationProvider,
+    TCACertificationResource,
 } from '../../learn-lib'
 
 import { CertificationSummary } from './certification-summary'
@@ -43,6 +44,10 @@ const CertificationCurriculum: FC<CertificationCurriculumProps> = (props: Certif
         }, {} as ProvidersByIdCollection)
     ), [props.certification])
 
+    const sortedCertResources: TCACertificationResource[] = useMemo(() => (
+        orderBy(props.certification.certificationResources, 'displayOrder')
+    ), [props.certification.certificationResources])
+
     return (
         <div className={styles.wrap}>
             <div className={styles.headline}>
@@ -70,7 +75,7 @@ const CertificationCurriculum: FC<CertificationCurriculumProps> = (props: Certif
 
             <div className={styles.container}>
                 <div className={styles.courses}>
-                    {props.certification.certificationResources.map(cert => (
+                    {sortedCertResources.map(cert => (
                         <CourseCard
                             certification={cert.freeCodeCampCertification}
                             progress={progressById[cert.freeCodeCampCertification.fccId]}


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1116

Orders the courses inside the TCA certification as per the `displayOrder` provided by the API.

NOTE: this is only for the FE to stick with what the API is sending. But there need a few changes on the API to update the order for the courses to be the correct one: https://topcoder.atlassian.net/browse/TCA-1116?focusedCommentId=46502 .