### PR TITLE
PM-4819: Move wallet-admin payment creator into work log section

### DIFF
--- a/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx
+++ b/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx
@@ -4,6 +4,7 @@ import {
     render,
     screen,
     waitFor,
+    within,
 } from '@testing-library/react'
 
 import { Winning } from '../../models/WinningDetail'
@@ -122,13 +123,29 @@ describe('PaymentView', () => {
 
         expect(await screen.findByRole('heading', { name: 'Engagement Details' }))
             .toBeTruthy()
-        expect(await screen.findByText('copilot-manager'))
-            .toBeTruthy()
         await waitFor(() => {
             expect(screen.getAllByText('43.75'))
                 .toHaveLength(2)
         })
         expect(await screen.findByText(/Completed sprint support and bug triage\./))
+            .toBeTruthy()
+
+        const workLogHeading = await screen.findByRole('heading', {
+            name: 'Work Log / Manager Inputs',
+        })
+        const workLogSection = workLogHeading.parentElement
+
+        if (!workLogSection) {
+            throw new Error('Expected work log section to be rendered.')
+        }
+
+        expect(screen.getAllByText('Payment Creator'))
+            .toHaveLength(1)
+        expect(within(workLogSection)
+            .getByText('Payment Creator'))
+            .toBeTruthy()
+        expect(within(workLogSection)
+            .getByText('copilot-manager'))
             .toBeTruthy()
 
         const descriptionLink = await screen.findByRole('link', {

--- a/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.tsx
+++ b/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.tsx
@@ -164,17 +164,6 @@ const PaymentView: React.FC<PaymentViewProps> = (props: PaymentViewProps) => {
                             <span className={styles.label}>Handle</span>
                             <p className={styles.value}>{props.payment.handle}</p>
                         </div>
-                        {isEngagementPayment && (
-                            <div className={styles.infoItem}>
-                                <span className={styles.label}>Payment Creator</span>
-                                <p className={styles.value}>
-                                    {isPaymentDetailsLoading
-                                        ? 'Loading...'
-                                        : formatOptionalText(paymentDetails?.paymentCreatorHandle)}
-                                </p>
-                            </div>
-                        )}
-
                         <div className={styles.infoItem}>
                             <span className={styles.label}>Type</span>
                             <p className={styles.value}>{props.payment.type}</p>
@@ -304,6 +293,12 @@ const PaymentView: React.FC<PaymentViewProps> = (props: PaymentViewProps) => {
                                                 <span className={styles.label}>Remarks</span>
                                                 <p className={styles.remarksValue}>
                                                     {renderOptionalLinkedText(paymentDetails?.workLog?.remarks)}
+                                                </p>
+                                            </div>
+                                            <div className={styles.infoItem}>
+                                                <span className={styles.label}>Payment Creator</span>
+                                                <p className={styles.value}>
+                                                    {formatOptionalText(paymentDetails?.paymentCreatorHandle)}
                                                 </p>
                                             </div>
                                         </div>


### PR DESCRIPTION
What was broken
Wallet-admin engagement payments showed Payment Creator below the assignee handle in the top summary area.
QA expected the field inside the Work Log / Manager Inputs section of the Payment Details modal.

Root cause (if identifiable)
The earlier fix added the new field to the summary block instead of the work-log section, and the wallet-admin test only asserted that the creator handle rendered somewhere.

What was changed
Moved the wallet-admin Payment Creator field into the Work Log / Manager Inputs section.
Updated the wallet-admin spec so it asserts the field is rendered inside that section and only appears once.

Any added/updated tests
Updated src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx to verify Payment Creator renders inside Work Log / Manager Inputs.
Ran yarn test:no-watch --runInBand --runTestsByPath src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx src/apps/work/src/lib/components/PaymentHistoryModal/PaymentHistoryModal.spec.tsx.
Ran yarn lint and yarn run build.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
