### PR TITLE
PM-4804 - for f2f challenges when completed show the winners tab

### DIFF
--- a/src/apps/review/src/lib/utils/challenge.spec.ts
+++ b/src/apps/review/src/lib/utils/challenge.spec.ts
@@ -232,22 +232,22 @@ describe('challenge phase tab helpers', () => {
 
     it('force-shows winners for past challenges with winners even when a phase remains open', () => {
         expect(shouldAllowWinnersTabForPastChallenge({
-            status: 'COMPLETED',
             phases: [
                 createBackendPhase('iterative-1', 'Iterative Review', '2026-04-20T00:00:00Z', {
                     isOpen: true,
                 }),
             ],
+            status: 'COMPLETED',
         }))
             .toBe(false)
 
         expect(shouldForceWinnersTabForPastChallenge({
-            status: 'COMPLETED',
             phases: [
                 createBackendPhase('iterative-1', 'Iterative Review', '2026-04-20T00:00:00Z', {
                     isOpen: true,
                 }),
             ],
+            status: 'COMPLETED',
             winners: [{ handle: 'winner-one', placement: 1, userId: 1 }],
         }))
             .toBe(true)

--- a/src/apps/review/src/lib/utils/challenge.spec.ts
+++ b/src/apps/review/src/lib/utils/challenge.spec.ts
@@ -230,6 +230,29 @@ describe('challenge phase tab helpers', () => {
             .toBe(false)
     })
 
+    it('force-shows winners for past challenges with winners even when a phase remains open', () => {
+        expect(shouldAllowWinnersTabForPastChallenge({
+            status: 'COMPLETED',
+            phases: [
+                createBackendPhase('iterative-1', 'Iterative Review', '2026-04-20T00:00:00Z', {
+                    isOpen: true,
+                }),
+            ],
+        }))
+            .toBe(false)
+
+        expect(shouldForceWinnersTabForPastChallenge({
+            status: 'COMPLETED',
+            phases: [
+                createBackendPhase('iterative-1', 'Iterative Review', '2026-04-20T00:00:00Z', {
+                    isOpen: true,
+                }),
+            ],
+            winners: [{ handle: 'winner-one', placement: 1, userId: 1 }],
+        }))
+            .toBe(true)
+    })
+
     it('keeps winners hidden when a follow-up approval review is still pending', () => {
         const challengeInfo = {
             phases: [

--- a/src/apps/review/src/lib/utils/challenge.ts
+++ b/src/apps/review/src/lib/utils/challenge.ts
@@ -743,11 +743,15 @@ export function shouldForceWinnersTabForPastChallenge(
     challengeInfo?: WinnersTabFallbackChallengeInfo,
     approvalReviews?: ApprovalReviewStatusLike[] | null,
 ): boolean {
+    if (!isPastChallengeStatus(challengeInfo?.status)) {
+        return false
+    }
+
     if (!(challengeInfo?.winners?.length)) {
         return false
     }
 
-    return shouldAllowWinnersTabForPastChallenge(challengeInfo, approvalReviews)
+    return !hasPendingApprovalReview(approvalReviews)
 }
 
 export function isReviewPhaseCurrentlyOpen(


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-4804


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
F2F: Winners tab is not displayed on completed F2Fs with AI workflows

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
