### PR TITLE
TCA-1260 - FCC: fix sidebar overlap -> dev

### DIFF
--- a/src-ts/tools/learn/free-code-camp/fcc-sidebar/FccSidebar.module.scss
+++ b/src-ts/tools/learn/free-code-camp/fcc-sidebar/FccSidebar.module.scss
@@ -6,6 +6,7 @@
     left: 0;
     top: 0;
     bottom: 0;
+    z-index: 1;
 
     @include ltemd {
         position: relative;


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1260

Fixes FCC course outline in sidebar being overlapped by the FCC iframe.