### PR TITLE
TCA-1272 move diceID required modal behind feature flag -> dev

### DIFF
--- a/src-ts/tools/learn/certification-details/enroll-cta-btn/EnrollCtaBtn.tsx
+++ b/src-ts/tools/learn/certification-details/enroll-cta-btn/EnrollCtaBtn.tsx
@@ -1,8 +1,10 @@
-import { FC, useCallback, useContext } from 'react'
+import { Dispatch, FC, SetStateAction, useCallback, useContext, useState } from 'react'
 import { NavigateFunction, useNavigate } from 'react-router-dom'
 
 import { Button, profileContext, ProfileContextData } from '../../../../lib'
 import { getAuthenticateAndEnrollRoute, getTCACertificationEnrollPath } from '../../learn.routes'
+import { LearnConfig } from '../../learn-config'
+import { DiceModal } from '../../course-details/course-curriculum/dice-modal'
 
 interface EnrollCtaBtnProps {
     certification: string
@@ -11,8 +13,14 @@ interface EnrollCtaBtnProps {
 const EnrollCtaBtn: FC<EnrollCtaBtnProps> = (props: EnrollCtaBtnProps) => {
     const navigate: NavigateFunction = useNavigate()
     const { initialized: profileReady, profile }: ProfileContextData = useContext(profileContext)
+    const [isDiceModalOpen, setIsDiceModalOpen]: [boolean, Dispatch<SetStateAction<boolean>>]
+        = useState<boolean>(false)
 
     const isLoggedIn: boolean = profileReady && !!profile
+
+    function onDiceModalClose(): void {
+        setIsDiceModalOpen(false)
+    }
 
     /**
      * Handle user click on start course/resume/login button
@@ -29,8 +37,8 @@ const EnrollCtaBtn: FC<EnrollCtaBtnProps> = (props: EnrollCtaBtnProps) => {
 
         // if the user is wipro and s/he hasn't set up DICE,
         // let the user know
-        if (profile?.isWipro && !profile.diceEnabled) {
-            // setIsDiceModalOpen(true)
+        if (LearnConfig.REQUIRE_DICE_ID && profile?.isWipro && !profile.diceEnabled) {
+            setIsDiceModalOpen(true)
             return
         }
 
@@ -44,6 +52,11 @@ const EnrollCtaBtn: FC<EnrollCtaBtnProps> = (props: EnrollCtaBtnProps) => {
                 size='md'
                 label={isLoggedIn ? 'Enroll Now' : 'Log in to enroll'}
                 onClick={handleEnrollClick}
+            />
+
+            <DiceModal
+                isOpen={isDiceModalOpen}
+                onClose={onDiceModalClose}
             />
         </>
     )

--- a/src-ts/tools/learn/course-details/course-curriculum/CourseCurriculum.tsx
+++ b/src-ts/tools/learn/course-details/course-curriculum/CourseCurriculum.tsx
@@ -21,6 +21,7 @@ import {
     getLessonPathFromCurrentLesson,
     LEARN_PATHS,
 } from '../../learn.routes'
+import { LearnConfig } from '../../learn-config'
 
 import { CurriculumSummary } from './curriculum-summary'
 import { TcAcademyPolicyModal } from './tc-academy-policy-modal'
@@ -98,7 +99,11 @@ const CourseCurriculum: FC<CourseCurriculumProps> = (props: CourseCurriculumProp
 
         // if the user is wipro and s/he hasn't set up DICE,
         // let the user know
-        if (props.profile?.isWipro && !props.profile.diceEnabled) {
+        if (
+            LearnConfig.REQUIRE_DICE_ID
+            && props.profile?.isWipro
+            && !props.profile.diceEnabled
+        ) {
             setIsDiceModalOpen(true)
             return
         }

--- a/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
+++ b/src-ts/tools/learn/free-code-camp/FreeCodeCamp.tsx
@@ -52,6 +52,7 @@ import {
     getLessonPathFromModule,
     getTCACertificationPath,
 } from '../learn.routes'
+import { LearnConfig } from '../learn-config'
 
 import { FccFrame } from './fcc-frame'
 import { FccSidebar } from './fcc-sidebar'
@@ -534,7 +535,7 @@ const FreeCodeCamp: FC<{}> = () => {
         // and if the user has accepted the academic honesty policy,
         // the user is permitted to take the course, so there's nothing to do.
         if (isLoggedIn
-            && (!profile?.isWipro || !!profile?.diceEnabled)
+            && (!LearnConfig.REQUIRE_DICE_ID || !profile?.isWipro || !!profile?.diceEnabled)
             && !!certificateProgress?.academicHonestyPolicyAcceptedAt) {
             return
         }

--- a/src-ts/tools/learn/learn-config/learn-config.model.ts
+++ b/src-ts/tools/learn/learn-config/learn-config.model.ts
@@ -7,4 +7,5 @@ export interface LearnConfigModel {
         value: string,
     }
     CLIENT: string
+    REQUIRE_DICE_ID: boolean | undefined
 }

--- a/src-ts/tools/learn/learn-config/learn.default.config.ts
+++ b/src-ts/tools/learn/learn-config/learn.default.config.ts
@@ -11,4 +11,5 @@ export const LearnConfigDefault: LearnConfigModel = {
         value: 'certificate-container',
     },
     CLIENT: 'https://fcc.topcoder-dev.com:4431',
+    REQUIRE_DICE_ID: `${process.env.REACT_APP_TCA_REQUIRE_DICE_ID}` === 'true',
 }


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1272

- Moves the DICE ID requirement for Wipro.com users behind a feature flag
- On the enrollment page, the Dice ID was not showing up when it was supposed to. I added the modal and it will show up when DiceID flag will be set to true.