### PR TITLE
PM-4878 load appeals in bulk

### DIFF
--- a/src/apps/review/src/lib/hooks/useFetchAppealQueue.ts
+++ b/src/apps/review/src/lib/hooks/useFetchAppealQueue.ts
@@ -7,7 +7,7 @@ import { filter } from 'lodash'
 import {
     MappingReviewAppeal,
 } from '../models'
-import { fetchAppealsWithReviewId } from '../services'
+import { fetchAllAppealsWithReviewIds } from '../services'
 
 export interface useFetchAppealQueueProps {
     mappingReviewAppeal: MappingReviewAppeal // from review id to appeal info
@@ -35,9 +35,11 @@ export function useFetchAppealQueue(): useFetchAppealQueueProps {
             return
         }
 
-        const nextId = idLoadQueue.current[0]
-        idLoadQueue.current = idLoadQueue.current.slice(1)
-        if (mappingReviewAppealRef.current[nextId]) {
+        const nextIds = Array.from(new Set(idLoadQueue.current))
+            .filter(id => !mappingReviewAppealRef.current[id])
+        idLoadQueue.current = []
+
+        if (!nextIds.length) {
             fetchNextDataInQueue()
             return
         }
@@ -49,24 +51,29 @@ export function useFetchAppealQueue(): useFetchAppealQueueProps {
         }
 
         const fetchDataFail = (): void => {
-            mappingReviewAppealRef.current[nextId] = {
-                finishAppeals: 0,
-                totalAppeals: 0,
-            }
+            nextIds.forEach(id => {
+                mappingReviewAppealRef.current[id] = {
+                    finishAppeals: 0,
+                    totalAppeals: 0,
+                }
+            })
             setMappingReviewAppeal({
                 ...mappingReviewAppealRef.current,
             })
             finish()
         }
 
-        // Fetch appeal datas
-        fetchAppealsWithReviewId(1, 100, nextId)
+        fetchAllAppealsWithReviewIds(nextIds)
             .then(res => {
-                mappingReviewAppealRef.current[nextId] = {
-                    finishAppeals: filter(res, item => !!item.appealResponse)
-                        .length,
-                    totalAppeals: res.length,
-                }
+                nextIds.forEach(id => {
+                    const reviewAppeals = res.filter(item => item.reviewId === id)
+
+                    mappingReviewAppealRef.current[id] = {
+                        finishAppeals: filter(reviewAppeals, item => !!item.appealResponse)
+                            .length,
+                        totalAppeals: reviewAppeals.length,
+                    }
+                })
                 setMappingReviewAppeal({
                     ...mappingReviewAppealRef.current,
                 })

--- a/src/apps/review/src/lib/models/AppealInfo.model.ts
+++ b/src/apps/review/src/lib/models/AppealInfo.model.ts
@@ -5,6 +5,7 @@ import { BackendAppealResponse } from './BackendAppealResponse.model'
  */
 export interface AppealInfo {
     id: string
+    reviewId?: string
     reviewItemCommentId: string
     content: string
     appealResponse?: BackendAppealResponse

--- a/src/apps/review/src/lib/models/BackendAppeal.model.ts
+++ b/src/apps/review/src/lib/models/BackendAppeal.model.ts
@@ -12,6 +12,7 @@ export interface BackendAppealBase {
 export interface BackendAppeal extends BackendAppealBase {
     resourceId: string
     id: string
+    reviewId?: string
     appealResponse?: BackendAppealResponse
     createdAt: string
     createdBy: string
@@ -30,6 +31,7 @@ export function convertBackendAppeal(data: BackendAppeal): AppealInfo {
         appealResponse: data.appealResponse,
         content: data.content,
         id: data.id,
+        reviewId: data.reviewId,
         reviewItemCommentId: data.reviewItemCommentId,
     }
 }

--- a/src/apps/review/src/lib/services/reviews.service.ts
+++ b/src/apps/review/src/lib/services/reviews.service.ts
@@ -455,20 +455,33 @@ export const fetchAllChallengeReviews = async (
  * @param resourceId resource id
  * @returns resolves to the array of appeals
  */
+const fetchAppealsPage = async (
+    page: number,
+    perPage: number,
+    filters: {
+        resourceId?: string
+        reviewId?: string
+        reviewIds?: string[]
+        challengeId?: string
+    },
+): Promise<BackendResponseWithMeta<BackendAppeal[]>> => (
+    xhrGetAsync<BackendResponseWithMeta<BackendAppeal[]>>(
+        `${EnvironmentConfig.API.V6}/appeals?${qs.stringify({
+            page,
+            perPage,
+            ...filters,
+        }, {
+            arrayFormat: 'comma',
+        })}`,
+    )
+)
+
 export const fetchAppeals = async (
     page: number,
     perPage: number,
     resourceId: string,
 ): Promise<AppealInfo[]> => {
-    const results = await xhrGetAsync<
-        BackendResponseWithMeta<BackendAppeal[]>
-    >(
-        `${EnvironmentConfig.API.V6}/appeals?${qs.stringify({
-            page,
-            perPage,
-            resourceId,
-        })}`,
-    )
+    const results = await fetchAppealsPage(page, perPage, { resourceId })
     return results.data.map(convertBackendAppeal)
 }
 
@@ -484,17 +497,66 @@ export const fetchAppealsWithReviewId = async (
     page: number,
     perPage: number,
     reviewId: string,
+): Promise<AppealInfo[]> => fetchAppealsPage(page, perPage, { reviewId })
+    .then(results => results.data.map(convertBackendAppeal))
+
+/**
+ * Fetch appeals with review ids
+ *
+ * @param page current page
+ * @param perPage number of item per page
+ * @param reviewIds review ids
+ * @returns resolves to the array of appeals
+ */
+export const fetchAppealsWithReviewIds = async (
+    page: number,
+    perPage: number,
+    reviewIds: string[],
 ): Promise<AppealInfo[]> => {
-    const results = await xhrGetAsync<
-        BackendResponseWithMeta<BackendAppeal[]>
-    >(
-        `${EnvironmentConfig.API.V6}/appeals?${qs.stringify({
-            page,
-            perPage,
-            reviewId,
-        })}`,
-    )
+    const results = await fetchAppealsPage(page, perPage, { reviewIds })
     return results.data.map(convertBackendAppeal)
+}
+
+/**
+ * Fetch all appeals with review ids using API pagination metadata.
+ *
+ * @param reviewIds review ids
+ * @param perPage number of items per page
+ * @returns resolves to the array of appeals
+ */
+export const fetchAllAppealsWithReviewIds = async (
+    reviewIds: string[],
+    perPage = 500,
+): Promise<AppealInfo[]> => {
+    if (!reviewIds.length) {
+        return []
+    }
+
+    const safePerPage = Number.isFinite(perPage) && perPage > 0 ? perPage : 500
+    const firstPage = await fetchAppealsPage(1, safePerPage, { reviewIds })
+    const combined = [...firstPage.data]
+    const totalPages = Math.max(firstPage.meta?.totalPages ?? 1, 1)
+
+    const fetchRemainingPages = async (
+        page: number,
+        currentTotal: number,
+    ): Promise<void> => {
+        if (page > currentTotal) {
+            return
+        }
+
+        const nextPage = await fetchAppealsPage(page, safePerPage, { reviewIds })
+        combined.push(...nextPage.data)
+        const nextTotal = typeof nextPage.meta?.totalPages === 'number'
+            ? Math.max(nextPage.meta.totalPages, currentTotal)
+            : currentTotal
+
+        await fetchRemainingPages(page + 1, nextTotal)
+    }
+
+    await fetchRemainingPages(2, totalPages)
+
+    return combined.map(convertBackendAppeal)
 }
 
 /**


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-4878


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request refactors and enhances how appeals are fetched and managed in the review application, especially for operations involving multiple review IDs. The main improvements include support for batch fetching of appeals by multiple review IDs, improved pagination handling, and updates to data models to include the `reviewId` field.
* Added `fetchAllAppealsWithReviewIds` to efficiently fetch all appeals for multiple review IDs, handling pagination automatically. (`src/apps/review/src/lib/services/reviews.service.ts`)
* Refactored `useFetchAppealQueue` to use the new batch fetch function, allowing for multiple review IDs to be loaded at once and reducing redundant requests. (`src/apps/review/src/lib/hooks/useFetchAppealQueue.ts`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
