### PR TITLE
TCA-1144 - remove "certification" from course completed title

### DIFF
--- a/src-ts/tools/learn/course-completed/CourseCompletedPage.tsx
+++ b/src-ts/tools/learn/course-completed/CourseCompletedPage.tsx
@@ -123,7 +123,7 @@ const CourseCompletedPage: FC<{}> = () => {
     return (
         <>
             <PageTitle>
-                {`${certification?.title ?? 'Certification'} Completed`}
+                {`${courseData?.title ?? 'Course'} Completed`}
             </PageTitle>
 
             <LoadingSpinner hide={ready} />


### PR DESCRIPTION
Removes "certification" wording from the course completed page