### PR TITLE
TAL-52 - Logout url udpate -> dev

### DIFF
--- a/src/apps/platform/src/components/app-header/AppHeader.tsx
+++ b/src/apps/platform/src/components/app-header/AppHeader.tsx
@@ -17,13 +17,13 @@ import classNames from 'classnames'
 import { EnvironmentConfig, PageSubheaderPortalId } from '~/config'
 import {
     authUrlLogin,
-    authUrlLogout,
     authUrlSignup,
     profileContext,
     ProfileContextData,
     routerContext,
     RouterContextData,
 } from '~/libs/core'
+import { ConfigContextValue, useConfigContext } from '~/libs/shared'
 
 import UniNavSnippet from './universal-nav-snippet'
 
@@ -39,6 +39,7 @@ const AppHeader: FC<{}> = () => {
 
     const { activeToolName, activeToolRoute }: RouterContextData = useContext(routerContext)
     const { profile, initialized: profileReady }: ProfileContextData = useContext(profileContext)
+    const { logoutUrl }: ConfigContextValue = useConfigContext()
     const [ready, setReady]: [boolean, Dispatch<SetStateAction<boolean>>] = useState<boolean>(false)
     const headerInit: MutableRefObject<boolean> = useRef(false)
     const navElementId: string = PageSubheaderPortalId
@@ -95,7 +96,7 @@ const AppHeader: FC<{}> = () => {
                 },
                 onReady() { setReady(true) },
                 signIn() { window.location.href = authUrlLogin() },
-                signOut() { window.location.href = authUrlLogout },
+                signOut() { window.location.href = logoutUrl },
                 signUp() { window.location.href = authUrlSignup() },
                 toolName: activeToolName,
                 toolRoot: activeToolRoute,
@@ -110,6 +111,7 @@ const AppHeader: FC<{}> = () => {
         navigationHandler,
         userInfo,
         profileReady,
+        logoutUrl,
     ])
 
     // update uni-nav's tool details
@@ -141,12 +143,14 @@ const AppHeader: FC<{}> = () => {
             navElementId,
             {
                 ...userInfo,
+                signOut() { window.location.href = logoutUrl },
             },
         )
     }, [
         profileReady,
         userInfo,
         navElementId,
+        logoutUrl,
     ])
 
     return (

--- a/src/apps/platform/src/providers/Providers.tsx
+++ b/src/apps/platform/src/providers/Providers.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react'
 
-import { ProfileProvider } from '~/libs/core'
+import { authUrlLogout, ProfileProvider } from '~/libs/core'
+import { ConfigContextProvider } from '~/libs/shared'
 
 import { PlatformRouterProvider } from './platform-router.provider'
 
@@ -9,11 +10,13 @@ interface ProvidersProps {
 }
 
 const Providers: FC<ProvidersProps> = props => (
-    <ProfileProvider>
-        <PlatformRouterProvider>
-            {props.children}
-        </PlatformRouterProvider>
-    </ProfileProvider>
+    <ConfigContextProvider logoutUrl={authUrlLogout}>
+        <ProfileProvider>
+            <PlatformRouterProvider>
+                {props.children}
+            </PlatformRouterProvider>
+        </ProfileProvider>
+    </ConfigContextProvider>
 )
 
 export default Providers

--- a/src/apps/profiles/src/ProfilesApp.tsx
+++ b/src/apps/profiles/src/ProfilesApp.tsx
@@ -1,13 +1,18 @@
-import { FC, useContext } from 'react'
+import { FC, useContext, useEffect } from 'react'
 import { Outlet, Routes } from 'react-router-dom'
 
-import { routerContext, RouterContextData } from '~/libs/core'
-import { SharedSwrConfig } from '~/libs/shared'
+import { authUrlLogin, authUrlLogoutFn, routerContext, RouterContextData } from '~/libs/core'
+import { ConfigContextValue, SharedSwrConfig, useConfigContext } from '~/libs/shared'
 
-import { toolTitle } from './profiles.routes'
+import { absoluteRootRoute, toolTitle } from './profiles.routes'
 
 const ProfilesApp: FC<{}> = () => {
+    const { setLogoutUrl }: ConfigContextValue = useConfigContext()
     const { getChildRoutes }: RouterContextData = useContext(routerContext)
+
+    useEffect(() => {
+        setLogoutUrl(authUrlLogoutFn(authUrlLogin(absoluteRootRoute)))
+    }, [setLogoutUrl])
 
     return (
         <SharedSwrConfig>

--- a/src/libs/core/lib/auth/authentication-functions/authentication-url.config.ts
+++ b/src/libs/core/lib/auth/authentication-functions/authentication-url.config.ts
@@ -9,8 +9,11 @@ export function login(returnUrl?: string): string {
     return `${authentication}?retUrl=${encodeURIComponent(retUrl)}`
 }
 
-export const logout: string
-    = `${authentication}?logout=true&retUrl=${encodeURIComponent(`https://${window.location.host}`)}`
+export const logoutFn = (retUrl: string): string => (
+    `${authentication}?logout=true&retUrl=${encodeURIComponent(retUrl)}`
+)
+
+export const logout: string = logoutFn(`https://${window.location.host}`)
 
 export function signup(returnUrl?: string, regSource?: AuthenticationRegistrationSource): string {
     return `${login(returnUrl)}&mode=signUp${!!regSource ? `&regSource=${regSource}` : ''}`

--- a/src/libs/core/lib/auth/authentication-functions/index.ts
+++ b/src/libs/core/lib/auth/authentication-functions/index.ts
@@ -3,6 +3,7 @@ export {
     authentication as authUrl,
     login as authUrlLogin,
     logout as authUrlLogout,
+    logoutFn as authUrlLogoutFn,
     signup as authUrlSignup,
 } from './authentication-url.config'
 export {

--- a/src/libs/shared/lib/contexts/config.context.tsx
+++ b/src/libs/shared/lib/contexts/config.context.tsx
@@ -1,0 +1,34 @@
+import { createContext, FC, ReactNode, useContext, useMemo, useState } from 'react'
+
+export interface ConfigContextValue {
+    logoutUrl: string
+    setLogoutUrl: (logoutUrl: string) => void
+}
+
+const ConfigReactCtx = createContext<ConfigContextValue>({} as ConfigContextValue)
+
+interface ConfigContextProps {
+    children?: ReactNode
+    logoutUrl: string
+}
+
+export const ConfigContextProvider: FC<ConfigContextProps> = props => {
+    const [logoutUrl, setLogoutUrl] = useState<string>(props.logoutUrl)
+
+    const contextValue = useMemo(() => ({
+        logoutUrl,
+        setLogoutUrl,
+    }), [setLogoutUrl, logoutUrl])
+
+    return (
+        <ConfigReactCtx.Provider
+            value={contextValue}
+        >
+            {props.children}
+        </ConfigReactCtx.Provider>
+    )
+}
+
+export const useConfigContext = (): ConfigContextValue => (
+    useContext(ConfigReactCtx)
+)

--- a/src/libs/shared/lib/contexts/index.ts
+++ b/src/libs/shared/lib/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './config.context'

--- a/src/libs/shared/lib/index.ts
+++ b/src/libs/shared/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './contexts'
 export * from './components'
 export * from './containers'
 export * from './hooks'


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/TAL-52

# What's in this PR?
Adds a `<ConfigContextProvider/>` for the whole platform that can be used to customize global configs based on the current application.
Updates the lgoout url for the profiles app to redirect back to login, and after login back to profiles app.