### PR TITLE
TAL-10 - redirect to talent search from profiles app -> dev

### DIFF
--- a/src/apps/profiles/src/member-profile/MemberProfilePage.tsx
+++ b/src/apps/profiles/src/member-profile/MemberProfilePage.tsx
@@ -1,7 +1,9 @@
 import { Dispatch, FC, SetStateAction, useCallback, useContext, useEffect, useState } from 'react'
 import { Params, useNavigate, useParams } from 'react-router-dom'
+import { AxiosError } from 'axios'
 
 import { profileContext, ProfileContextData, profileGetPublicAsync, UserProfile } from '~/libs/core'
+import { TALENT_SEARCH_PATHS } from '~/apps/talent-search'
 import { LoadingSpinner } from '~/libs/ui'
 
 import { notifyUniNavi, triggerSprigSurvey } from '../lib'
@@ -34,7 +36,11 @@ const MemberProfilePage: FC<{}> = () => {
                     setProfile({ ...userProfile } as UserProfile)
                     setProfileReady(true)
                 })
-            // TODO: NOT FOUND PAGE redirect/dispaly
+                .catch((e: AxiosError) => {
+                    if (e.code === AxiosError.ERR_BAD_REQUEST && e.response?.status === 404) {
+                        window.location.href = `${TALENT_SEARCH_PATHS.absoluteRootUrl}?memberNotFound`
+                    }
+                })
         }
     }, [routeParams.memberHandle])
 

--- a/src/apps/talent-search/src/index.ts
+++ b/src/apps/talent-search/src/index.ts
@@ -1,1 +1,1 @@
-export { talentSearchRoutes } from './talent-search.routes'
+export { talentSearchRoutes, TALENT_SEARCH_PATHS } from './talent-search.routes'

--- a/src/apps/talent-search/src/talent-search.routes.tsx
+++ b/src/apps/talent-search/src/talent-search.routes.tsx
@@ -14,11 +14,18 @@ const TalentPage: LazyLoadedComponent = lazyLoad(
     'TalentPage',
 )
 
+const isOnAppSubdomain = EnvironmentConfig.SUBDOMAIN === AppSubdomain.talentSearch
 export const rootRoute: string = (
-    EnvironmentConfig.SUBDOMAIN === AppSubdomain.talentSearch ? '' : `/${AppSubdomain.talentSearch}`
+    isOnAppSubdomain ? '' : `/${AppSubdomain.talentSearch}`
 )
 
+const absoluteRootUrl = (() => {
+    const subdomain = isOnAppSubdomain ? AppSubdomain.talentSearch : EnvironmentConfig.SUBDOMAIN
+    return `//${subdomain}.${EnvironmentConfig.TC_DOMAIN}${rootRoute}`
+})()
+
 export const TALENT_SEARCH_PATHS = {
+    absoluteRootUrl,
     results: `${rootRoute}/results`,
     root: rootRoute,
     talent: `${rootRoute}/talent`,


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/TAL-10

# What's in this PR?
Redirects the user to talent-search when they use wrong user handle and hit a profile not found error on profiles app.