### PR TITLE
PM-4835: remove inline group creation from challenge groups

### DIFF
--- a/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.tsx
+++ b/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.tsx
@@ -11,6 +11,7 @@ import {
     useFormContext,
 } from 'react-hook-form'
 import AsyncCreatableSelect from 'react-select/async-creatable'
+import AsyncSelect from 'react-select/async'
 
 import {
     AUTOCOMPLETE_DEBOUNCE_TIME_MS,
@@ -33,6 +34,7 @@ interface FormGroupsSelectProps {
     additionalGroups?: Group[]
     disabled?: boolean
     hideLabel?: boolean
+    isCreatable?: boolean
     label: string
     name: string
     required?: boolean
@@ -105,6 +107,11 @@ export const FormGroupsSelect: FC<FormGroupsSelectProps> = (props: FormGroupsSel
     const fieldState = controller.fieldState
 
     const [optionCache, setOptionCache] = useState<GroupOption[]>([])
+    const isCreatable = props.isCreatable ?? true
+    const SelectComponent = useMemo<any>(
+        () => (isCreatable ? AsyncCreatableSelect : AsyncSelect),
+        [isCreatable],
+    )
 
     const menuPortalTarget = useMemo(
         () => (typeof document === 'undefined' ? undefined : document.body),
@@ -258,7 +265,7 @@ export const FormGroupsSelect: FC<FormGroupsSelectProps> = (props: FormGroupsSel
             name={props.name}
             required={props.required}
         >
-            <AsyncCreatableSelect
+            <SelectComponent
                 cacheOptions
                 className={styles.select}
                 classNamePrefix='challenge-select'
@@ -270,7 +277,9 @@ export const FormGroupsSelect: FC<FormGroupsSelectProps> = (props: FormGroupsSel
                 menuPortalTarget={menuPortalTarget}
                 onBlur={field.onBlur}
                 onChange={handleSelectionChange}
-                onCreateOption={handleCreateGroup}
+                onCreateOption={isCreatable
+                    ? handleCreateGroup
+                    : undefined}
                 placeholder='Search groups'
                 value={selectedValue}
             />

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/GroupsField/GroupsField.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/GroupsField/GroupsField.spec.tsx
@@ -66,6 +66,7 @@ jest.mock('../../../../../lib/components/form', () => ({
             id: string
             name: string
         }>
+        isCreatable?: boolean
         name: string
     }) => {
         const reactHookForm = jest.requireActual('react-hook-form') as typeof import('react-hook-form')
@@ -79,6 +80,7 @@ jest.mock('../../../../../lib/components/form', () => ({
             <div data-testid='groups-select'>
                 {JSON.stringify({
                     additionalGroups: props.additionalGroups,
+                    isCreatable: props.isCreatable,
                     selectedGroupIds,
                 })}
             </div>
@@ -161,6 +163,8 @@ describe('GroupsField', () => {
 
         expect(screen.getByTestId('groups-select'))
             .toHaveTextContent('"selectedGroupIds":[]')
+        expect(screen.getByTestId('groups-select'))
+            .toHaveTextContent('"isCreatable":false')
 
         await user.click(screen.getByRole('button', {
             name: 'Create Group',

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/GroupsField/GroupsField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/GroupsField/GroupsField.tsx
@@ -108,6 +108,7 @@ export const GroupsField: FC = () => {
                 <FormGroupsSelect
                     additionalGroups={createdGroups}
                     hideLabel
+                    isCreatable={false}
                     label='Groups'
                     name='groups'
                 />


### PR DESCRIPTION
What was broken
Users could type a new group name into the Create Challenge groups field and select the generated "Create ..." option, which led to a failing group-create request and no useful UI response.

Root cause (if identifiable)
The challenge groups field reused a shared async-creatable select, so it exposed inline group creation even though the challenge flow already has a separate modal-based group creation path.

What was changed
Added an explicit `isCreatable` switch to the shared work-app groups select and disabled inline creation for the challenge editor groups field, leaving the existing modal-based create-group flow in place.

Any added/updated tests
Updated the challenge groups field test to assert that the challenge editor passes `isCreatable={false}` while preserving the existing modal create-group behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
