### PR TITLE
fix-principal-skills-typo -> dev

### DIFF
--- a/src/apps/profiles/src/member-profile/skills/ModifySkillsModal/ModifySkillsModal.tsx
+++ b/src/apps/profiles/src/member-profile/skills/ModifySkillsModal/ModifySkillsModal.tsx
@@ -74,7 +74,7 @@ const ModifySkillsModal: FC<ModifySkillsModalProps> = (props: ModifySkillsModalP
                     onClick={props.showPrincipalIntroModal}
                 >
                     <span className='body-main-link'>
-                        See what Principal skills are
+                        See what Principal Skills are
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
Fixes typo for "Principal Skills"

Only place where the casing is wrong:
![image](https://github.com/topcoder-platform/platform-ui/assets/2527433/d222898d-47e5-4aa1-9ec4-ebb023373c3c)
