### PR TITLE
PM-2698: hydrate saved challenge groups from accessible list

### DIFF
--- a/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.spec.tsx
+++ b/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.spec.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { FC } from 'react'
+import {
+    render,
+    waitFor,
+} from '@testing-library/react'
+import {
+    FormProvider,
+    useForm,
+} from 'react-hook-form'
+
+import { fetchGroups } from '../../../services'
+
+import { FormGroupsSelect } from './FormGroupsSelect'
+
+let latestAsyncSelectProps: Record<string, unknown> | undefined
+
+const fetchGroupsMock = fetchGroups as jest.Mock
+
+jest.mock('react-select/async', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+        latestAsyncSelectProps = props
+
+        return false
+    },
+}))
+
+jest.mock('react-select/async-creatable', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+        latestAsyncSelectProps = props
+
+        return false
+    },
+}))
+
+jest.mock('../../../services', () => ({
+    createGroup: jest.fn(),
+    fetchGroups: jest.fn(),
+}))
+
+interface TestFormValues {
+    groups: string[]
+}
+
+const TestHarness: FC = () => {
+    const formMethods = useForm<TestFormValues>({
+        defaultValues: {
+            groups: ['db53f15b-2d61-4d9e-8263-8cfc3f98337e'],
+        },
+    })
+
+    return (
+        <FormProvider {...formMethods}>
+            <FormGroupsSelect
+                label='Groups'
+                name='groups'
+            />
+        </FormProvider>
+    )
+}
+
+describe('FormGroupsSelect', () => {
+    beforeEach(() => {
+        latestAsyncSelectProps = undefined
+        jest.clearAllMocks()
+    })
+
+    it('hydrates saved group ids from the accessible groups list before falling back to raw ids', async () => {
+        fetchGroupsMock.mockResolvedValue([
+            {
+                id: 'db53f15b-2d61-4d9e-8263-8cfc3f98337e',
+                name: 'Hide Challenges',
+            },
+        ])
+
+        render(
+            <TestHarness />,
+        )
+
+        await waitFor(() => {
+            expect(fetchGroupsMock)
+                .toHaveBeenCalledWith()
+        })
+
+        await waitFor(() => {
+            expect(latestAsyncSelectProps?.value)
+                .toEqual([
+                    {
+                        label: 'Hide Challenges',
+                        value: 'db53f15b-2d61-4d9e-8263-8cfc3f98337e',
+                    },
+                ])
+        })
+    })
+})

--- a/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.tsx
+++ b/src/apps/work/src/lib/components/form/FormGroupsSelect/FormGroupsSelect.tsx
@@ -23,7 +23,6 @@ import {
 } from '../../../models'
 import {
     createGroup,
-    fetchGroupById,
     fetchGroups,
 } from '../../../services'
 import { FormFieldWrapper } from '../FormFieldWrapper'
@@ -178,26 +177,37 @@ export const FormGroupsSelect: FC<FormGroupsSelectProps> = (props: FormGroupsSel
 
         let isMounted = true
 
-        Promise.all(missingGroupIds.map(async groupId => {
-            try {
-                const group = await fetchGroupById(groupId)
-
-                return toOption(group)
-            } catch {
-                return {
-                    label: groupId,
-                    value: groupId,
-                }
-            }
-        }))
-            .then(resolvedOptions => {
+        fetchGroups()
+            .then(accessibleGroups => {
                 if (!isMounted) {
                     return
                 }
 
+                const accessibleGroupsById = new Map(
+                    accessibleGroups.map(group => [group.id, toOption(group)]),
+                )
+                const resolvedOptions = missingGroupIds.map(groupId => (
+                    accessibleGroupsById.get(groupId) || {
+                        label: groupId,
+                        value: groupId,
+                    }
+                ))
+
                 setOptionCache(previousOptions => mergeOptions(previousOptions, resolvedOptions))
             })
-            .catch(() => undefined)
+            .catch(() => {
+                if (!isMounted) {
+                    return
+                }
+
+                setOptionCache(previousOptions => mergeOptions(
+                    previousOptions,
+                    missingGroupIds.map(groupId => ({
+                        label: groupId,
+                        value: groupId,
+                    })),
+                ))
+            })
 
         return () => {
             isMounted = false

--- a/src/apps/work/src/lib/services/groups.service.spec.ts
+++ b/src/apps/work/src/lib/services/groups.service.spec.ts
@@ -1,0 +1,87 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { xhrGetPaginatedAsync } from '~/libs/core'
+
+import { fetchGroups } from './groups.service'
+
+jest.mock('~/libs/core', () => ({
+    xhrCreateInstance: jest.fn(() => ({
+        defaults: {
+            headers: {
+                common: {},
+            },
+        },
+    })),
+    xhrDeleteAsync: jest.fn(),
+    xhrGetAsync: jest.fn(),
+    xhrGetPaginatedAsync: jest.fn(),
+    xhrPatchAsync: jest.fn(),
+    xhrPostAsync: jest.fn(),
+    xhrPutAsync: jest.fn(),
+}), {
+    virtual: true,
+})
+jest.mock('../constants', () => ({
+    GROUPS_API_URL: 'https://example.com/groups',
+}))
+
+describe('fetchGroups', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('merges all paginated accessible group results when hydrating saved group ids', async () => {
+        const mockedGetPaginated = xhrGetPaginatedAsync as jest.Mock
+
+        mockedGetPaginated
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 'group-1',
+                        name: ' Hide Challenges ',
+                    },
+                ],
+                page: 1,
+                perPage: 1000,
+                total: 2,
+                totalPages: 2,
+            })
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        id: 'group-2',
+                        name: 'QA - Public',
+                    },
+                ],
+                page: 2,
+                perPage: 1000,
+                total: 2,
+                totalPages: 2,
+            })
+
+        await expect(fetchGroups({
+            name: 'Hide',
+        }))
+            .resolves
+            .toEqual([
+                expect.objectContaining({
+                    id: 'group-1',
+                    name: 'Hide Challenges',
+                }),
+                expect.objectContaining({
+                    id: 'group-2',
+                    name: 'QA - Public',
+                }),
+            ])
+
+        expect(mockedGetPaginated)
+            .toHaveBeenNthCalledWith(
+                1,
+                'https://example.com/groups?page=1&perPage=1000&name=Hide',
+            )
+        expect(mockedGetPaginated)
+            .toHaveBeenNthCalledWith(
+                2,
+                'https://example.com/groups?page=2&perPage=1000&name=Hide',
+            )
+    })
+})

--- a/src/apps/work/src/lib/services/groups.service.ts
+++ b/src/apps/work/src/lib/services/groups.service.ts
@@ -193,24 +193,50 @@ function normalizeGroupMember(value: unknown): GroupMember | undefined {
 }
 
 export async function fetchGroups(filters?: { name?: string }): Promise<Group[]> {
-    const query = new URLSearchParams({
-        page: '1',
-        perPage: String(GROUPS_PER_PAGE),
-    })
-
-    const groupNameFilter = filters?.name?.trim()
-    if (groupNameFilter) {
-        query.set('name', groupNameFilter)
-    }
-
     try {
-        const response = await xhrGetPaginatedAsync<Group[]>(
-            `${GROUPS_API_URL}?${query.toString()}`,
-        )
+        const buildGroupsUrl = (page: number): string => {
+            const query = new URLSearchParams({
+                page: String(page),
+                perPage: String(GROUPS_PER_PAGE),
+            })
+            const groupNameFilter = filters?.name?.trim()
 
-        return (response.data || [])
+            if (groupNameFilter) {
+                query.set('name', groupNameFilter)
+            }
+
+            return `${GROUPS_API_URL}?${query.toString()}`
+        }
+
+        const firstPageResponse = await xhrGetPaginatedAsync<Group[]>(
+            buildGroupsUrl(1),
+        )
+        const firstPageGroups = (firstPageResponse.data || [])
             .map(group => normalizeGroup(group))
             .filter((group): group is Group => !!group)
+
+        if ((firstPageResponse.totalPages || 1) <= 1) {
+            return firstPageGroups
+        }
+
+        const extraPageNumbers = Array.from({
+            length: firstPageResponse.totalPages - 1,
+        }, (_, index) => index + 2)
+
+        const extraPageResponses = await Promise.all(extraPageNumbers
+            .map(pageNumber => xhrGetPaginatedAsync<Group[]>(
+                buildGroupsUrl(pageNumber),
+            )))
+
+        const extraPageGroups = extraPageResponses
+            .flatMap(response => response.data || [])
+            .map(group => normalizeGroup(group))
+            .filter((group): group is Group => !!group)
+
+        return [
+            ...firstPageGroups,
+            ...extraPageGroups,
+        ]
     } catch (error) {
         throw normalizeError(error, 'Failed to fetch groups')
     }


### PR DESCRIPTION
What was broken
Saved draft challenges could keep their group association, but reopening the challenge in the work app could show the raw group UUID instead of the group name.

Root cause (if identifiable)
The work-app groups field rehydrated persisted group IDs through the per-group detail endpoint. That endpoint can return 403 for saved challenge groups even when the accessible groups list/search endpoint can resolve the same group, so the field fell back to the raw ID.

What was changed
Updated work-app group hydration to resolve persisted group IDs from the accessible groups list instead of per-group detail fetches, and expanded the groups service to collect all paginated accessible group results before resolving labels.

Any added/updated tests
Added a FormGroupsSelect regression test covering saved-group hydration and a groups.service test covering paginated group list aggregation.

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
