### PR TITLE
PM-4954: Gate copilot payment details by project flag

### DIFF
--- a/src/apps/work/src/lib/components/ProjectBillingAccountExpiredNotice/ProjectBillingAccountExpiredNotice.spec.tsx
+++ b/src/apps/work/src/lib/components/ProjectBillingAccountExpiredNotice/ProjectBillingAccountExpiredNotice.spec.tsx
@@ -72,7 +72,10 @@ const defaultContextValue: WorkAppContextModel = {
     userRoles: [],
 }
 
-function renderNotice(contextValue: WorkAppContextModel = defaultContextValue): void {
+function renderNotice(
+    contextValue: WorkAppContextModel = defaultContextValue,
+    displayMemberPaymentDetailsToCopilots: boolean = false,
+): void {
     render(
         <WorkAppContext.Provider value={contextValue}>
             <MemoryRouter>
@@ -80,6 +83,7 @@ function renderNotice(contextValue: WorkAppContextModel = defaultContextValue): 
                     billingAccountId={80001063}
                     billingAccountName='Test Project Engagement BA'
                     canManageProject
+                    displayMemberPaymentDetailsToCopilots={displayMemberPaymentDetailsToCopilots}
                     projectId='project-1'
                 />
             </MemoryRouter>
@@ -169,11 +173,42 @@ describe('ProjectBillingAccountExpiredNotice', () => {
             ...defaultContextValue,
             isCopilot: true,
             userRoles: ['copilot'],
-        })
+        }, true)
 
         expect(screen.getByText('Member Payments Remaining: $200.00'))
             .toBeTruthy()
         expect(screen.queryByText('$750 / $1,000 spent'))
             .toBeNull()
+    })
+
+    it('hides member payment details and billing account modal access from copilots when disabled', () => {
+        mockedUseFetchBillingAccountDetails.mockReturnValue({
+            billingAccountDetails: {
+                ...billingAccountDetails,
+                budget: 1000,
+                markup: 0.25,
+                totalBudgetRemaining: 250,
+            },
+            error: undefined,
+            isError: false,
+            isLoading: false,
+        })
+
+        renderNotice({
+            ...defaultContextValue,
+            isCopilot: true,
+            userRoles: ['copilot'],
+        })
+
+        expect(screen.queryByText('Member Payments Remaining: $200.00'))
+            .toBeNull()
+        expect(screen.queryByText('$750 / $1,000 spent'))
+            .toBeNull()
+        expect(screen.queryByRole('button', {
+            name: 'View billing account details',
+        }))
+            .toBeNull()
+        expect(mockedUseFetchBillingAccountDetails)
+            .toHaveBeenCalledWith(undefined)
     })
 })

--- a/src/apps/work/src/lib/components/ProjectBillingAccountExpiredNotice/ProjectBillingAccountExpiredNotice.tsx
+++ b/src/apps/work/src/lib/components/ProjectBillingAccountExpiredNotice/ProjectBillingAccountExpiredNotice.tsx
@@ -41,6 +41,7 @@ interface ProjectBillingAccountExpiredNoticeProps {
     billingAccountId?: number | string
     billingAccountName?: string
     canManageProject: boolean
+    displayMemberPaymentDetailsToCopilots?: boolean
     projectId: string
 }
 
@@ -65,10 +66,71 @@ function formatCurrency(amount: number, includeCents: boolean = false): string {
         .format(amount)
 }
 
-function canShowMemberPaymentsRemaining(workAppContext: WorkAppContextModel): boolean {
+/**
+ * Identifies copilot-only users whose project payment details are controlled
+ * by the project-level display flag.
+ *
+ * @param workAppContext Current work app user context.
+ * @returns `true` when the user is a copilot without admin or manager access.
+ */
+function isRestrictedCopilot(workAppContext: WorkAppContextModel): boolean {
     return workAppContext.isCopilot
         && !workAppContext.isAdmin
         && !workAppContext.isManager
+}
+
+/**
+ * Resolves whether the current user may see project payment details.
+ *
+ * @param workAppContext Current work app user context.
+ * @param displayMemberPaymentDetailsToCopilots Project-level copilot display flag.
+ * @returns `true` when payment amounts and the line-item modal may be shown.
+ */
+function canShowProjectPaymentDetails(
+    workAppContext: WorkAppContextModel,
+    displayMemberPaymentDetailsToCopilots: boolean | undefined,
+): boolean {
+    return !isRestrictedCopilot(workAppContext)
+        || displayMemberPaymentDetailsToCopilots === true
+}
+
+/**
+ * Resolves whether the copilot-safe member-payment balance should be shown.
+ *
+ * @param workAppContext Current work app user context.
+ * @param showPaymentDetails Whether payment details are enabled for this project.
+ * @returns `true` when the user should see member payments remaining.
+ */
+function canShowMemberPaymentsRemaining(
+    workAppContext: WorkAppContextModel,
+    showPaymentDetails: boolean,
+): boolean {
+    return showPaymentDetails && isRestrictedCopilot(workAppContext)
+}
+
+interface VisibleBudgetInfoParams {
+    copilotBudgetInfo: CopilotMemberPaymentsBudgetInfo | undefined
+    showMemberPaymentsRemaining: boolean
+    showPaymentDetails: boolean
+    standardBudgetInfo: BillingAccountBudgetInfo | undefined
+}
+
+/**
+ * Selects the budget payload that is safe for the current user to see.
+ *
+ * @param params Standard and copilot budget variants with display flags.
+ * @returns The visible budget payload, or `undefined` when hidden.
+ */
+function getVisibleBudgetInfo(
+    params: VisibleBudgetInfoParams,
+): BillingAccountBudgetInfo | undefined {
+    if (!params.showPaymentDetails) {
+        return undefined
+    }
+
+    return params.showMemberPaymentsRemaining
+        ? params.copilotBudgetInfo
+        : params.standardBudgetInfo
 }
 
 function getBudgetStatusClass(
@@ -114,7 +176,14 @@ export const ProjectBillingAccountExpiredNotice: FC<ProjectBillingAccountExpired
 ) => {
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
     const workAppContext: WorkAppContextModel = useContext(WorkAppContext)
-    const showMemberPaymentsRemaining: boolean = canShowMemberPaymentsRemaining(workAppContext)
+    const showPaymentDetails: boolean = canShowProjectPaymentDetails(
+        workAppContext,
+        props.displayMemberPaymentDetailsToCopilots,
+    )
+    const showMemberPaymentsRemaining: boolean = canShowMemberPaymentsRemaining(
+        workAppContext,
+        showPaymentDetails,
+    )
 
     const projectBillingAccountResult: UseFetchProjectBillingAccountResult = useFetchProjectBillingAccount(
         props.projectId,
@@ -124,7 +193,9 @@ export const ProjectBillingAccountExpiredNotice: FC<ProjectBillingAccountExpired
     const normalizedBillingAccountId = normalizeOptionalString(props.billingAccountId)
         || normalizeOptionalString(billingAccount?.id)
     const billingAccountDetailsResult: UseFetchBillingAccountDetailsResult = useFetchBillingAccountDetails(
-        normalizedBillingAccountId,
+        showPaymentDetails
+            ? normalizedBillingAccountId
+            : undefined,
     )
 
     const billingAccountDetailsData = billingAccountDetailsResult.billingAccountDetails
@@ -165,9 +236,12 @@ export const ProjectBillingAccountExpiredNotice: FC<ProjectBillingAccountExpired
             ? getCopilotMemberPaymentsBudgetInfo(billingAccountDetailsData)
             : undefined
     ), [billingAccountDetailsData, showMemberPaymentsRemaining])
-    const budgetInfo = showMemberPaymentsRemaining
-        ? copilotBudgetInfo
-        : standardBudgetInfo
+    const budgetInfo = getVisibleBudgetInfo({
+        copilotBudgetInfo,
+        showMemberPaymentsRemaining,
+        showPaymentDetails,
+        standardBudgetInfo,
+    })
 
     const handleOpenModal = useCallback((): void => {
         setIsModalOpen(true)

--- a/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx
@@ -232,6 +232,9 @@ describe('ProjectsTable', () => {
             [{
                 ...invitedProject,
                 billingAccountId: 80001063,
+                details: {
+                    displayMemberPaymentDetailsToCopilots: true,
+                },
             }],
             {
                 ...defaultContextValue,
@@ -243,6 +246,49 @@ describe('ProjectsTable', () => {
         expect(screen.getAllByText('Member Payments Remaining: $200.00').length)
             .toBeGreaterThan(0)
         expect(screen.queryByText('$750 / $1,000 spent'))
+            .toBeNull()
+    })
+
+    it('hides payment amounts and billing details access for copilot project rows when disabled', () => {
+        mockedUseFetchBillingAccounts.mockReturnValue({
+            billingAccounts: [
+                {
+                    budget: 1000,
+                    consumedBudget: 225,
+                    id: 80001063,
+                    lockedBudget: 525,
+                    markup: 0.25,
+                    name: 'Access BA',
+                    totalBudgetRemaining: 250,
+                },
+            ],
+            error: undefined,
+            isError: false,
+            isLoading: false,
+        })
+
+        renderTable(
+            [{
+                ...invitedProject,
+                billingAccountId: 80001063,
+                details: {
+                    displayMemberPaymentDetailsToCopilots: false,
+                },
+            }],
+            {
+                ...defaultContextValue,
+                isCopilot: true,
+                userRoles: ['copilot'],
+            },
+        )
+
+        expect(screen.queryByText('Member Payments Remaining: $200.00'))
+            .toBeNull()
+        expect(screen.queryByText('$750 / $1,000 spent'))
+            .toBeNull()
+        expect(screen.queryByRole('button', {
+            name: 'View billing account details',
+        }))
             .toBeNull()
     })
 })

--- a/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.tsx
+++ b/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.tsx
@@ -144,10 +144,32 @@ function formatCurrency(amount: number, includeCents: boolean = false): string {
         .format(amount)
 }
 
-function canShowMemberPaymentsRemaining(workAppContext: WorkAppContextModel): boolean {
+/**
+ * Identifies copilot-only users whose project payment details are controlled
+ * by the project-level display flag.
+ *
+ * @param workAppContext Current work app user context.
+ * @returns `true` when the user is a copilot without admin or manager access.
+ */
+function isRestrictedCopilot(workAppContext: WorkAppContextModel): boolean {
     return workAppContext.isCopilot
         && !workAppContext.isAdmin
         && !workAppContext.isManager
+}
+
+/**
+ * Resolves whether the current user may see payment details for one project row.
+ *
+ * @param workAppContext Current work app user context.
+ * @param project Project row being rendered.
+ * @returns `true` when payment amounts and the line-item modal may be shown.
+ */
+function canShowProjectPaymentDetails(
+    workAppContext: WorkAppContextModel,
+    project: Project,
+): boolean {
+    return !isRestrictedCopilot(workAppContext)
+        || project.details?.displayMemberPaymentDetailsToCopilots === true
 }
 
 function getBudgetStatusClass(
@@ -220,6 +242,7 @@ function getBillingAccountDisplay(
 interface ProjectBillingAccountCellProps {
     billingAccount: BillingAccount | undefined
     project: Project
+    showPaymentDetails: boolean
     showMemberPaymentsRemaining: boolean
 }
 
@@ -238,9 +261,13 @@ const ProjectBillingAccountCell: FC<ProjectBillingAccountCellProps> = (
     const normalizedBillingAccountId = normalizeOptionalString(props.project.billingAccountId)
         || normalizeOptionalString(props.billingAccount?.id)
     const billingAccountDetailsResult: UseFetchBillingAccountDetailsResult = useFetchBillingAccountDetails(
-        isModalOpen ? normalizedBillingAccountId : undefined,
+        isModalOpen && props.showPaymentDetails
+            ? normalizedBillingAccountId
+            : undefined,
     )
-    const standardBudgetInfo = getBillingAccountBudgetInfo(props.billingAccount)
+    const standardBudgetInfo = props.showPaymentDetails
+        ? getBillingAccountBudgetInfo(props.billingAccount)
+        : undefined
     const copilotBudgetInfo = props.showMemberPaymentsRemaining
         ? getCopilotMemberPaymentsBudgetInfo(props.billingAccount)
         : undefined
@@ -280,7 +307,7 @@ const ProjectBillingAccountCell: FC<ProjectBillingAccountCellProps> = (
                     </span>
                 )
                 : undefined}
-            {normalizedBillingAccountId
+            {normalizedBillingAccountId && props.showPaymentDetails
                 ? (
                     <button
                         aria-label='View billing account details'
@@ -315,7 +342,6 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props: ProjectsTableProps)
     const sortBy: string = props.sortBy
     const sortOrder: SortOrder = props.sortOrder
     const workAppContext: WorkAppContextModel = useContext(WorkAppContext)
-    const showMemberPaymentsRemaining: boolean = canShowMemberPaymentsRemaining(workAppContext)
     const {
         billingAccounts,
     }: UseFetchBillingAccountsResult = useFetchBillingAccounts()
@@ -368,7 +394,9 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props: ProjectsTableProps)
                     <ProjectBillingAccountCell
                         billingAccount={billingAccountsById.get(String(project.billingAccountId))}
                         project={project}
-                        showMemberPaymentsRemaining={showMemberPaymentsRemaining}
+                        showMemberPaymentsRemaining={isRestrictedCopilot(workAppContext)
+                            && canShowProjectPaymentDetails(workAppContext, project)}
+                        showPaymentDetails={canShowProjectPaymentDetails(workAppContext, project)}
                     />
                 ),
                 type: 'element',
@@ -399,7 +427,7 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props: ProjectsTableProps)
                 type: 'action',
             },
         ],
-        [billingAccountsById, canEditProject, showMemberPaymentsRemaining],
+        [billingAccountsById, canEditProject, workAppContext],
     )
 
     const forceSort = useMemo<Sort>(
@@ -456,7 +484,9 @@ export const ProjectsTable: FC<ProjectsTableProps> = (props: ProjectsTableProps)
                             <ProjectBillingAccountCell
                                 billingAccount={billingAccountsById.get(String(project.billingAccountId))}
                                 project={project}
-                                showMemberPaymentsRemaining={showMemberPaymentsRemaining}
+                                showMemberPaymentsRemaining={isRestrictedCopilot(workAppContext)
+                                    && canShowProjectPaymentDetails(workAppContext, project)}
+                                showPaymentDetails={canShowProjectPaymentDetails(workAppContext, project)}
                             />
                         )}
                         canEdit={canEditProject(project)}

--- a/src/apps/work/src/lib/models/Project.model.ts
+++ b/src/apps/work/src/lib/models/Project.model.ts
@@ -8,6 +8,13 @@ import { TaasJob } from './TaasJob.model'
 
 export type ProjectStatus = typeof PROJECT_STATUSES[number]['value']
 
+export interface ProjectDetails extends Record<string, unknown> {
+    displayMemberPaymentDetailsToCopilots?: boolean
+    taasDefinition?: {
+        taasJobs?: TaasJob[]
+    }
+}
+
 export interface Project {
     id: number | string
     name: string
@@ -25,11 +32,7 @@ export interface Project {
     members?: ProjectMember[]
     invites?: ProjectInvite[]
     isInvited?: boolean
-    details?: {
-        taasDefinition?: {
-            taasJobs?: TaasJob[]
-        }
-    }
+    details?: ProjectDetails
 }
 
 export interface ProjectType {
@@ -43,6 +46,7 @@ export interface CreateProjectPayload {
     description: string
     type: string
     billingAccountId?: number | string
+    details?: ProjectDetails
     terms?: string[]
     groups?: string[]
 }
@@ -51,6 +55,7 @@ export interface UpdateProjectPayload {
     name: string
     description: string
     billingAccountId?: number | string
+    details?: ProjectDetails
     status?: ProjectStatus
     cancelReason?: string
     terms?: string[]

--- a/src/apps/work/src/lib/models/index.ts
+++ b/src/apps/work/src/lib/models/index.ts
@@ -14,6 +14,7 @@ export type {
     ProjectPhase,
     ProjectPhaseProduct,
     Project,
+    ProjectDetails,
     ProjectFilters,
     ProjectStatus as ProjectStatusValue,
     ProjectType,

--- a/src/apps/work/src/lib/schemas/project-editor.schema.ts
+++ b/src/apps/work/src/lib/schemas/project-editor.schema.ts
@@ -6,6 +6,7 @@ export interface ProjectEditorSchemaData {
     billingAccountId?: string
     name: string
     description: string
+    displayMemberPaymentDetailsToCopilots?: boolean
     type?: string
     status?: string
     cancelReason?: string
@@ -32,6 +33,9 @@ export function createProjectEditorSchema(
             description: yup
                 .string()
                 .required('Description is required'),
+            displayMemberPaymentDetailsToCopilots: yup
+                .boolean()
+                .optional(),
             groups: yup
                 .array()
                 .of(yup.string()

--- a/src/apps/work/src/lib/services/projects.service.spec.ts
+++ b/src/apps/work/src/lib/services/projects.service.spec.ts
@@ -258,6 +258,9 @@ describe('fetchProjectsList', () => {
         mockedGetPaginatedAsync.mockResolvedValue({
             data: [
                 {
+                    details: {
+                        displayMemberPaymentDetailsToCopilots: true,
+                    },
                     id: 200,
                     invites: [
                         {
@@ -282,6 +285,9 @@ describe('fetchProjectsList', () => {
         expect(result.projects)
             .toEqual([
                 expect.objectContaining({
+                    details: {
+                        displayMemberPaymentDetailsToCopilots: true,
+                    },
                     id: 200,
                     invites: [
                         expect.objectContaining({
@@ -344,6 +350,9 @@ describe('fetchProjectById', () => {
         const mockedGetAsync = xhrGetAsync as jest.Mock
 
         mockedGetAsync.mockResolvedValue({
+            details: {
+                displayMemberPaymentDetailsToCopilots: true,
+            },
             id: 200,
             invites: [
                 {
@@ -361,6 +370,9 @@ describe('fetchProjectById', () => {
 
         expect(result)
             .toEqual(expect.objectContaining({
+                details: {
+                    displayMemberPaymentDetailsToCopilots: true,
+                },
                 id: '200',
                 invites: [
                     expect.objectContaining({

--- a/src/apps/work/src/lib/services/projects.service.ts
+++ b/src/apps/work/src/lib/services/projects.service.ts
@@ -23,6 +23,7 @@ import {
     Project,
     ProjectAttachment,
     ProjectAttachmentPayload,
+    ProjectDetails,
     ProjectInvite,
     ProjectMember,
     ProjectPhase,
@@ -44,6 +45,7 @@ export type ProjectSummary = Pick<Project,
     | 'billingAccountId'
     | 'billingAccountName'
     | 'createdAt'
+    | 'details'
     | 'id'
     | 'invites'
     | 'isInvited'
@@ -189,6 +191,21 @@ function normalizeOptionalId(value: unknown): string | undefined {
     return normalizedValue || undefined
 }
 
+/**
+ * Normalizes project details metadata into the plain object shape consumed by
+ * the work app.
+ *
+ * @param value Raw `details` payload from the Projects API.
+ * @returns Project details metadata, or `undefined` when the payload is not an object.
+ */
+function normalizeProjectDetails(value: unknown): ProjectDetails | undefined {
+    if (typeof value !== 'object' || !value || Array.isArray(value)) {
+        return undefined
+    }
+
+    return value as ProjectDetails
+}
+
 function normalizeProjectMember(member: unknown): ProjectMember | undefined {
     if (typeof member !== 'object' || !member) {
         return undefined
@@ -310,6 +327,7 @@ function normalizeProject(project: Partial<Project>): Project {
         description: typeof project.description === 'string'
             ? project.description
             : undefined,
+        details: normalizeProjectDetails(project.details),
         groups: normalizeProjectTermsOrGroups(project.groups),
         id,
         invites,
@@ -532,6 +550,7 @@ function normalizeProjectSummary(project: ProjectSummary): ProjectSummary {
 
     return {
         ...project,
+        details: normalizeProjectDetails(project.details),
         invites,
         isInvited: normalizeOptionalBoolean(project.isInvited),
         members,

--- a/src/apps/work/src/pages/assets/ProjectAssetsPage/ProjectAssetsPage.tsx
+++ b/src/apps/work/src/pages/assets/ProjectAssetsPage/ProjectAssetsPage.tsx
@@ -739,6 +739,9 @@ export const ProjectAssetsPage: FC = () => {
                 billingAccountId={projectResult.project?.billingAccountId}
                 billingAccountName={projectResult.project?.billingAccountName}
                 canManageProject={canManageProject}
+                displayMemberPaymentDetailsToCopilots={
+                    projectResult.project?.details?.displayMemberPaymentDetailsToCopilots
+                }
                 projectId={projectId}
             />
         )

--- a/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.tsx
@@ -218,6 +218,7 @@ interface RenderBillingAccountNoticeParams {
     billingAccountId?: number | string
     billingAccountName?: string
     canManageProject: boolean
+    displayMemberPaymentDetailsToCopilots?: boolean
     projectId: string | undefined
 }
 
@@ -231,6 +232,7 @@ function renderBillingAccountNotice(params: RenderBillingAccountNoticeParams): J
             billingAccountId={params.billingAccountId}
             billingAccountName={params.billingAccountName}
             canManageProject={params.canManageProject}
+            displayMemberPaymentDetailsToCopilots={params.displayMemberPaymentDetailsToCopilots}
             projectId={params.projectId}
         />
     )
@@ -671,6 +673,8 @@ export const ChallengesListPage: FC = () => {
                 billingAccountId: projectResult.project?.billingAccountId,
                 billingAccountName: projectResult.project?.billingAccountName,
                 canManageProject,
+                displayMemberPaymentDetailsToCopilots:
+                    projectResult.project?.details?.displayMemberPaymentDetailsToCopilots,
                 projectId: projectIdFromRoute,
             })}
             {projectIdFromRoute

--- a/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.tsx
@@ -769,6 +769,9 @@ export const EngagementsListPage: FC = () => {
                 billingAccountId={projectResult.project?.billingAccountId}
                 billingAccountName={projectResult.project?.billingAccountName}
                 canManageProject={canManageProject}
+                displayMemberPaymentDetailsToCopilots={
+                    projectResult.project?.details?.displayMemberPaymentDetailsToCopilots
+                }
                 projectId={projectId}
             />
         )

--- a/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx
@@ -1,0 +1,244 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import {
+    useFetchProjectBillingAccount,
+} from '../../../../../lib/hooks'
+import {
+    createProject,
+} from '../../../../../lib/services'
+
+import { ProjectEditorForm } from './ProjectEditorForm'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        ADMIN: {
+            DIRECT_URL: 'https://direct.example.com',
+            REVIEW_UI_URL: 'https://review.example.com',
+        },
+        API: {
+            V6: 'https://example.com/v6',
+        },
+        CHALLENGE_API_URL: 'https://example.com/v5/challenges',
+        CHALLENGE_API_VERSION: 'v5',
+        COMMUNITY_APP_URL: 'https://community.example.com',
+        COPILOTS_URL: 'https://copilots.example.com',
+        DIRECT_PROJECT_URL: 'https://direct.example.com',
+        ENGAGEMENTS_URL: 'https://work.example.com',
+        REVIEW_APP_URL: 'https://review.example.com',
+        TC_DOMAIN: 'example.com',
+        TC_FINANCE_API: 'https://finance.example.com',
+        TOPCODER_URL: 'https://topcoder.example.com',
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('../../../../../lib/components/form', () => {
+    const reactHookForm: typeof import('react-hook-form') = jest.requireActual('react-hook-form')
+    const useFormContext: typeof reactHookForm.useFormContext = reactHookForm.useFormContext
+
+    interface MockFieldProps {
+        label: string
+        name: string
+        options?: Array<{
+            label: string
+            value: string
+        }>
+        placeholder?: string
+    }
+
+    return {
+        FormBillingAccountAutocomplete: (props: MockFieldProps): JSX.Element => {
+            const formContext = useFormContext()
+
+            return (
+                <input
+                    aria-label={props.label}
+                    {...formContext.register(props.name)}
+                />
+            )
+        },
+        FormCheckboxField: (props: MockFieldProps): JSX.Element => {
+            const formContext = useFormContext()
+
+            return (
+                <label htmlFor={props.name}>
+                    <input
+                        id={props.name}
+                        type='checkbox'
+                        {...formContext.register(props.name)}
+                    />
+                    {props.label}
+                </label>
+            )
+        },
+        FormGroupsSelect: (): JSX.Element => <div />,
+        FormRadioGroup: (): JSX.Element => <div />,
+        FormSelectField: (props: MockFieldProps): JSX.Element => {
+            const formContext = useFormContext()
+
+            return (
+                <label htmlFor={props.name}>
+                    {props.label}
+                    <select
+                        aria-label={props.label}
+                        id={props.name}
+                        {...formContext.register(props.name)}
+                    >
+                        <option value=''>{props.placeholder || 'Select'}</option>
+                        {(props.options || []).map(option => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+            )
+        },
+        FormSelectOption: undefined,
+        FormTextAreaField: (props: MockFieldProps): JSX.Element => {
+            const formContext = useFormContext()
+
+            return (
+                <label htmlFor={props.name}>
+                    {props.label}
+                    <textarea
+                        aria-label={props.label}
+                        id={props.name}
+                        {...formContext.register(props.name)}
+                    />
+                </label>
+            )
+        },
+        FormTextField: (props: MockFieldProps): JSX.Element => {
+            const formContext = useFormContext()
+
+            return (
+                <label htmlFor={props.name}>
+                    {props.label}
+                    <input
+                        aria-label={props.label}
+                        id={props.name}
+                        {...formContext.register(props.name)}
+                    />
+                </label>
+            )
+        },
+    }
+})
+
+jest.mock('../../../../../lib/hooks', () => ({
+    useFetchProjectBillingAccount: jest.fn(),
+}))
+
+jest.mock('../../../../../lib/services', () => ({
+    createProject: jest.fn(),
+    updateProject: jest.fn(),
+}))
+
+jest.mock('../../../../../lib/utils', () => ({
+    formatDate: () => '-',
+    showErrorToast: jest.fn(),
+    showSuccessToast: jest.fn(),
+}))
+
+jest.mock('~/libs/ui', () => ({
+    Button: (props: {
+        disabled?: boolean
+        label: string
+        type?: 'button' | 'submit'
+    }): JSX.Element => (
+        <button
+            disabled={props.disabled}
+            type={props.type === 'submit'
+                ? 'submit'
+                : 'button'}
+        >
+            {props.label}
+        </button>
+    ),
+}), {
+    virtual: true,
+})
+
+const mockedUseFetchProjectBillingAccount = useFetchProjectBillingAccount as jest.MockedFunction<
+    typeof useFetchProjectBillingAccount
+>
+const mockedCreateProject = createProject as jest.MockedFunction<typeof createProject>
+
+describe('ProjectEditorForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: undefined,
+            isLoading: false,
+        })
+        mockedCreateProject.mockResolvedValue({
+            id: 'project-1',
+            name: 'Payments Project',
+            status: 'draft',
+        })
+    })
+
+    it('defaults the copilot payment details flag off and submits it when selected', async () => {
+        render(
+            <MemoryRouter>
+                <ProjectEditorForm
+                    canManage
+                    isEdit={false}
+                    projectTypes={[{
+                        displayName: 'Generic',
+                        key: 'generic',
+                    }]}
+                />
+            </MemoryRouter>,
+        )
+
+        const displayPaymentDetailsCheckbox = screen.getByLabelText(
+            'Display member payment details to copilots',
+        ) as HTMLInputElement
+
+        expect(displayPaymentDetailsCheckbox.checked)
+            .toBe(false)
+
+        fireEvent.change(screen.getByLabelText('Project Name'), {
+            target: {
+                value: 'Payments Project',
+            },
+        })
+        fireEvent.change(screen.getByLabelText('Project Type'), {
+            target: {
+                value: 'generic',
+            },
+        })
+        fireEvent.change(screen.getByLabelText('Description'), {
+            target: {
+                value: 'Project with visible copilot payment details.',
+            },
+        })
+        fireEvent.click(displayPaymentDetailsCheckbox)
+
+        await waitFor(() => expect((screen.getByRole('button', {
+            name: 'Save project',
+        }) as HTMLButtonElement).disabled)
+            .toBe(false))
+
+        fireEvent.click(screen.getByRole('button', {
+            name: 'Save project',
+        }))
+
+        await waitFor(() => expect(mockedCreateProject)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                details: {
+                    displayMemberPaymentDetailsToCopilots: true,
+                },
+            })))
+    })
+})

--- a/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
+++ b/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../../lib/constants'
 import {
     FormBillingAccountAutocomplete,
+    FormCheckboxField,
     FormGroupsSelect,
     FormRadioGroup,
     FormSelectField,
@@ -66,6 +67,7 @@ interface ProjectEditorFormValues {
     billingAccountId: string
     cancelReason: string
     description: string
+    displayMemberPaymentDetailsToCopilots: boolean
     groups: string[]
     name: string
     status: ProjectStatusValue | ''
@@ -95,6 +97,8 @@ function getDefaultFormValues(
         billingAccountId,
         cancelReason: projectDetail?.cancelReason || '',
         description: projectDetail?.description || '',
+        displayMemberPaymentDetailsToCopilots:
+            projectDetail?.details?.displayMemberPaymentDetailsToCopilots === true,
         groups,
         name: projectDetail?.name || '',
         status: isEdit
@@ -363,6 +367,10 @@ export const ProjectEditorForm: FC<ProjectEditorFormProps> = (props: ProjectEdit
                     const payload: CreateProjectPayload = {
                         billingAccountId: normalizedBillingAccountId,
                         description: formData.description,
+                        details: {
+                            displayMemberPaymentDetailsToCopilots:
+                                formData.displayMemberPaymentDetailsToCopilots,
+                        },
                         groups,
                         name: formData.name,
                         terms,
@@ -386,6 +394,11 @@ export const ProjectEditorForm: FC<ProjectEditorFormProps> = (props: ProjectEdit
                 const payload: UpdateProjectPayload = {
                     billingAccountId: normalizedBillingAccountId || '',
                     description: formData.description,
+                    details: {
+                        ...(props.projectDetail.details || {}),
+                        displayMemberPaymentDetailsToCopilots:
+                            formData.displayMemberPaymentDetailsToCopilots,
+                    },
                     groups,
                     name: formData.name,
                     terms,
@@ -547,6 +560,11 @@ export const ProjectEditorForm: FC<ProjectEditorFormProps> = (props: ProjectEdit
                         <FormGroupsSelect
                             label='Intended Work Groups'
                             name='groups'
+                        />
+
+                        <FormCheckboxField
+                            label='Display member payment details to copilots'
+                            name='displayMemberPaymentDetailsToCopilots'
                         />
                     </div>
                 </section>


### PR DESCRIPTION
What was broken
Copilot users always saw member payments remaining and the billing account details modal entry point whenever billing data was available.
The work app project editor did not expose a project-level flag for PMs to control that visibility.

Root cause
The billing UI only checked the user's role before showing copilot-safe payment details.
Project details metadata from the Projects API was also dropped during work app normalization, so there was no persisted project flag available to gate the UI.

What was changed
Added the displayMemberPaymentDetailsToCopilots project details flag to the work app project model, editor schema, and create/update payloads.
Preserved project details metadata when normalizing project responses and passed the flag into project billing notices.
Hid copilot member payment balances and billing account modal access unless the project flag is enabled, while preserving admin and manager billing views.

Any added/updated tests
Added ProjectEditorForm coverage for the default-off flag and selected create payload.
Updated ProjectBillingAccountExpiredNotice and ProjectsTable coverage for enabled and disabled copilot payment visibility.
Updated project service coverage so project details metadata is retained.

Validation run
Passed: yarn lint
Passed: yarn test --watchAll=false src/apps/work/src/lib/components/ProjectBillingAccountExpiredNotice/ProjectBillingAccountExpiredNotice.spec.tsx src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx src/apps/work/src/lib/services/projects.service.spec.ts src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx
Passed: yarn run build
Full suite note: yarn test --watchAll=false fails in existing wallet-admin coverage at src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx, where the isolated test expects https://challenges.example.com/projects/42/challenges/challenge-uuid-1/view but the component renders https://challenges.example.com/projects/42. This is outside the PM-4954 work app changes and reproduces when run by itself.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
