### PR TITLE
MP-178 BaseModal: do not use bodyscrolllock

### DIFF
--- a/src/libs/ui/lib/components/modals/base-modal/BaseModal.tsx
+++ b/src/libs/ui/lib/components/modals/base-modal/BaseModal.tsx
@@ -40,7 +40,7 @@ const BaseModal: FC<BaseModalProps> = (props: BaseModalProps) => {
     }
 
     useEffect(() => {
-        if (props.blockScroll === false) {
+        if (!props.blockScroll) {
             document.documentElement.style.overflow = props.open ? 'hidden' : ''
             document.body.style.overflow = props.open ? 'hidden' : ''
         }
@@ -58,6 +58,8 @@ const BaseModal: FC<BaseModalProps> = (props: BaseModalProps) => {
                 ),
             }}
             closeIcon={<IconOutline.XIcon className={styles['close-icon']} width={24} height={24} />}
+            // send blockScroll as false unless we get a specific true from props
+            blockScroll={props.blockScroll === true}
         >
             {props.title && (
                 <>


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/MP-178

# What's in this PR?
This PR updates the BaseModal component and sets the `blockScroll` to false by default for the `react-responsive-modal`. this is because the way they're blocking the body scroll by default is broken, and we've had issues with it before.
The BaseModal component instead is handling the body scroll blocking by itself.

https://github.com/topcoder-platform/platform-ui/assets/2527433/a4069ae0-b927-4a29-a008-214bc05e29b2


