### PR TITLE
PM-4814: fix manual phase duration entry

### DIFF
--- a/src/apps/work/src/lib/components/form/PhaseDurationInput/PhaseDurationInput.spec.tsx
+++ b/src/apps/work/src/lib/components/form/PhaseDurationInput/PhaseDurationInput.spec.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import {
+    render,
+    screen,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+
+import { PhaseDurationInput } from './PhaseDurationInput'
+
+jest.mock('../../../utils', () => ({
+    convertPhaseHoursMinutesToPhaseDuration: (
+        hoursMinutes: {
+            hours: number
+            minutes: number
+        },
+    ): number => (hoursMinutes.hours * 60) + hoursMinutes.minutes,
+    getPhaseHoursMinutes: (durationMinutes: number): {
+        hours: number
+        minutes: number
+    } => ({
+        hours: Math.floor(durationMinutes / 60),
+        minutes: durationMinutes % 60,
+    }),
+}))
+
+interface TestHarnessProps {
+    initialValue: number
+    onChange: (durationMinutes: number) => void
+}
+
+const TestHarness = (props: TestHarnessProps): JSX.Element => {
+    const [value, setValue] = useState<number>(props.initialValue)
+
+    function handleChange(durationMinutes: number): void {
+        props.onChange(durationMinutes)
+        setValue(durationMinutes)
+    }
+
+    return (
+        <PhaseDurationInput
+            onChange={handleChange}
+            value={value}
+        />
+    )
+}
+
+describe('PhaseDurationInput', () => {
+    it('allows manual replacement of hours and minutes values', async () => {
+        const user = userEvent.setup()
+        const onChange = jest.fn()
+
+        render(
+            <TestHarness
+                initialValue={720 * 60}
+                onChange={onChange}
+            />,
+        )
+
+        const hoursInput = screen.getByLabelText('Phase duration hours')
+        const minutesInput = screen.getByLabelText('Phase duration minutes')
+
+        await user.clear(hoursInput)
+        await user.type(hoursInput, '24')
+
+        expect(hoursInput)
+            .toHaveValue('24')
+        expect(onChange)
+            .toHaveBeenLastCalledWith(24 * 60)
+
+        await user.clear(minutesInput)
+        await user.type(minutesInput, '15')
+
+        expect(minutesInput)
+            .toHaveValue('15')
+        expect(onChange)
+            .toHaveBeenLastCalledWith((24 * 60) + 15)
+    })
+})

--- a/src/apps/work/src/lib/components/form/PhaseDurationInput/PhaseDurationInput.tsx
+++ b/src/apps/work/src/lib/components/form/PhaseDurationInput/PhaseDurationInput.tsx
@@ -1,7 +1,8 @@
 import {
     ChangeEvent,
     FC,
-    useMemo,
+    useEffect,
+    useState,
 } from 'react'
 import classNames from 'classnames'
 
@@ -20,11 +21,33 @@ export interface PhaseDurationInputProps {
     error?: string
 }
 
-function normalizeInputValue(value: string): number {
-    const parsedValue = Number(value)
+/**
+ * Removes any non-digit characters from a duration field value.
+ *
+ * @param value raw input text entered into the duration field.
+ * @returns digits-only string that can be safely parsed as a whole number.
+ */
+function sanitizeInputValue(value: string): string {
+    return value.replace(/\D/g, '')
+}
 
+/**
+ * Parses a sanitized duration field value into a non-negative integer.
+ *
+ * Empty values remain undefined so the user can temporarily clear a field
+ * while typing a replacement value.
+ *
+ * @param value digits-only duration input value.
+ * @returns parsed integer, or `undefined` when the field is empty.
+ */
+function parseInputValue(value: string): number | undefined {
+    if (!value) {
+        return undefined
+    }
+
+    const parsedValue = Number(value)
     if (!Number.isFinite(parsedValue)) {
-        return 0
+        return undefined
     }
 
     return Math.max(0, Math.trunc(parsedValue))
@@ -35,30 +58,67 @@ export const PhaseDurationInput: FC<PhaseDurationInputProps> = (props: PhaseDura
     const error = props.error
     const label = props.label
     const value = props.value
+    const hoursMinutes = getPhaseHoursMinutes(Number(value) || 0)
+    const [hoursInput, setHoursInput] = useState<string>(() => String(hoursMinutes.hours))
+    const [minutesInput, setMinutesInput] = useState<string>(() => String(hoursMinutes.minutes))
 
-    const hoursMinutes = useMemo(
-        () => getPhaseHoursMinutes(Number(value) || 0),
-        [value],
-    )
+    useEffect(() => {
+        setHoursInput(String(hoursMinutes.hours))
+        setMinutesInput(String(hoursMinutes.minutes))
+    }, [
+        hoursMinutes.hours,
+        hoursMinutes.minutes,
+    ])
 
     function handleHoursChange(event: ChangeEvent<HTMLInputElement>): void {
-        const nextHours = normalizeInputValue(event.target.value)
+        const nextHoursInput = sanitizeInputValue(event.target.value)
+        const nextHours = parseInputValue(nextHoursInput)
+
+        setHoursInput(nextHoursInput)
+
+        if (nextHours === undefined) {
+            return
+        }
+
         const nextDuration = convertPhaseHoursMinutesToPhaseDuration({
             hours: nextHours,
-            minutes: hoursMinutes.minutes,
+            minutes: parseInputValue(minutesInput) ?? hoursMinutes.minutes,
         })
 
         props.onChange(nextDuration)
     }
 
     function handleMinutesChange(event: ChangeEvent<HTMLInputElement>): void {
-        const nextMinutes = Math.max(0, Math.min(59, normalizeInputValue(event.target.value)))
+        const nextMinutesInput = sanitizeInputValue(event.target.value)
+        const parsedMinutes = parseInputValue(nextMinutesInput)
+
+        if (parsedMinutes === undefined) {
+            setMinutesInput('')
+            return
+        }
+
+        const nextMinutes = Math.max(0, Math.min(59, parsedMinutes))
+
+        setMinutesInput(String(nextMinutes))
+
         const nextDuration = convertPhaseHoursMinutesToPhaseDuration({
-            hours: hoursMinutes.hours,
+            hours: parseInputValue(hoursInput) ?? hoursMinutes.hours,
             minutes: nextMinutes,
         })
 
         props.onChange(nextDuration)
+    }
+
+    function handleHoursBlur(): void {
+        if (!hoursInput) {
+            setHoursInput(String(hoursMinutes.hours))
+        }
+    }
+
+    function handleMinutesBlur(): void {
+        if (!minutesInput) {
+            setMinutesInput(String(hoursMinutes.minutes))
+        }
     }
 
     return (
@@ -77,10 +137,13 @@ export const PhaseDurationInput: FC<PhaseDurationInputProps> = (props: PhaseDura
                             error ? styles.error : undefined,
                         )}
                         disabled={disabled}
+                        inputMode='numeric'
                         min={0}
+                        onBlur={handleHoursBlur}
                         onChange={handleHoursChange}
-                        type='number'
-                        value={hoursMinutes.hours}
+                        pattern='[0-9]*'
+                        type='text'
+                        value={hoursInput}
                     />
                 </label>
 
@@ -93,11 +156,14 @@ export const PhaseDurationInput: FC<PhaseDurationInputProps> = (props: PhaseDura
                             error ? styles.error : undefined,
                         )}
                         disabled={disabled}
+                        inputMode='numeric'
                         max={59}
                         min={0}
+                        onBlur={handleMinutesBlur}
                         onChange={handleMinutesChange}
-                        type='number'
-                        value={hoursMinutes.minutes}
+                        pattern='[0-9]*'
+                        type='text'
+                        value={minutesInput}
                     />
                 </label>
             </div>


### PR DESCRIPTION
What was broken

F2F schedule rows in the work challenge editor would not reliably accept manual typing in the Hours and Minutes fields. Clearing a value to replace it immediately snapped back to the derived duration state, which blocked manual entry.

Root cause

PhaseDurationInput treated both controls as fully derived numeric inputs and reparsed them on every keystroke. Temporary empty states could not persist long enough for a user to replace the current value.

What was changed

Updated PhaseDurationInput to keep local string state while the user edits, sanitize numeric input, and only sync back to the derived duration when a valid value is present. The fields now use text inputs with numeric input mode and restore the last valid derived value on blur when left empty.

Any added/updated tests

Added PhaseDurationInput.spec.tsx to cover manual replacement of both hours and minutes values.
Verified the related challenge schedule specs still pass.
The full yarn test:no-watch suite still has existing unrelated failures in src/apps/wallet-admin/src/home/tabs/payments/PaymentsListView.spec.tsx on the current origin/dev baseline.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
