### PR TITLE
Add NameOnCard in enroll payment form

### DIFF
--- a/src-ts/tools/learn/certification-details/enrollment-page/enroll-payment-form/EnrollPaymentForm.tsx
+++ b/src-ts/tools/learn/certification-details/enrollment-page/enroll-payment-form/EnrollPaymentForm.tsx
@@ -1,10 +1,12 @@
 import { Dispatch, SetStateAction, useState } from 'react'
+import { trim } from 'lodash'
 import classNames from 'classnames'
 
 import {
     CardCvcElement,
     CardExpiryElement,
     CardNumberElement,
+
 } from '@stripe/react-stripe-js'
 import {
     StripeCardCvcElementChangeEvent,
@@ -26,6 +28,7 @@ interface FieldDirtyState {
     cardComplete: boolean
     expiryComplete: boolean
     cvvComplete: boolean
+    cardName: boolean
 }
 
 interface EnrollPaymentFormProps {
@@ -44,10 +47,12 @@ const EnrollPaymentForm: React.FC<EnrollPaymentFormProps> = (props: EnrollPaymen
     const [cardNumberError, setCardNumberError]: [string, Dispatch<string>] = useState<string>('')
     const [cardExpiryError, setCardExpiryError]: [string, Dispatch<string>] = useState<string>('')
     const [cardCVVError, setCardCVVError]: [string, Dispatch<string>] = useState<string>('')
+    const [cardNameError, setCardNameError]: [string, Dispatch<string>] = useState<string>('yesyt')
 
     const [formDirtyState, setFormDirtyState]: [FieldDirtyState, Dispatch<SetStateAction<FieldDirtyState>>]
         = useState<FieldDirtyState>({
             cardComplete: false,
+            cardName: false,
             cvvComplete: false,
             expiryComplete: false,
         })
@@ -78,6 +83,24 @@ const EnrollPaymentForm: React.FC<EnrollPaymentFormProps> = (props: EnrollPaymen
             ...formDirtyState,
             [fieldName]: true,
         })
+    }
+
+    function onNameOnCardUpdate(event: React.FocusEvent<HTMLInputElement, Element>): void {
+        const name: string = event.target.value
+
+        if (!formDirtyState.cardName) {
+            setFormDirtyState({
+                ...formDirtyState,
+                cardName: true,
+            })
+        }
+
+        if (!trim(name)) {
+            setCardNameError('Name On Card is required field.')
+        } else {
+            props.onUpdateField('cardName', name)
+            setCardNameError('')
+        }
     }
 
     return (
@@ -150,6 +173,20 @@ const EnrollPaymentForm: React.FC<EnrollPaymentFormProps> = (props: EnrollPaymen
                 </InputWrapper>
             </div>
 
+            <div className={styles['input-wrap-wrapper']}>
+                <InputText
+                    label='Name On Card'
+                    name='card-name'
+                    tabIndex={4}
+                    type='text'
+                    disabled={false}
+                    error={cardNameError}
+                    hideInlineErrors={false}
+                    dirty={formDirtyState.cardName}
+                    onChange={onNameOnCardUpdate}
+                />
+            </div>
+
             <InputText
                 label={renderCheckboxLabel()}
                 name='order-contract'
@@ -179,7 +216,7 @@ const EnrollPaymentForm: React.FC<EnrollPaymentFormProps> = (props: EnrollPaymen
                 type='button'
                 buttonStyle='primary'
                 name='pay-button'
-                label={`Pay ${props.formData.price} and enroll`}
+                label='Complete Enrollment'
                 disable={!props.isFormValid || props.isPayProcessing}
                 onClick={props.onPay}
             />

--- a/src-ts/tools/learn/certification-details/enrollment-page/enrollment-sidebar/EnrollmentSidebar.tsx
+++ b/src-ts/tools/learn/certification-details/enrollment-page/enrollment-sidebar/EnrollmentSidebar.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, FC, SetStateAction, useState } from 'react'
+import { trim } from 'lodash'
 
 import { PaymentIntentResult, Stripe, StripeCardNumberElement, StripeElements } from '@stripe/stripe-js'
 import { loadStripe } from '@stripe/stripe-js/pure'
@@ -30,6 +31,7 @@ const EnrollmentSidebar: FC<EnrollmentSidebarProps> = (props: EnrollmentSidebarP
 
     const [formFieldValues, setFormValues]: [any, Dispatch<SetStateAction<any>>] = useState<any>({
         cardComplete: false,
+        cardName: undefined,
         cvvComplete: false,
         expiryComplete: false,
         price: `$${price}`,
@@ -57,6 +59,7 @@ const EnrollmentSidebar: FC<EnrollmentSidebarProps> = (props: EnrollmentSidebarP
             && formFieldValues.cvvComplete
             && formFieldValues.expiryComplete
             && formFieldValues.subsContract
+            && trim(formFieldValues.cardName)
     }
 
     /**
@@ -79,6 +82,9 @@ const EnrollmentSidebar: FC<EnrollmentSidebarProps> = (props: EnrollmentSidebarP
             const paymentResult: PaymentIntentResult | undefined
                 = await stripe?.confirmCardPayment(paymentSheet.clientSecret, {
                     payment_method: {
+                        billing_details: {
+                            name: formFieldValues.cardName,
+                        },
                         card: elements?.getElement(CardNumberElement) as StripeCardNumberElement,
                     },
                 })
@@ -88,7 +94,7 @@ const EnrollmentSidebar: FC<EnrollmentSidebarProps> = (props: EnrollmentSidebarP
                 setTimeout(() => {
                     props.onEnroll()
                     setPayProcessing(false)
-                }, 3000)
+                }, 1000)
             } else {
                 // payment error!
                 console.error('Enroll payment error', paymentResult.error)
@@ -112,7 +118,10 @@ const EnrollmentSidebar: FC<EnrollmentSidebarProps> = (props: EnrollmentSidebarP
                                 $
                                 {price}
                             </div>
-                            <span className='strike'>$40</span>
+                            <span className='strike'>
+                                $
+                                {props.product?.metadata?.estimatedRetailPrice || ' n/a'}
+                            </span>
                             <span className='body-small-bold'>TOTAL PAYMENT</span>
                         </div>
                         <hr />


### PR DESCRIPTION
- adds `Name On Card` text field for enroll payment form
- reads & links `estimatedRetailPrice` to be stored in stripe product metadata