### PR TITLE
PM-4799 iterrative phases submission order

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
@@ -169,53 +169,56 @@ describe('filterIterativeReviewRows', () => {
             .toBe('submission-2')
     })
 
-    it('skips iterative phases that already have assigned reviews when mapping phase-less AI-failed submissions', () => {
-        const multiIterativePhases: BackendPhase[] = [
-            createPhase('submission-1', 'Submission'),
-            createPhase('iterative-1', 'Iterative Review', 'iterative-phase-1'),
-            createPhase('iterative-2', 'Iterative Review', 'iterative-phase-2'),
-            createPhase('review-1', 'Review', 'review-phase-1'),
-        ]
+    it(
+        'skips iterative phases that already have assigned reviews when mapping phase-less AI-failed submissions',
+        () => {
+            const multiIterativePhases: BackendPhase[] = [
+                createPhase('submission-1', 'Submission'),
+                createPhase('iterative-1', 'Iterative Review', 'iterative-phase-1'),
+                createPhase('iterative-2', 'Iterative Review', 'iterative-phase-2'),
+                createPhase('review-1', 'Review', 'review-phase-1'),
+            ]
 
-        const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
-        const assignedSubmission: SubmissionInfo = {
-            ...createSubmission('assigned-reviewer', 'iterative-phase-1'),
-            id: 'assigned-submission',
-        }
+            const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
+            const assignedSubmission: SubmissionInfo = {
+                ...createSubmission('assigned-reviewer', 'iterative-phase-1'),
+                id: 'assigned-submission',
+            }
 
-        const aiFailedSubmission: SubmissionInfo = {
-            ...createSubmission(iterativeReviewer.id),
-            id: 'ai-failed-submission',
-            status: 'AI_FAILED_REVIEW',
-            submittedDate: '2026-04-01T04:56:13.405Z',
-        }
+            const aiFailedSubmission: SubmissionInfo = {
+                ...createSubmission(iterativeReviewer.id),
+                id: 'ai-failed-submission',
+                status: 'AI_FAILED_REVIEW',
+                submittedDate: '2026-04-01T04:56:13.405Z',
+            }
 
-        const phase1Results = filterIterativeReviewRows({
-            challengePhases: multiIterativePhases,
-            isPostMortemPhase: false,
-            phaseIdFilter: 'iterative-1',
-            reviewerResources: [iterativeReviewer],
-            sourceRows: [assignedSubmission, aiFailedSubmission],
-        })
+            const phase1Results = filterIterativeReviewRows({
+                challengePhases: multiIterativePhases,
+                isPostMortemPhase: false,
+                phaseIdFilter: 'iterative-1',
+                reviewerResources: [iterativeReviewer],
+                sourceRows: [assignedSubmission, aiFailedSubmission],
+            })
 
-        const phase2Results = filterIterativeReviewRows({
-            challengePhases: multiIterativePhases,
-            isPostMortemPhase: false,
-            phaseIdFilter: 'iterative-2',
-            reviewerResources: [iterativeReviewer],
-            sourceRows: [assignedSubmission, aiFailedSubmission],
-        })
+            const phase2Results = filterIterativeReviewRows({
+                challengePhases: multiIterativePhases,
+                isPostMortemPhase: false,
+                phaseIdFilter: 'iterative-2',
+                reviewerResources: [iterativeReviewer],
+                sourceRows: [assignedSubmission, aiFailedSubmission],
+            })
 
-        expect(phase1Results)
-            .toHaveLength(1)
-        expect(phase1Results[0].id)
-            .toBe('assigned-submission')
+            expect(phase1Results)
+                .toHaveLength(1)
+            expect(phase1Results[0].id)
+                .toBe('assigned-submission')
 
-        expect(phase2Results)
-            .toHaveLength(1)
-        expect(phase2Results[0].id)
-            .toBe('ai-failed-submission')
-    })
+            expect(phase2Results)
+                .toHaveLength(1)
+            expect(phase2Results[0].id)
+                .toBe('ai-failed-submission')
+        },
+    )
 
     it('keeps a phase-less AI-failed submission when only one iterative phase exists', () => {
         const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
@@ -119,6 +119,125 @@ describe('filterIterativeReviewRows', () => {
             .toBe('iterative-phase-1')
     })
 
+    it('maps phase-less AI-failed submissions to iterative tabs by submission order', () => {
+        const multiIterativePhases: BackendPhase[] = [
+            createPhase('submission-1', 'Submission'),
+            createPhase('iterative-1', 'Iterative Review', 'iterative-phase-1'),
+            createPhase('iterative-2', 'Iterative Review', 'iterative-phase-2'),
+            createPhase('review-1', 'Review', 'review-phase-1'),
+        ]
+
+        const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
+        const firstAiFailedSubmission: SubmissionInfo = {
+            ...createSubmission(iterativeReviewer.id),
+            id: 'submission-1',
+            status: 'AI_FAILED_REVIEW',
+            submittedDate: '2026-04-01T04:56:13.405Z',
+        }
+
+        const secondAiFailedSubmission: SubmissionInfo = {
+            ...createSubmission(iterativeReviewer.id),
+            id: 'submission-2',
+            status: 'AI_FAILED_REVIEW',
+            submittedDate: '2026-04-01T04:57:13.405Z',
+        }
+
+        const phase1Results = filterIterativeReviewRows({
+            challengePhases: multiIterativePhases,
+            isPostMortemPhase: false,
+            phaseIdFilter: 'iterative-1',
+            reviewerResources: [iterativeReviewer],
+            sourceRows: [secondAiFailedSubmission, firstAiFailedSubmission],
+        })
+
+        const phase2Results = filterIterativeReviewRows({
+            challengePhases: multiIterativePhases,
+            isPostMortemPhase: false,
+            phaseIdFilter: 'iterative-2',
+            reviewerResources: [iterativeReviewer],
+            sourceRows: [secondAiFailedSubmission, firstAiFailedSubmission],
+        })
+
+        expect(phase1Results)
+            .toHaveLength(1)
+        expect(phase1Results[0].id)
+            .toBe('submission-1')
+
+        expect(phase2Results)
+            .toHaveLength(1)
+        expect(phase2Results[0].id)
+            .toBe('submission-2')
+    })
+
+    it('skips iterative phases that already have assigned reviews when mapping phase-less AI-failed submissions', () => {
+        const multiIterativePhases: BackendPhase[] = [
+            createPhase('submission-1', 'Submission'),
+            createPhase('iterative-1', 'Iterative Review', 'iterative-phase-1'),
+            createPhase('iterative-2', 'Iterative Review', 'iterative-phase-2'),
+            createPhase('review-1', 'Review', 'review-phase-1'),
+        ]
+
+        const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
+        const assignedSubmission: SubmissionInfo = {
+            ...createSubmission('assigned-reviewer', 'iterative-phase-1'),
+            id: 'assigned-submission',
+        }
+
+        const aiFailedSubmission: SubmissionInfo = {
+            ...createSubmission(iterativeReviewer.id),
+            id: 'ai-failed-submission',
+            status: 'AI_FAILED_REVIEW',
+            submittedDate: '2026-04-01T04:56:13.405Z',
+        }
+
+        const phase1Results = filterIterativeReviewRows({
+            challengePhases: multiIterativePhases,
+            isPostMortemPhase: false,
+            phaseIdFilter: 'iterative-1',
+            reviewerResources: [iterativeReviewer],
+            sourceRows: [assignedSubmission, aiFailedSubmission],
+        })
+
+        const phase2Results = filterIterativeReviewRows({
+            challengePhases: multiIterativePhases,
+            isPostMortemPhase: false,
+            phaseIdFilter: 'iterative-2',
+            reviewerResources: [iterativeReviewer],
+            sourceRows: [assignedSubmission, aiFailedSubmission],
+        })
+
+        expect(phase1Results)
+            .toHaveLength(1)
+        expect(phase1Results[0].id)
+            .toBe('assigned-submission')
+
+        expect(phase2Results)
+            .toHaveLength(1)
+        expect(phase2Results[0].id)
+            .toBe('ai-failed-submission')
+    })
+
+    it('keeps a phase-less AI-failed submission when only one iterative phase exists', () => {
+        const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
+        const aiFailedSubmission: SubmissionInfo = {
+            ...createSubmission(iterativeReviewer.id),
+            status: 'AI_FAILED_REVIEW',
+        }
+
+        const results = filterIterativeReviewRows({
+            challengePhases,
+            isPostMortemPhase: false,
+            phaseIdFilter: 'iterative-1',
+            reviewerResources: [iterativeReviewer],
+            sourceRows: [aiFailedSubmission],
+        })
+
+        expect(results)
+            .toHaveLength(1)
+        expect(results[0].id)
+            .toBe(`submission-${iterativeReviewer.id}`)
+    })
+
     it('limits completed F2F rows to the supplied winning submission ids', () => {
         const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
         const losingReviewer = createResource('iterative-resource-2', 'Iterative Reviewer')

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
@@ -142,6 +142,167 @@ function countIterativeReviewPhases(challengePhases: BackendPhase[] | undefined)
         .includes('iterative review')).length
 }
 
+interface OrderedIterativePhase {
+    id: string
+    phaseTypeId?: string
+}
+
+function getOrderedIterativePhases(challengePhases: BackendPhase[] | undefined): OrderedIterativePhase[] {
+    const iterativePhases = (challengePhases ?? [])
+        .map((phase, index) => ({
+            id: normalizeIdentifier(phase.id),
+            index,
+            phaseTypeId: normalizeIdentifier(phase.phaseId),
+            startedAt: parseSortableDate(phase.actualStartDate ?? phase.scheduledStartDate),
+        }))
+        .filter(phase => Boolean(phase.id))
+        .filter(phase => (challengePhases?.[phase.index].name ?? '')
+            .toLowerCase()
+            .includes('iterative review'))
+        .sort((left, right) => {
+            const leftStartedAt = Number.isFinite(left.startedAt)
+                ? left.startedAt
+                : Number.POSITIVE_INFINITY
+            const rightStartedAt = Number.isFinite(right.startedAt)
+                ? right.startedAt
+                : Number.POSITIVE_INFINITY
+
+            if (leftStartedAt !== rightStartedAt) {
+                return leftStartedAt - rightStartedAt
+            }
+
+            return left.index - right.index
+        })
+
+    return iterativePhases
+        .map(phase => ({
+            id: phase.id,
+            phaseTypeId: phase.phaseTypeId,
+        } as OrderedIterativePhase))
+        .filter((phase): phase is OrderedIterativePhase => Boolean(phase.id))
+}
+
+function getAiFailedSubmissionIdsForSelectedIterativePhase(
+    sourceRows: SubmissionInfo[],
+    challengePhases: BackendPhase[] | undefined,
+    phaseIdFilterSet: Set<string>,
+    aiReviewDecisionsBySubmissionId?: Record<string, AiReviewDecision>,
+): Set<string> {
+    const orderedIterativePhases = getOrderedIterativePhases(challengePhases)
+    if (!orderedIterativePhases.length) {
+        return new Set<string>()
+    }
+
+    const assignedIterativePhaseIds = new Set<string>()
+    sourceRows.forEach(submission => {
+        const reviewPhaseId = normalizeIdentifier(submission.review?.phaseId)
+        if (!reviewPhaseId) {
+            return
+        }
+
+        const matchedByPhaseId = orderedIterativePhases.find(phase => phase.id === reviewPhaseId)
+        if (matchedByPhaseId) {
+            assignedIterativePhaseIds.add(matchedByPhaseId.id)
+            return
+        }
+
+        const matchedByPhaseTypeId = orderedIterativePhases.filter(
+            phase => phase.phaseTypeId === reviewPhaseId,
+        )
+        if (matchedByPhaseTypeId.length === 1) {
+            assignedIterativePhaseIds.add(matchedByPhaseTypeId[0].id)
+        }
+    })
+
+    const unassignedIterativePhaseIds = orderedIterativePhases
+        .map(phase => phase.id)
+        .filter(phaseId => !assignedIterativePhaseIds.has(phaseId))
+
+    if (!unassignedIterativePhaseIds.length) {
+        return new Set<string>()
+    }
+
+    const selectedPhase = orderedIterativePhases.find(phase => phaseIdFilterSet.has(phase.id))
+        ?? (() => {
+            const matchedByPhaseTypeId = orderedIterativePhases.filter(
+                phase => Boolean(phase.phaseTypeId && phaseIdFilterSet.has(phase.phaseTypeId)),
+            )
+
+            if (matchedByPhaseTypeId.length === 1) {
+                return matchedByPhaseTypeId[0]
+            }
+
+            return undefined
+        })()
+
+    const aiFailedRows = sourceRows
+        .filter(submission => !normalizeIdentifier(submission.review?.phaseId))
+        .filter(submission => shouldTreatAsAiFailedSubmission(submission, aiReviewDecisionsBySubmissionId))
+        .map((submission, index) => ({
+            index,
+            reviewCreatedAt: parseSortableDate(submission.review?.createdAt),
+            submission,
+            submittedAt: parseSortableDate(submission.submittedDate),
+        }))
+        .sort((left, right) => {
+            const leftSubmittedAt = Number.isFinite(left.submittedAt)
+                ? left.submittedAt
+                : Number.POSITIVE_INFINITY
+            const rightSubmittedAt = Number.isFinite(right.submittedAt)
+                ? right.submittedAt
+                : Number.POSITIVE_INFINITY
+
+            if (leftSubmittedAt !== rightSubmittedAt) {
+                return leftSubmittedAt - rightSubmittedAt
+            }
+
+            const leftReviewCreatedAt = Number.isFinite(left.reviewCreatedAt)
+                ? left.reviewCreatedAt
+                : Number.POSITIVE_INFINITY
+            const rightReviewCreatedAt = Number.isFinite(right.reviewCreatedAt)
+                ? right.reviewCreatedAt
+                : Number.POSITIVE_INFINITY
+
+            if (leftReviewCreatedAt !== rightReviewCreatedAt) {
+                return leftReviewCreatedAt - rightReviewCreatedAt
+            }
+
+            return left.index - right.index
+        })
+
+    if (!aiFailedRows.length) {
+        return new Set<string>()
+    }
+
+    if (!selectedPhase) {
+        return new Set<string>()
+    }
+
+    const selectedPhaseIndex = unassignedIterativePhaseIds.findIndex(phaseId => phaseId === selectedPhase.id)
+    if (selectedPhaseIndex < 0) {
+        return new Set<string>()
+    }
+
+    if (unassignedIterativePhaseIds.length === 1) {
+        return new Set(
+            aiFailedRows
+                .map(row => normalizeIdentifier(row.submission.id))
+                .filter((id): id is string => Boolean(id)),
+        )
+    }
+
+    const isLastIterativePhase = selectedPhaseIndex === unassignedIterativePhaseIds.length - 1
+    const assignedRows = isLastIterativePhase
+        ? aiFailedRows.slice(selectedPhaseIndex)
+        : aiFailedRows.slice(selectedPhaseIndex, selectedPhaseIndex + 1)
+
+    return new Set(
+        assignedRows
+            .map(row => normalizeIdentifier(row.submission.id))
+            .filter((id): id is string => Boolean(id)),
+    )
+}
+
 /**
  * Collect resource ids assigned to iterative-review roles.
  *
@@ -288,6 +449,13 @@ export function filterIterativeReviewRows(args: FilterIterativeReviewRowsArgs): 
     const iterativeReviewerResourceIds = collectIterativeReviewerResourceIds(reviewerResources)
 
     if (phaseIdFilterSet?.size) {
+        const aiFailedSubmissionIdsForSelectedPhase = getAiFailedSubmissionIdsForSelectedIterativePhase(
+            sourceRows,
+            challengePhases,
+            phaseIdFilterSet,
+            aiReviewDecisionsBySubmissionId,
+        )
+
         const filteredRows = sourceRows.filter(submission => {
             const reviewPhaseId = normalizeIdentifier(submission.review?.phaseId)
             if (reviewPhaseId) {
@@ -295,7 +463,8 @@ export function filterIterativeReviewRows(args: FilterIterativeReviewRowsArgs): 
             }
 
             if (shouldTreatAsAiFailedSubmission(submission, aiReviewDecisionsBySubmissionId)) {
-                return true
+                const submissionId = normalizeIdentifier(submission.id)
+                return submissionId ? aiFailedSubmissionIdsForSelectedPhase.has(submissionId) : false
             }
 
             // New WM F2F flows can surface assigned submissions before the review row has a phase id.


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-4799


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request enhances the logic for filtering iterative review rows, specifically improving how AI-failed submissions without an assigned phase are mapped to iterative review phases. The changes add robust handling for multiple iterative phases, ensuring that phase-less AI-failed submissions are distributed appropriately and do not overlap with already assigned reviews. Comprehensive tests are included to validate these scenarios.

- Add getOrderedIterativePhases() to sort iterative phases by start time, carrying both id and phaseTypeId for dual-id resolution
- Add getAiFailedSubmissionIdsForSelectedIterativePhase() to map AI-failed submissions to unoccupied iterative phase slots
- Detect occupied phases by matching review.phaseId against phase instance id first, then phaseTypeId as fallback
- Fix reviewCreatedAt sort key reading submission.review?.createdAt instead of submittedDate
- Add/update tests (9 passing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
