### PR TITLE
fix: label pluralization

### DIFF
--- a/src/apps/wallet/src/home/tabs/winnings/WinningsTab.tsx
+++ b/src/apps/wallet/src/home/tabs/winnings/WinningsTab.tsx
@@ -93,7 +93,12 @@ const ListView: FC<ListViewProps> = (props: ListViewProps) => {
                 const diffMinutes = diffMs / (1000 * 60)
                 const hours = Math.floor(diffHours)
                 const minutes = Math.round(diffMinutes - hours * 60)
-                formattedReleaseDate = `In ${hours} hours ${minutes} minutes`
+                formattedReleaseDate = `${minutes} minute${minutes !== 1 ? 's' : ''}`
+                if (hours > 0) {
+                    formattedReleaseDate = `In ${hours} hour${hours !== 1 ? 's' : ''} ${formattedReleaseDate}`
+                } else if (minutes > 0) {
+                    formattedReleaseDate = `In ${minutes} minute${minutes !== 1 ? 's' : ''}`
+                }
             } else {
                 formattedReleaseDate = formatIOSDateString(payment.releaseDate)
             }


### PR DESCRIPTION
Related JIRA Ticket:
https://topcoder.atlassian.net/browse/CORE-330
# What's in this PR?
If release date <= 24 hours, show time left in hours and minutes. This is to prevent giving users the mistaken impression that a payment can be released when there's less than 24 hours left to release the payment. This PR specifically fixes pluralization of the displayed label.