### PR TITLE
Add price info on cert details page

### DIFF
--- a/src-ts/tools/learn/learn-lib/data-providers/payments/stripe/stripe-product.provider.ts
+++ b/src-ts/tools/learn/learn-lib/data-providers/payments/stripe/stripe-product.provider.ts
@@ -15,7 +15,7 @@ export function useGetStripeProduct(productId: string): StripeProductData {
     )
     const swrCacheConfig: SWRConfiguration = useSwrCache(url)
 
-    const { data: product, error }: SWRResponse<StripeProduct> = useSWR(url, swrCacheConfig)
+    const { data: product, error }: SWRResponse<StripeProduct> = useSWR(productId ? url : undefined, swrCacheConfig)
 
     return {
         loading: !product && !error,


### PR DESCRIPTION
Part of monetization - adds the price info on TCA certs details page.

![image](https://user-images.githubusercontent.com/5585002/227421286-db622bee-e370-46b9-9294-04cc3c2dc670.png)