### PR TITLE
PM-4959: Link billing account engagement names

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -227,6 +227,81 @@ describe('BillingAccountLineItemsModal', () => {
             .toBe('/work/projects/project%20200/engagements/engagement-300')
     })
 
+    it('builds engagement links from assignment-backed billing rows for copilot views', () => {
+        mockedUseFetchEngagements.mockReturnValue({
+            engagements: [
+                {
+                    anticipatedStart: 'IMMEDIATE',
+                    assignedMemberHandles: [],
+                    assignments: [
+                        {
+                            agreementRate: '100',
+                            endDate: '2026-03-01T00:00:00.000Z',
+                            engagementId: 'engagement-300',
+                            id: 'assignment-300',
+                            memberHandle: 'member',
+                            memberId: 123,
+                            otherRemarks: '',
+                            startDate: '2026-02-01T00:00:00.000Z',
+                            status: 'ACTIVE',
+                            termsAccepted: true,
+                        },
+                    ],
+                    compensationRange: '$100',
+                    countries: [],
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                    description: 'Engagement description',
+                    durationWeeks: 4,
+                    id: 'engagement-300',
+                    isPrivate: false,
+                    projectId: 'project 200',
+                    requiredMemberCount: 1,
+                    role: 'SOFTWARE_DEVELOPER',
+                    skills: [],
+                    status: 'Active',
+                    timezones: [],
+                    title: 'Resolved Engagement',
+                    updatedAt: '2026-01-01T00:00:00.000Z',
+                    workload: 'FULL_TIME',
+                },
+            ],
+            error: undefined,
+            isLoading: false,
+            isValidating: false,
+            metadata: {
+                page: 1,
+                perPage: 1,
+                total: 1,
+                totalPages: 1,
+            },
+            mutate: jest.fn(),
+        })
+
+        renderModal({
+            ...baseBillingAccountDetails,
+            consumedAmounts: [
+                {
+                    amount: '120',
+                    date: '2026-02-10T00:00:00.000Z',
+                    externalId: 'assignment-300',
+                    externalName: 'Resolved Engagement',
+                    externalType: 'ENGAGEMENT',
+                    memberPaymentAmount: '100',
+                },
+            ],
+            consumedBudget: 120,
+            memberPaymentsRemaining: 500,
+            totalBudgetRemaining: 880,
+        }, true, 'project 200')
+
+        const engagementLink = screen.getByRole('link', {
+            name: 'Resolved Engagement',
+        })
+
+        expect(engagementLink.getAttribute('href'))
+            .toBe('/work/projects/project%20200/engagements/engagement-300')
+    })
+
     it('renders legacy-only challenge rows as plain text', () => {
         renderModal({
             ...baseBillingAccountDetails,

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -366,7 +366,7 @@ export const BillingAccountLineItemsModal: FC<BillingAccountLineItemsModalProps>
         normalizedProjectId,
         EMPTY_ENGAGEMENT_FILTERS,
         {
-            enabled: showChallengeFeeColumn && !!normalizedProjectId && hasEngagementLineItems,
+            enabled: !!normalizedProjectId && hasEngagementLineItems,
         },
     )
     const engagementIdsByAssignmentId = useMemo(


### PR DESCRIPTION
What was broken
Engagement entries in the billing account details modal could render as plain text in the member-payments view while challenge entries were linked.

Root cause
The modal only fetched the assignment-to-engagement lookup when the challenge fee column was visible. Copilot/member-payments views hide that column, so assignment-backed engagement rows could not resolve the engagement details URL.

What was changed
The engagement lookup now runs whenever the modal has engagement line items and a project id, independent of the visible table columns.

Any added/updated tests
Added a BillingAccountLineItemsModal regression test covering assignment-backed engagement links in the copilot/member-payments view.

Validation note: the targeted modal test, lint, and build passed. The broader yarn test:no-watch run has one deterministic unrelated wallet-admin PaymentView.spec.tsx failure on the current base: task payment project link expected a challenge detail URL but rendered the project URL.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
