### PR TITLE
From 'Not open to work' to 'Open to work' status update from profile page is not reflected in onboarding app

### DIFF
--- a/src/apps/profiles/src/member-profile/profile-header/OpenForGigs/OpenForGigs.tsx
+++ b/src/apps/profiles/src/member-profile/profile-header/OpenForGigs/OpenForGigs.tsx
@@ -40,7 +40,7 @@ const OpenForGigs: FC<OpenForGigsProps> = (props: OpenForGigsProps) => {
 
     const openForWork: UserTrait | undefined
         = useMemo(() => memberPersonalizationTraits?.[0]?.traits?.data?.find(
-            (trait: UserTrait) => trait.availableForGigs,
+            (trait: UserTrait) => trait.availableForGigs !== undefined,
         ), [memberPersonalizationTraits])
 
     function handleModifyOpenForWorkClick(): void {

--- a/src/apps/profiles/src/member-profile/profile-header/OpenForGigsModifyModal/OpenForGigsModifyModal.tsx
+++ b/src/apps/profiles/src/member-profile/profile-header/OpenForGigsModifyModal/OpenForGigsModifyModal.tsx
@@ -42,7 +42,10 @@ const OpenForGigsModifyModal: FC<OpenForGigsModifyModalProps> = (props: OpenForG
         setIsSaving(true)
 
         const updatedPersonalizationTraits: UserTrait[]
-            = reject(props.memberPersonalizationTraitsFullData, (trait: UserTrait) => !!trait.availableForGigs)
+            = reject(
+                props.memberPersonalizationTraitsFullData,
+                (trait: UserTrait) => trait.availableForGigs !== undefined,
+            )
 
         methodsMap[!!props.memberPersonalizationTraitsFullData ? 'update' : 'create'](props.profile.handle, [{
             categoryName: UserTraitCategoryNames.personalization,


### PR DESCRIPTION


Related JIRA Ticket:
https://topcoder.atlassian.net/browse/MP-285

# What's in this PR?
From 'Not open to work' to 'Open to work' status update from profile page is not reflected in onboarding app