### PR TITLE
TCA-1254 - fix the lesson completed api call -> dev

### DIFF
--- a/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
+++ b/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
@@ -265,10 +265,24 @@ const FreeCodeCamp: FC<{}> = () => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const handleFccLessonComplete: (challengeUuid: string) => void = useCallback(debounce((challengeUuid: string) => {
+        let lessonName: string = ''
+        let moduleName: string = ''
+
+        // Search in course's meta data, to determine the correct lesson name and module name based on the challengeUuid
+        courseData!.modules.forEach(m => {
+            const lessonData: LearnLesson | undefined = m.lessons.find(l => l.id === challengeUuid)
+
+            if (!lessonData) {
+                return
+            }
+
+            lessonName = lessonData.dashedName
+            moduleName = m.dashedName
+        })
 
         const currentLesson: { [key: string]: string } = {
-            lesson: lessonParam,
-            module: moduleParam,
+            lesson: lessonName,
+            module: moduleName,
             uuid: challengeUuid,
         }
 


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1254

Updates the code that handles the FCC lesson completed event:
- As this event is asynchronous and can be delayed by a number of different factors, the event handler doesn't rely on the "context" parameter values anymore
- Searches through the course's metadata to find the correct module & lesson name, based on the even handler's `challengeUuid` parameter.
