### PR TITLE
TCA-1260 - fix sidebar overlap while loading -> dev

### DIFF
--- a/src-ts/tools/learn/free-code-camp/FreeCodeCamp.module.scss
+++ b/src-ts/tools/learn/free-code-camp/FreeCodeCamp.module.scss
@@ -27,6 +27,8 @@
     width: 100%;
     display: flex;
     flex-direction: column;
+    position: relative;
+    z-index: 1;
 
     padding-left: $space-xxxxl;
 

--- a/src-ts/tools/learn/free-code-camp/fcc-sidebar/FccSidebar.module.scss
+++ b/src-ts/tools/learn/free-code-camp/fcc-sidebar/FccSidebar.module.scss
@@ -6,7 +6,7 @@
     left: 0;
     top: 0;
     bottom: 0;
-    z-index: 1;
+    z-index: 2;
 
     @include ltemd {
         position: relative;


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1260

Fixes FCC course outline in sidebar being overlapped by the loading spinner.

