### PR TITLE
fix(PM-1464): Copilot applications list breaks when a copilot lacks stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ workflows:
                               - LVT-256
                               - CORE-635
                               - feat/system-admin
+                              - pm-1464
 
             - deployQa:
                   context: org-global

--- a/src/apps/copilots/src/services/members.ts
+++ b/src/apps/copilots/src/services/members.ts
@@ -42,8 +42,8 @@ export const getMembersByUserIds = async (
 
 const membersFactory = (members: Member[]): FormattedMembers[] => members.map(member => ({
     ...member,
-    activeProjects: member.stats.find(item => item.COPILOT?.activeProjects)?.COPILOT?.activeProjects || 0,
-    copilotFulfillment: member.stats.find(item => item.COPILOT?.fulfillment)?.COPILOT?.fulfillment || 0,
+    activeProjects: member.stats?.find(item => item.COPILOT?.activeProjects)?.COPILOT?.activeProjects || 0,
+    copilotFulfillment: member.stats?.find(item => item.COPILOT?.fulfillment)?.COPILOT?.fulfillment || 0,
 }))
 
 /**

--- a/src/apps/copilots/src/services/members.ts
+++ b/src/apps/copilots/src/services/members.ts
@@ -42,8 +42,8 @@ export const getMembersByUserIds = async (
 
 const membersFactory = (members: Member[]): FormattedMembers[] => members.map(member => ({
     ...member,
-    activeProjects: member.stats.find(item => item.COPILOT.activeProjects)?.COPILOT.activeProjects || 0,
-    copilotFulfillment: member.stats.find(item => item.COPILOT.fulfillment)?.COPILOT.fulfillment || 0,
+    activeProjects: member.stats.find(item => item.COPILOT?.activeProjects)?.COPILOT?.activeProjects || 0,
+    copilotFulfillment: member.stats.find(item => item.COPILOT?.fulfillment)?.COPILOT?.fulfillment || 0,
 }))
 
 /**


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-1464


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

- Copilot applications list breaks when a copilot lacks stats
- This checks if the COPILOT is defined or not, this way undefined exception can be avoided


