### PR TITLE
TAL-14 - remove the admin restriction for the talent search app -> dev

### DIFF
--- a/src/apps/talent-search/src/talent-search.routes.tsx
+++ b/src/apps/talent-search/src/talent-search.routes.tsx
@@ -26,9 +26,11 @@ export const TALENT_SEARCH_PATHS = {
 
 export const toolTitle: string = ToolTitle.talentSearch
 
+const isAdminRestricted = EnvironmentConfig.RESTRICT_TALENT_SEARCH
+
 export const talentSearchRoutes: ReadonlyArray<PlatformRoute> = [
     {
-        authRequired: true,
+        authRequired: isAdminRestricted,
         children: [
             {
                 element: <SearchPage />,
@@ -46,9 +48,9 @@ export const talentSearchRoutes: ReadonlyArray<PlatformRoute> = [
         domain: AppSubdomain.talentSearch,
         element: <TalentSearchAppRoot />,
         id: toolTitle,
-        rolesRequired: [
+        rolesRequired: isAdminRestricted ? [
             UserRole.administrator,
-        ],
+        ] : undefined,
         route: rootRoute,
     },
 ]

--- a/src/config/environments/default.env.ts
+++ b/src/config/environments/default.env.ts
@@ -69,3 +69,5 @@ export const DICE_VERIFY_URL = get({
     prod: 'https://accounts-auth0.topcoder.com',
     qa: 'https://accounts-auth0.topcoder-qa.com',
 }, ENV, 'https://accounts-auth0.topcoder.com')
+
+export const RESTRICT_TALENT_SEARCH = getReactEnv<boolean>('RESTRICT_TALENT_SEARCH', false)

--- a/src/config/environments/global-config.model.ts
+++ b/src/config/environments/global-config.model.ts
@@ -40,4 +40,5 @@ export interface GlobalConfig {
     SUBDOMAIN: string,
     GAMIFICATION_ORG_ID: string
     DICE_VERIFY_URL: string
+    RESTRICT_TALENT_SEARCH: boolean
 }


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/TAL-14

# What's in this PR?
Removes the admin restriction for the talent search app. Allows env var to toggle it back on if needed.