### PR TITLE
PM-4904: Make project billing account optional

### DIFF
--- a/src/apps/work/src/lib/schemas/project-editor.schema.spec.ts
+++ b/src/apps/work/src/lib/schemas/project-editor.schema.spec.ts
@@ -1,0 +1,52 @@
+import { PROJECT_STATUS } from '../constants'
+
+import {
+    createProjectEditorSchema,
+    ProjectEditorSchemaData,
+} from './project-editor.schema'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        ADMIN: {
+            DIRECT_URL: 'https://direct.topcoder-dev.com',
+            REVIEW_UI_URL: 'https://review.topcoder-dev.com',
+        },
+        API: {
+            V5: 'https://api.topcoder-dev.com/v5',
+            V6: 'https://api.topcoder-dev.com/v6',
+        },
+        CHALLENGE_API_URL: 'https://api.topcoder-dev.com/v5/challenges',
+        CHALLENGE_API_VERSION: 'v5',
+        COMMUNITY_APP_URL: 'https://topcoder-dev.com',
+        DIRECT_PROJECT_URL: 'https://direct.topcoder-dev.com',
+        ENGAGEMENTS_URL: 'https://work.topcoder-dev.com',
+        REVIEW_APP_URL: 'https://review.topcoder-dev.com',
+        TC_DOMAIN: 'topcoder-dev.com',
+        TC_FINANCE_API: 'https://finance.topcoder-dev.com',
+        TOPCODER_URL: 'https://topcoder-dev.com',
+    },
+}), {
+    virtual: true,
+})
+
+describe('createProjectEditorSchema', () => {
+    it('allows project creation without a billing account', async () => {
+        const schema = createProjectEditorSchema(false, true)
+        const values: ProjectEditorSchemaData = {
+            billingAccountId: '',
+            description: 'Create work before billing is assigned',
+            groups: [],
+            name: 'Project without billing',
+            status: PROJECT_STATUS.DRAFT,
+            terms: '',
+            type: 'generic',
+        }
+
+        await expect(schema.validate(values, {
+            abortEarly: false,
+        })).resolves.toMatchObject({
+            billingAccountId: '',
+            name: 'Project without billing',
+        })
+    })
+})

--- a/src/apps/work/src/lib/schemas/project-editor.schema.ts
+++ b/src/apps/work/src/lib/schemas/project-editor.schema.ts
@@ -21,7 +21,7 @@ export function createProjectEditorSchema(
         .object({
             billingAccountId: yup
                 .string()
-                .required('Billing account is required'),
+                .optional(),
             cancelReason: yup
                 .string()
                 .when('status', {

--- a/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
+++ b/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
@@ -513,7 +513,6 @@ export const ProjectEditorForm: FC<ProjectEditorFormProps> = (props: ProjectEdit
                             name='billingAccountId'
                             placeholder='Search billing account by name'
                             projectId={projectId}
-                            required
                             selectedBillingAccount={selectedBillingAccount}
                             userId={props.billingAccountSearchUserId}
                         />


### PR DESCRIPTION
What was broken
Project create and edit forms treated billing account as mandatory, so users could not save projects without assigning a billing account.

Root cause
The work app project editor Yup schema required billingAccountId, and the billing account autocomplete was rendered with the required marker.

What was changed
Made billingAccountId optional in the project editor validation schema and removed the required state from the billing account selector.

Any added/updated tests
Added a project editor schema regression test confirming project creation validates without a billing account.

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
