### PR TITLE
PM-4890: allow past engagement start dates

### DIFF
--- a/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.spec.tsx
+++ b/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.spec.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render } from '@testing-library/react'
+
+import AcceptApplicationModal from './AcceptApplicationModal'
+
+const mockStartDateTimeInput = jest.fn((props: { label: string }): JSX.Element => (
+    <div>{props.label}</div>
+))
+
+jest.mock('~/libs/ui', () => ({
+    BaseModal: (props: {
+        buttons?: JSX.Element
+        children: JSX.Element
+        open: boolean
+    }): JSX.Element => (
+        props.open ? (
+            <div>
+                {props.children}
+                {props.buttons}
+            </div>
+        ) : <></>
+    ),
+    Button: (props: {
+        disabled?: boolean
+        label: string
+        onClick?: () => void
+    }): JSX.Element => (
+        <button disabled={props.disabled} onClick={props.onClick} type='button'>
+            {props.label}
+        </button>
+    ),
+}), {
+    virtual: true,
+})
+
+jest.mock('../form', () => ({
+    StartDateTimeInput: (props: { label: string }): JSX.Element => mockStartDateTimeInput(props),
+}))
+
+jest.mock('../../utils', () => ({
+    calculateAssignmentRatePerWeek: jest.fn(() => ''),
+    sanitizePositiveNumericInput: jest.fn((value: string) => value),
+    serializeTentativeAssignmentDate: jest.fn((value: Date) => value.toISOString()),
+    toPositiveInteger: jest.fn(() => 1),
+    toPositiveNumber: jest.fn(() => 1),
+    toPositiveNumberWithMaxDecimalPlaces: jest.fn(() => 1),
+}))
+
+describe('AcceptApplicationModal', () => {
+    beforeEach(() => {
+        mockStartDateTimeInput.mockClear()
+    })
+
+    it('does not restrict the billing start date to today or later', () => {
+        render(
+            <AcceptApplicationModal
+                application={undefined}
+                onCancel={jest.fn()}
+                onConfirm={jest.fn()}
+                open
+            />,
+        )
+
+        const startDateTimeInputProps = mockStartDateTimeInput
+            .mock.calls[mockStartDateTimeInput.mock.calls.length - 1][0] as {
+            label: string
+            minDate?: Date | null
+        }
+
+        expect(startDateTimeInputProps.label)
+            .toBe('Billing start date')
+        expect(startDateTimeInputProps.minDate)
+            .toBeUndefined()
+    })
+})

--- a/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.tsx
+++ b/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.tsx
@@ -65,7 +65,6 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
 
     const isSubmitting = props.isSubmitting === true
 
-    const minStartDate = useMemo(() => new Date(), [])
     const timezone = useMemo(
         () => Intl.DateTimeFormat()
             .resolvedOptions()
@@ -191,7 +190,6 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
 
                     <StartDateTimeInput
                         label='Billing start date'
-                        minDate={minStartDate}
                         preventOpenOnFocus
                         showTimeSelect={false}
                         showTimezone={false}

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.spec.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.spec.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render } from '@testing-library/react'
+
+import AssignmentDetailsModal from './AssignmentDetailsModal'
+
+const mockStartDateTimeInput = jest.fn((props: { label: string }): JSX.Element => (
+    <div>{props.label}</div>
+))
+
+jest.mock('~/libs/ui', () => ({
+    BaseModal: (props: {
+        buttons?: JSX.Element
+        children: JSX.Element
+        open: boolean
+    }): JSX.Element => (
+        props.open ? (
+            <div>
+                {props.children}
+                {props.buttons}
+            </div>
+        ) : <></>
+    ),
+    Button: (props: {
+        label: string
+        onClick?: () => void
+    }): JSX.Element => (
+        <button onClick={props.onClick} type='button'>
+            {props.label}
+        </button>
+    ),
+}), {
+    virtual: true,
+})
+
+jest.mock('../../../../lib/components/form', () => ({
+    StartDateTimeInput: (props: { label: string }): JSX.Element => mockStartDateTimeInput(props),
+}))
+
+jest.mock('../../../../lib/utils', () => ({
+    calculateAssignmentRatePerWeek: jest.fn(() => ''),
+    deserializeTentativeAssignmentDate: jest.fn(() => undefined),
+    sanitizePositiveNumericInput: jest.fn((value: string) => value),
+    serializeTentativeAssignmentDate: jest.fn((value: Date) => value.toISOString()),
+    toPositiveInteger: jest.fn(() => 1),
+    toPositiveNumber: jest.fn(() => 1),
+    toPositiveNumberWithMaxDecimalPlaces: jest.fn(() => 1),
+}))
+
+describe('AssignmentDetailsModal', () => {
+    beforeEach(() => {
+        mockStartDateTimeInput.mockClear()
+    })
+
+    it('allows past engagement start dates in the assignment form', () => {
+        render(
+            <AssignmentDetailsModal
+                memberHandle='testaws1'
+                onCancel={jest.fn()}
+                onSave={jest.fn()}
+                open
+            />,
+        )
+
+        const startDateTimeInputProps = mockStartDateTimeInput
+            .mock.calls[mockStartDateTimeInput.mock.calls.length - 1][0] as {
+            label: string
+            minDate?: Date | null
+        }
+
+        expect(startDateTimeInputProps.label)
+            .toBe('Engagement start date *')
+        expect(startDateTimeInputProps.minDate)
+            .toBeUndefined()
+    })
+})

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.tsx
@@ -67,7 +67,6 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
         props.initialValue?.standardHoursPerWeek || '',
     )
 
-    const minStartDate = useMemo(() => new Date(), [])
     const timezone = useMemo(
         () => Intl.DateTimeFormat()
             .resolvedOptions()
@@ -186,7 +185,6 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
                     </p>
                     <StartDateTimeInput
                         label='Engagement start date *'
-                        minDate={minStartDate}
                         onChange={value => {
                             setStartDate(value || undefined)
                             setErrors(previous => ({


### PR DESCRIPTION
What was broken
The Accept Application and Assign Member modals blocked users from selecting past dates for the engagement start date fields.

Root cause (if identifiable)
Both modals created a minimum start date from the current day and passed it to the shared start-date picker, which prevented choosing any earlier date.

What was changed
Removed the min-date restriction from the billing start date field in Accept Application and from the engagement start date field in Assign Member so both modals can select past dates.

Any added/updated tests
Added focused regression tests for AcceptApplicationModal and AssignmentDetailsModal to verify those start-date inputs no longer receive a minimum date constraint.

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
