### PR TITLE
PM-4834: Persist edited phase end dates

### DIFF
--- a/src/apps/work/src/lib/services/challenges.service.spec.ts
+++ b/src/apps/work/src/lib/services/challenges.service.spec.ts
@@ -165,4 +165,36 @@ describe('patchChallenge', () => {
                 expect.any(Object),
             )
     })
+
+    it('preserves scheduled phase end dates when patching a challenge', async () => {
+        const mockedPatch = xhrPatchAsync as jest.Mock
+
+        mockedPatch.mockResolvedValue({
+            id: 'challenge-1',
+            phases: [],
+        })
+
+        await patchChallenge('challenge-1', {
+            phases: [{
+                duration: 1440,
+                phaseId: 'submission-phase',
+                scheduledEndDate: '2026-04-15T15:05:00.000Z',
+                scheduledStartDate: '2026-04-09T15:05:00.000Z',
+            }],
+        })
+
+        expect(xhrPatchAsync)
+            .toHaveBeenCalledWith(
+                'https://example.com/challenges/challenge-1',
+                expect.objectContaining({
+                    phases: [{
+                        duration: 86400,
+                        phaseId: 'submission-phase',
+                        scheduledEndDate: '2026-04-15T15:05:00.000Z',
+                        scheduledStartDate: '2026-04-09T15:05:00.000Z',
+                    }],
+                }),
+                expect.any(Object),
+            )
+    })
 })

--- a/src/apps/work/src/lib/services/challenges.service.ts
+++ b/src/apps/work/src/lib/services/challenges.service.ts
@@ -199,6 +199,7 @@ function serializeChallengePhases(phases: unknown): ChallengePhase[] | undefined
                 duration: serializePhaseDurationToSeconds(typedPhase.duration),
                 phaseId: typedPhase.phaseId,
                 predecessor: typedPhase.predecessor,
+                scheduledEndDate: asIsoDateString(typedPhase.scheduledEndDate),
                 scheduledStartDate: asIsoDateString(typedPhase.scheduledStartDate),
             }
         })

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
@@ -226,6 +226,38 @@ describe('challenge-editor utils submission count mapping', () => {
     })
 })
 
+describe('challenge-editor utils schedule mapping', () => {
+    it('serializes scheduled phase end dates to the API payload', () => {
+        const formData: Record<string, unknown> = {
+            description: 'Public specification',
+            legacy: {
+                useSchedulingAPI: true,
+            },
+            name: 'Scheduled challenge',
+            phases: [{
+                duration: 1440,
+                phaseId: 'submission-phase',
+                scheduledEndDate: '2026-04-15T15:05:00.000Z',
+                scheduledStartDate: '2026-04-09T15:05:00.000Z',
+            }],
+            skills: [],
+            tags: [],
+            trackId: 'track-id',
+            typeId: 'type-id',
+        }
+
+        const result = transformFormDataToChallenge(formData as any)
+
+        expect(result.phases)
+            .toEqual([{
+                duration: 1440,
+                phaseId: 'submission-phase',
+                scheduledEndDate: '2026-04-15T15:05:00.000Z',
+                scheduledStartDate: '2026-04-09T15:05:00.000Z',
+            }])
+    })
+})
+
 describe('challenge-editor utils task reviewer mapping', () => {
     it('maps task reviewer and task flag into form data', () => {
         const result = transformChallengeToFormData({

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.ts
@@ -895,6 +895,7 @@ function serializePhasesForApi(phases: unknown): ChallengePhase[] | undefined {
                 duration: normalizePhaseDurationMinutes(typedPhase.duration),
                 phaseId: typedPhase.phaseId,
                 predecessor: typedPhase.predecessor,
+                scheduledEndDate: toIsoDateString(typedPhase.scheduledEndDate),
                 scheduledStartDate: toIsoDateString(typedPhase.scheduledStartDate),
             }
         })


### PR DESCRIPTION
What was broken
Edit challenge saves reported success even when a phase end date had been changed, but the updated end date was missing after reload because the save request omitted it.

Root cause (if identifiable)
The challenge editor serialized phase data twice before patching the challenge, and both serializers kept scheduledStartDate but dropped scheduledEndDate.

What was changed
Preserved scheduledEndDate in the challenge editor phase mapper and the challenges service payload serializer so edited phase end dates reach the API on update and create flows.
Added focused coverage for form-data transformation and the patch request payload.

Any added/updated tests
Added a challenge editor utility test covering scheduledEndDate serialization.
Added a challenges service test covering scheduledEndDate in the patch payload.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
