### PR TITLE
PM-4827: remove challenge editor attachments section

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -1351,7 +1351,6 @@ describe('ChallengeEditorForm', () => {
         const timelineIndex = sectionHeadings.indexOf('Timeline & Schedule')
         const submissionSettingsIndex = sectionHeadings.indexOf('Submission Settings')
         const reviewIndex = sectionHeadings.indexOf('Review')
-        const attachmentsIndex = sectionHeadings.indexOf('Attachments')
 
         expect(timelineIndex)
             .toBeGreaterThanOrEqual(0)
@@ -1359,8 +1358,8 @@ describe('ChallengeEditorForm', () => {
             .toBeGreaterThan(timelineIndex)
         expect(reviewIndex)
             .toBeGreaterThan(submissionSettingsIndex)
-        expect(attachmentsIndex)
-            .toBeGreaterThan(reviewIndex)
+        expect(sectionHeadings)
+            .not.toContain('Attachments')
         expect(screen.getByTestId('reviewers-field'))
             .toHaveAttribute('data-read-only', 'true')
         expect(screen.getByTestId('reviewers-field')
@@ -1747,36 +1746,17 @@ describe('ChallengeEditorForm', () => {
             .not.toHaveBeenCalledWith('Failed to save challenge')
     })
 
-    it('preserves uploaded attachments after saving when the update response omits them', async () => {
-        const user = userEvent.setup()
-
-        mockedPatchChallenge.mockResolvedValue({
-            ...validDraftChallenge,
-            attachments: undefined,
-        })
-
+    it('does not render the attachments section while editing a draft', () => {
         render(
             <MemoryRouter>
                 <ChallengeEditorForm challenge={validDraftChallenge} />
             </MemoryRouter>,
         )
 
-        expect(screen.getByText('Attachment Count: 0'))
-            .toBeInTheDocument()
-
-        await user.click(screen.getByRole('button', { name: 'Mock Add Attachment' }))
-
-        expect(screen.getByText('Attachment Count: 1'))
-            .toBeInTheDocument()
-
-        await user.click(screen.getByRole('button', { name: 'Save Challenge' }))
-
-        await waitFor(() => {
-            expect(mockedPatchChallenge)
-                .toHaveBeenCalledTimes(1)
-            expect(screen.getByText('Attachment Count: 1'))
-                .toBeInTheDocument()
-        })
+        expect(screen.queryByRole('heading', { level: 3, name: 'Attachments' }))
+            .not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Mock Add Attachment' }))
+            .not.toBeInTheDocument()
     })
 
     it('returns to view mode after saving from an edit route', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -78,9 +78,6 @@ import {
     AssignedMemberField,
 } from './AssignedMemberField'
 import {
-    AttachmentsField,
-} from './AttachmentsField'
-import {
     ChallengeDescriptionField,
 } from './ChallengeDescriptionField'
 import {
@@ -2477,14 +2474,6 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
             </section>
         )
         : undefined
-    const attachmentsSection = (
-        <section className={styles.section}>
-            <h3 className={styles.sectionTitle}>Attachments</h3>
-            <div className={styles.block}>
-                <AttachmentsField />
-            </div>
-        </section>
-    )
     const footerSection = !isReadOnly
         ? (
             <div className={styles.footer}>
@@ -2748,22 +2737,11 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                                 {!isReadOnly
                                     ? reviewSection
                                     : undefined}
-                                {!isReadOnly
-                                    ? attachmentsSection
-                                    : undefined}
                                 {footerSection}
                             </fieldset>
 
                             {isReadOnly
                                 ? reviewSection
-                                : undefined}
-
-                            {isReadOnly
-                                ? (
-                                    <fieldset className={styles.formContent} disabled>
-                                        {attachmentsSection}
-                                    </fieldset>
-                                )
                                 : undefined}
                         </>
                     )


### PR DESCRIPTION
What was broken
The challenge draft and read-only challenge editor still rendered an Attachments section even though that workflow is no longer relied on and is not behaving correctly.

Root cause
ChallengeEditorForm continued to mount the legacy attachments block in both editable and read-only layouts.

What was changed
Removed the Attachments section from ChallengeEditorForm so it no longer appears in the work app challenge editor.
Updated the existing challenge editor spec to assert the section is absent in both read-only ordering coverage and editable draft rendering.

Any added/updated tests
Updated ChallengeEditorForm.spec.tsx to verify the attachments heading is not rendered in read-only mode and that the mock attachments control is absent while editing a draft.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
