### PR TITLE
Fix useFetchTalentMatches: reset page number when updating skills -> dev

### DIFF
--- a/src/apps/talent-search/src/lib/services/use-fetch-talent-matches.ts
+++ b/src/apps/talent-search/src/lib/services/use-fetch-talent-matches.ts
@@ -74,6 +74,7 @@ export function useInfiniteTalentMatches(
     // clear matches when skills array is updated
     useEffect(() => {
         setMatches([])
+        setPage(1)
     }, [skills])
 
     // when we have new matches, concatenate the response to the matches array


### PR DESCRIPTION
Related JIRA Ticket:

# What's in this PR?
Fixes `useFetchTalentMatches()`: resets the page number when updating skills array