### PR TITLE
TCA-1189 - update uuid route redirect (keep query string) -> dev

### DIFF
--- a/src-ts/tools/learn/learn-lib/hiring-manager-view/HiringManagerView.module.scss
+++ b/src-ts/tools/learn/learn-lib/hiring-manager-view/HiringManagerView.module.scss
@@ -360,10 +360,6 @@
     .courses {
         margin-bottom: 0;
     }
-
-    .colsWrap {
-        margin-top: 0;
-    }
     
     .colWrap {
         &:last-child {

--- a/src-ts/tools/learn/learn-lib/hiring-manager-view/certificate-modal/CertificateModal.module.scss
+++ b/src-ts/tools/learn/learn-lib/hiring-manager-view/certificate-modal/CertificateModal.module.scss
@@ -2,6 +2,7 @@
 
 .wrap {
     position: relative;
+    overflow: hidden;
 }
 
 .certificateModal {
@@ -10,8 +11,8 @@
 
         :global(.modal-body) {
             padding: 0;
-            overflow: hidden;
-            @include ltemd {
+            display: block;
+            @include ltesm {
                 padding: 60px 10px 0;
                 background: linear-gradient(84.45deg, #05456D 2.12%, #0A7AC0 97.43%);
             }

--- a/src-ts/tools/learn/tca-certificate/user-certification-view/UuidCertificationView.tsx
+++ b/src-ts/tools/learn/tca-certificate/user-certification-view/UuidCertificationView.tsx
@@ -1,5 +1,5 @@
 import { FC, useLayoutEffect } from 'react'
-import { NavigateFunction, Params, useNavigate, useParams } from 'react-router-dom'
+import { NavigateFunction, Params, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import { LoadingSpinner } from '../../../../lib'
 import {
@@ -14,6 +14,7 @@ import UserCertificationViewBase from './UserCertificationViewBase'
 const UuidCertificationView: FC<{}> = () => {
     const navigate: NavigateFunction = useNavigate()
     const routeParams: Params<string> = useParams()
+    const [queryParams]: [URLSearchParams, any] = useSearchParams()
 
     const {
         enrollment,
@@ -27,13 +28,14 @@ const UuidCertificationView: FC<{}> = () => {
     useLayoutEffect(() => {
         if (enrollmentReady && enrollment) {
             navigate(
-                getTCAUserCertificationUrl(
+                `${getTCAUserCertificationUrl(
                     certification?.dashedName as string,
                     enrollment.userHandle,
-                ),
+                )}?${queryParams.toString()}`,
+                { replace: true },
             )
         }
-    }, [certification?.dashedName, enrollment, enrollmentReady, navigate])
+    }, [certification?.dashedName, enrollment, enrollmentReady, navigate, queryParams])
 
     return (
         <>


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1189

When redirecting uuid routes, keeps the query string in the url. Also fixes some minor layout issues.