### PR TITLE
MP-303 - add am/pm for local timezone for profiles -> dev

### DIFF
--- a/src/apps/profiles/src/member-profile/local-info/MemberLocalInfo.tsx
+++ b/src/apps/profiles/src/member-profile/local-info/MemberLocalInfo.tsx
@@ -81,7 +81,7 @@ const MemberLocalInfo: FC<MemberLocalInfoProps> = (props: MemberLocalInfoProps) 
                         {' '}
                         {moment()
                             .tz(memberCityTimezone)
-                            .format('hh:mm a')
+                            .format('hh:mm a z')
                             .toUpperCase()}
                     </div>
                 )


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/MP-303

# What's in this PR?
- adds the AM/PM suffix to user's local time
- shows the Timezone near the user's local time
![image](https://github.com/topcoder-platform/platform-ui/assets/2527433/8cd0cbce-e63b-4d45-9930-c8f647cd3bc6)
