### PR TITLE
PM-1157 Add fallback content for copilot requests when access denied

### DIFF
--- a/src/apps/copilots/src/pages/copilot-requests/index.tsx
+++ b/src/apps/copilots/src/pages/copilot-requests/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo } from 'react'
+import { FC, useCallback, useContext, useMemo } from 'react'
 import { find } from 'lodash'
 import { NavigateFunction, Params, useNavigate, useParams } from 'react-router-dom'
 
@@ -14,6 +14,7 @@ import {
     TableColumn,
     useConfirmationModal,
 } from '~/libs/ui'
+import { profileContext, ProfileContextData, UserRole } from '~/libs/core'
 
 import { ProjectTypeLabels } from '../../constants'
 import { approveCopilotRequest, CopilotRequestsResponse, useCopilotRequests } from '../../services/copilot-requests'
@@ -121,6 +122,12 @@ const CopilotRequestsPage: FC = () => {
     const navigate: NavigateFunction = useNavigate()
     const routeParams: Params<string> = useParams()
 
+    const { profile }: ProfileContextData = useContext(profileContext)
+    const isAdminOrPM: boolean = useMemo(
+        () => !!profile?.roles?.some(role => role === UserRole.administrator || role === UserRole.projectManager),
+        [profile],
+    )
+
     const { data: requests = [], isValidating: requestsLoading }: CopilotRequestsResponse = useCopilotRequests()
     const projectIds = useMemo(() => (
         (new Set(requests.map(r => r.projectId))
@@ -156,6 +163,15 @@ const CopilotRequestsPage: FC = () => {
     const addNewRequestButton: ButtonProps = {
         label: 'New Copilot Request',
         onClick: () => navigate(copilotRoutesMap.CopilotRequestForm),
+    }
+
+    if (!isAdminOrPM) {
+        return (
+            <ContentLayout title='Copilot Requests'>
+                <PageTitle>Access Denied</PageTitle>
+                <p>You do not have required permissions to access this page.</p>
+            </ContentLayout>
+        )
     }
 
     return (


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-1157


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
Only allow Admins and PMs to view the copilot requests page. The api has this check already. This PR only adds the frontend content for when the access is denied.