### PR TITLE
TCA-1287 - add redirect for certificate route, redirect query params -> dev

### DIFF
--- a/src-ts/lib/route-provider/rewrite.tsx
+++ b/src-ts/lib/route-provider/rewrite.tsx
@@ -19,6 +19,6 @@ export const Rewrite: FC<RewriteProps> = props => {
     )
 
     return (
-        <Navigate to={rewriteTo} />
+        <Navigate to={`${rewriteTo}${window.location.search}`} />
     )
 }

--- a/src-ts/tools/learn/learn.routes.tsx
+++ b/src-ts/tools/learn/learn.routes.tsx
@@ -154,6 +154,12 @@ export function getAuthenticateAndEnrollRoute(): string {
 const oldUrlRedirectRoute: ReadonlyArray<PlatformRoute> = EnvironmentConfig.SUBDOMAIN === AppSubdomain.tca ? [
     {
         children: [],
+        element: <Rewrite to='/certificate/:certUuid' />,
+        id: 'redirect-old-uuidcert-url',
+        route: '/learn/:certUuid',
+    },
+    {
+        children: [],
         element: <Rewrite to='/*' />,
         id: 'redirect-old-url',
         route: '/learn/*',


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-1287 - Friendlier URLs: TCA -> My Profile-> The certifications certificate is not getting displayed in the pop up.

Redirects `platform-ui.topcoder.com/learn/:certUuid` to `academy.topcoder.com/certificate/certUuid`. Also forwards the url query params.