### PR TITLE
PM-4895: restore required assignee field markers

### DIFF
--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.module.scss
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.module.scss
@@ -100,6 +100,11 @@
     margin-bottom: 4px;
 }
 
+.required {
+    color: #db3030;
+    margin-left: 2px;
+}
+
 .value {
     color: #2a2a2a;
     font-size: 14px;

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.spec.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.spec.tsx
@@ -193,7 +193,7 @@ describe('EngagementPaymentPage', () => {
             },
         } as unknown as ReturnType<typeof useFetchProject>)
 
-        render(
+        const renderedPage: ReturnType<typeof render> = render(
             <MemoryRouter initialEntries={['/projects/project-1/engagements/engagement-1/assignments']}>
                 <Routes>
                     <Route
@@ -203,9 +203,19 @@ describe('EngagementPaymentPage', () => {
                 </Routes>
             </MemoryRouter>,
         )
+        const container: HTMLElement = renderedPage.container
 
         expect(screen.queryByText('testing 123'))
             .toBeNull()
+        const labels: Array<string | null> = Array.from(container.querySelectorAll('.label'))
+            .map(element => element.textContent)
+
+        expect(labels)
+            .toEqual(expect.arrayContaining([
+                'Billing Start Date*',
+                'Rate Per Hour*',
+                'Standard Hours Per Week*',
+            ]))
 
         fireEvent.click(screen.getByRole('button', {
             name: 'View other remarks for testaws1',

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
@@ -853,7 +853,10 @@ export const EngagementPaymentPage: FC = () => {
                                                 </span>
                                             </div>
                                             <div>
-                                                <span className={styles.label}>Billing Start</span>
+                                                <span className={styles.label}>
+                                                    Billing Start Date
+                                                    <span aria-hidden='true' className={styles.required}>*</span>
+                                                </span>
                                                 <span className={styles.value}>{formatDate(assignment.startDate)}</span>
                                             </div>
                                             <div>
@@ -861,11 +864,17 @@ export const EngagementPaymentPage: FC = () => {
                                                 <span className={styles.value}>{formatDurationMonths(assignment.durationMonths)}</span>
                                             </div>
                                             <div>
-                                                <span className={styles.label}>Rate Per Hour</span>
+                                                <span className={styles.label}>
+                                                    Rate Per Hour
+                                                    <span aria-hidden='true' className={styles.required}>*</span>
+                                                </span>
                                                 <span className={styles.value}>{formatCurrency(assignment.ratePerHour)}</span>
                                             </div>
                                             <div>
-                                                <span className={styles.label}>Hours Per Week</span>
+                                                <span className={styles.label}>
+                                                    Standard Hours Per Week
+                                                    <span aria-hidden='true' className={styles.required}>*</span>
+                                                </span>
                                                 <span className={styles.value}>
                                                     {assignment.standardHoursPerWeek || '-'}
                                                 </span>


### PR DESCRIPTION
What was broken
The work app assignees page did not show mandatory markers for Billing Start Date, Rate Per Hour, and Standard Hours Per Week, so it no longer matched the legacy work-manager behavior.

Root cause
The assignee summary card used simplified static labels and never rendered a required indicator for the three mandatory assignment fields.

What was changed
Updated the assignee summary labels to use the established field names and render a required marker for Billing Start Date, Rate Per Hour, and Standard Hours Per Week. Added scoped styling for the required marker so it is visually distinct on the summary card.

Any added/updated tests
Updated the EngagementPaymentPage spec to assert that the assignee summary renders those three labels with mandatory markers.

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
