### PR TITLE
PM-4879 - disable ai workflows

### DIFF
--- a/src/apps/work/src/lib/models/AiReview.model.ts
+++ b/src/apps/work/src/lib/models/AiReview.model.ts
@@ -37,6 +37,7 @@ export interface AiReviewTemplate {
     challengeTrack: string
     challengeType: string
     createdAt?: string | Date
+    disabled?: boolean
     description: string
     formula?: Record<string, unknown>
     id: string

--- a/src/apps/work/src/lib/models/Reviewer.model.ts
+++ b/src/apps/work/src/lib/models/Reviewer.model.ts
@@ -30,6 +30,7 @@ export interface Scorecard {
 }
 
 export interface Workflow {
+    disabled?: boolean
     id: string
     name: string
     scorecardId?: string

--- a/src/apps/work/src/lib/services/ai-review-templates.service.ts
+++ b/src/apps/work/src/lib/services/ai-review-templates.service.ts
@@ -132,6 +132,7 @@ function normalizeTemplate(
         challengeType,
         createdAt: normalizeText(typedTemplate.createdAt),
         description: normalizeText(typedTemplate.description) || '',
+        disabled: normalizeBoolean(typedTemplate.disabled) === true,
         formula: typeof typedTemplate.formula === 'object' && typedTemplate.formula
             ? typedTemplate.formula as Record<string, unknown>
             : undefined,

--- a/src/apps/work/src/lib/services/challenges.service.ts
+++ b/src/apps/work/src/lib/services/challenges.service.ts
@@ -404,6 +404,7 @@ function normalizeWorkflow(workflow: Partial<Workflow>): Workflow | undefined {
     }
 
     return {
+        disabled: (workflow as Record<string, unknown>).disabled === true,
         id,
         name,
         scorecardId: workflow.scorecardId !== undefined && workflow.scorecardId !== null

--- a/src/apps/work/src/lib/services/reviewers.service.ts
+++ b/src/apps/work/src/lib/services/reviewers.service.ts
@@ -89,6 +89,7 @@ function normalizeWorkflow(workflow: Partial<Workflow>): Workflow | undefined {
     }
 
     return {
+        disabled: (workflow as Record<string, unknown>).disabled === true,
         id,
         name,
         scorecardId: workflow.scorecardId !== undefined && workflow.scorecardId !== null

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
@@ -581,6 +581,8 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
             if (
                 configurationMode === 'template'
                 && selectedTemplateId
+                && !templatesLoading
+                && templates.length > 0
                 && !activeTemplateIdSet.has(selectedTemplateId)
             ) {
                 errors.push('Selected AI review template is deactivated. Please select an active template.')
@@ -609,6 +611,8 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
             configuration.workflows,
             configurationMode,
             normalizedConfiguration,
+            templates,
+            templatesLoading,
         ],
     )
     const hasPersistedConfigForCurrentChallenge = useMemo(

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
@@ -541,6 +541,22 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
         () => templates.find(template => template.id === configuration.templateId),
         [configuration.templateId, templates],
     )
+    const activeTemplates = useMemo(
+        () => templates.filter(template => template.disabled !== true),
+        [templates],
+    )
+    const activeWorkflows = useMemo(
+        () => availableWorkflows.filter(workflow => workflow.disabled !== true),
+        [availableWorkflows],
+    )
+    const activeWorkflowIdSet = useMemo(
+        () => new Set(activeWorkflows.map(workflow => normalizeReviewerText(workflow.id))),
+        [activeWorkflows],
+    )
+    const activeTemplateIdSet = useMemo(
+        () => new Set(activeTemplates.map(template => normalizeReviewerText(template.id))),
+        [activeTemplates],
+    )
     const normalizedConfiguration = useMemo(
         (): SaveAiReviewConfigInput | undefined => (
             normalizedChallengeId
@@ -554,10 +570,46 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
         [configuration, configurationMode, normalizedChallengeId],
     )
     const validationErrors = useMemo(
-        () => (normalizedConfiguration
-            ? validateAiReviewConfiguration(normalizedConfiguration)
-            : []),
-        [normalizedConfiguration],
+        () => {
+            if (!normalizedConfiguration) {
+                return []
+            }
+
+            const errors = validateAiReviewConfiguration(normalizedConfiguration)
+
+            const selectedTemplateId = normalizeReviewerText(configuration.templateId)
+            if (
+                configurationMode === 'template'
+                && selectedTemplateId
+                && !activeTemplateIdSet.has(selectedTemplateId)
+            ) {
+                errors.push('Selected AI review template is deactivated. Please select an active template.')
+            }
+
+            if (configurationMode === 'manual') {
+                const hasDeactivatedWorkflow = (configuration.workflows || [])
+                    .map(workflow => normalizeReviewerText(workflow.workflowId))
+                    .filter(Boolean)
+                    .some(workflowId => !activeWorkflowIdSet.has(workflowId))
+
+                if (hasDeactivatedWorkflow) {
+                    errors.push(
+                        'One or more selected AI workflows are deactivated. '
+                        + 'Please select active workflows only.',
+                    )
+                }
+            }
+
+            return errors
+        },
+        [
+            activeTemplateIdSet,
+            activeWorkflowIdSet,
+            configuration.templateId,
+            configuration.workflows,
+            configurationMode,
+            normalizedConfiguration,
+        ],
     )
     const hasPersistedConfigForCurrentChallenge = useMemo(
         () => (
@@ -654,7 +706,7 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
 
     const handleTemplateSelect = useCallback(
         (templateId: string): void => {
-            const selected = templates.find(template => template.id === templateId)
+            const selected = activeTemplates.find(template => template.id === templateId)
             if (!selected) {
                 setConfiguration(previousConfiguration => ({
                     ...previousConfiguration,
@@ -672,7 +724,7 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
                 workflows: selected.workflows.map(toDraftWorkflow),
             })
         },
-        [templates],
+        [activeTemplates],
     )
 
     const performModeSwitch = useCallback(async (targetMode: ConfigurationMode): Promise<void> => {
@@ -1123,7 +1175,7 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
                                     value={configuration.templateId || ''}
                                 >
                                     <option value=''>Select template</option>
-                                    {templates.map(template => (
+                                    {activeTemplates.map(template => (
                                         <option key={template.id} value={template.id}>
                                             {template.title}
                                         </option>
@@ -1191,7 +1243,7 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
                                 {(configuration.workflows || []).map((workflow, index) => (
                                     <ManualWorkflowEditor
                                         assignedWorkflowIds={assignedWorkflowIds}
-                                        availableWorkflows={availableWorkflows}
+                                        availableWorkflows={activeWorkflows}
                                         key={getWorkflowDraftKey(workflow)}
                                         onRemove={removeWorkflow}
                                         onUpdate={updateWorkflow}

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/AiReviewTab.tsx
@@ -588,7 +588,11 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
                 errors.push('Selected AI review template is deactivated. Please select an active template.')
             }
 
-            if (configurationMode === 'manual') {
+            if (
+                configurationMode === 'manual'
+                && !isWorkflowsLoading
+                && availableWorkflows.length > 0
+            ) {
                 const hasDeactivatedWorkflow = (configuration.workflows || [])
                     .map(workflow => normalizeReviewerText(workflow.workflowId))
                     .filter(Boolean)
@@ -610,6 +614,8 @@ export const AiReviewTab: FC<AiReviewTabProps> = (
             configuration.templateId,
             configuration.workflows,
             configurationMode,
+            availableWorkflows,
+            isWorkflowsLoading,
             normalizedConfiguration,
             templates,
             templatesLoading,


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-4879


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

This pull request introduces support for deactivating (disabling) AI review templates and workflows in the challenge editor. It updates the data models, normalization logic, and UI to filter out disabled items and provide validation feedback if a user selects a deactivated template or workflow.

* Added a `disabled` property to the `AiReviewTemplate` and `Workflow` interfaces, and updated normalization functions to handle this property so that disabled items can be tracked throughout the app.

* Updated the `AiReviewTab` component to filter out disabled templates and workflows from selection lists, ensuring only active items are available for user selection.
* Enhanced validation in the `AiReviewTab` to display errors if a user attempts to select a deactivated template or workflow, guiding users to select only active options.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
