### PR TITLE
MP-330 - use name from members API if available -> dev

### DIFF
--- a/src/apps/learn/src/tca-certificate/user-certification-view/UserCertificationViewBase.tsx
+++ b/src/apps/learn/src/tca-certificate/user-certification-view/UserCertificationViewBase.tsx
@@ -5,6 +5,7 @@ import {
     SetStateAction,
     useEffect,
     useLayoutEffect,
+    useMemo,
     useRef,
     useState,
 } from 'react'
@@ -44,6 +45,11 @@ const UserCertificationViewBase: FC<UserCertificationViewBaseProps> = (props: Us
     const isOwnProfile: boolean = !!props.profile?.email
 
     const isModalView: boolean = queryParams.get('view-style') === 'modal'
+    const userName = useMemo(() => (
+        !!(props.profile?.firstName || props.profile?.lastName)
+            ? `${props.profile.firstName} ${props.profile.lastName}`
+            : props.enrollment?.userName
+    ), [props.profile, props.enrollment])
 
     const [isMemberVerified, setIsMemberVerified]: [boolean, Dispatch<SetStateAction<boolean>>]
         = useState<boolean>(false)
@@ -95,7 +101,7 @@ const UserCertificationViewBase: FC<UserCertificationViewBaseProps> = (props: Us
                         completionUuid={props.enrollment.completionUuid ?? undefined}
                         isMemberVerified={isMemberVerified}
                         userProfile={props.profile}
-                        userName={props.enrollment.userName}
+                        userName={userName}
                         isOwner={isOwnProfile}
                         validationUrl={validationUrl}
                         isPreview={props.isPreview}


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/MP-330

# What's in this PR?
Before the recent updates, the first and last names of the users were not exposed in the member api.
This PR looks and checks if the member's name is exposed in the api, and if so, I'm using the data from there, otherwise it fallback to the enrollment saved data.