### PR TITLE
TAL-36 - await restricted route user roles

### DIFF
--- a/src/libs/core/lib/router/restricted.route.tsx
+++ b/src/libs/core/lib/router/restricted.route.tsx
@@ -1,6 +1,7 @@
 import { FC, useContext } from 'react'
 
 import { RestrictedPage } from '~/libs/shared'
+import { LoadingSpinner } from '~/libs/ui'
 
 import { profileContext, ProfileContextData } from '../profile'
 
@@ -17,7 +18,7 @@ const RestrictedRoute: FC<RestrictedRouteProps> = props => {
 
     // if we're not initialized yet, just return the children
     if (!initialized) {
-        return props.children
+        return <LoadingSpinner />
     }
 
     // if we have a profile and `rolesRequired` is configured for the route


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/MP-36

# What's in this PR?
Restricted routes need to wait for profile data to load before rendering anything