### PR TITLE
PM-4859: restore Any option in engagement location fields

### DIFF
--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementLocationFields.spec.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementLocationFields.spec.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    render,
+} from '@testing-library/react'
+import moment from 'moment-timezone'
+
+import { EngagementLocationFields } from './EngagementLocationFields'
+
+const mockRecordedFields = new Map<string, any>()
+
+jest.mock('../../../../lib/components/form', () => ({
+    FormSelectField: function FormSelectField(props: any) {
+        mockRecordedFields.set(props.name, props)
+
+        return <div data-testid={props.name}>{props.label}</div>
+    },
+}))
+
+describe('EngagementLocationFields', () => {
+    beforeEach(() => {
+        mockRecordedFields.clear()
+        jest.spyOn(moment.tz, 'countries')
+            .mockReturnValue(['DE', 'US'])
+        jest.spyOn(moment.tz, 'names')
+            .mockReturnValue(['Europe/Berlin'])
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('prepends Any to the timezone and country option lists', () => {
+        render(<EngagementLocationFields />)
+
+        const timezoneField = mockRecordedFields.get('timezones')
+        const countryField = mockRecordedFields.get('countries')
+
+        expect(timezoneField.options[0])
+            .toEqual({
+                label: 'Any',
+                value: 'Any',
+            })
+        expect(countryField.options[0])
+            .toEqual({
+                label: 'Any',
+                value: 'Any',
+            })
+    })
+
+    it('stores Any as the only selected value when present', () => {
+        render(<EngagementLocationFields />)
+
+        const timezoneField = mockRecordedFields.get('timezones')
+        const countryField = mockRecordedFields.get('countries')
+
+        expect(timezoneField.toFieldValue([
+            {
+                label: 'Any',
+                value: 'Any',
+            },
+            {
+                label: '(UTC+01:00) Europe/Berlin',
+                value: 'Europe/Berlin',
+            },
+        ]))
+            .toEqual(['Any'])
+        expect(countryField.toFieldValue([
+            {
+                label: 'Germany',
+                value: 'DE',
+            },
+            {
+                label: 'Any',
+                value: 'Any',
+            },
+        ]))
+            .toEqual(['Any'])
+        expect(countryField.toFieldValue([
+            {
+                label: 'Germany',
+                value: 'DE',
+            },
+        ]))
+            .toEqual(['DE'])
+    })
+})

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementLocationFields.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementLocationFields.tsx
@@ -1,5 +1,6 @@
 import {
     FC,
+    useCallback,
     useMemo,
 } from 'react'
 import moment from 'moment-timezone'
@@ -11,6 +12,11 @@ import {
 
 interface EngagementLocationFieldsProps {
     disabled?: boolean
+}
+
+const ANY_OPTION: FormSelectOption = {
+    label: 'Any',
+    value: 'Any',
 }
 
 function formatTimezoneLabel(timezone: string): string {
@@ -59,11 +65,14 @@ function formatTimezoneLabel(timezone: string): string {
 }
 
 function getTimezoneOptions(): FormSelectOption[] {
-    return moment.tz.names()
-        .map(timezone => ({
-            label: formatTimezoneLabel(timezone),
-            value: timezone,
-        }))
+    return [
+        ANY_OPTION,
+        ...moment.tz.names()
+            .map(timezone => ({
+                label: formatTimezoneLabel(timezone),
+                value: timezone,
+            })),
+    ]
 }
 
 function getCountryOptions(): FormSelectOption[] {
@@ -77,7 +86,10 @@ function getCountryOptions(): FormSelectOption[] {
             value: countryCode,
         }))
 
-    return options.sort((optionA, optionB) => optionA.label.localeCompare(optionB.label))
+    return [
+        ANY_OPTION,
+        ...options.sort((optionA, optionB) => optionA.label.localeCompare(optionB.label)),
+    ]
 }
 
 export const EngagementLocationFields: FC<EngagementLocationFieldsProps> = (
@@ -85,6 +97,23 @@ export const EngagementLocationFields: FC<EngagementLocationFieldsProps> = (
 ) => {
     const timezoneOptions = useMemo(() => getTimezoneOptions(), [])
     const countryOptions = useMemo(() => getCountryOptions(), [])
+    /**
+     * Preserves the legacy "Any" sentinel as a mutually exclusive selection.
+     *
+     * @param selected Select value emitted by the form field.
+     * @returns Normalized form values for react-hook-form state.
+     */
+    const toAnyOnlyFieldValue = useCallback((selected: unknown): string[] => {
+        const selectedOptions = Array.isArray(selected)
+            ? selected
+            : []
+
+        if (selectedOptions.some(option => option.value === ANY_OPTION.value)) {
+            return [ANY_OPTION.value]
+        }
+
+        return selectedOptions.map(option => option.value)
+    }, [])
 
     return (
         <>
@@ -96,6 +125,7 @@ export const EngagementLocationFields: FC<EngagementLocationFieldsProps> = (
                 options={timezoneOptions}
                 placeholder='Select timezones'
                 required
+                toFieldValue={toAnyOnlyFieldValue}
             />
 
             <FormSelectField
@@ -106,6 +136,7 @@ export const EngagementLocationFields: FC<EngagementLocationFieldsProps> = (
                 options={countryOptions}
                 placeholder='Select countries'
                 required
+                toFieldValue={toAnyOnlyFieldValue}
             />
         </>
     )


### PR DESCRIPTION
What was broken
The new engagement editor in the Work app did not offer the legacy Any choice in the Countries and Timezones multiselects. Existing Any values could still hydrate into the form, but users could not reselect that option from the dropdowns.

Root cause
The new location option builders only listed concrete countries and timezones, and the multiselect persisted raw selections instead of treating the legacy Any sentinel as mutually exclusive.

What was changed
Added Any as the first option in both location dropdowns. Normalized the multi-select values so choosing Any saves only Any. Kept the fix scoped to the engagement location field component.

Any added/updated tests
Added a regression test for the engagement location fields that covers both the visible Any option and the Any-only normalization behavior. Validated with yarn test:no-watch, yarn lint, and yarn run build.

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
