### PR TITLE
fix: add task payment in category/type filter

### DIFF
--- a/src/apps/wallet/src/home/tabs/winnings/WinningsTab.tsx
+++ b/src/apps/wallet/src/home/tabs/winnings/WinningsTab.tsx
@@ -192,6 +192,10 @@ const ListView: FC<ListViewProps> = (props: ListViewProps) => {
                                     label: 'Type',
                                     options: [
                                         {
+                                            label: 'Task Payment',
+                                            value: 'TASK_PAYMENT',
+                                        },
+                                        {
                                             label: 'Contest Payment',
                                             value: 'CONTEST_PAYMENT',
                                         },


### PR DESCRIPTION
This PR adds a "Task Payment" to the type filter in Wallet App