### PR TITLE
PM-4876: Restore view-mode specification scrolling

### DIFF
--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.module.scss
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.module.scss
@@ -34,6 +34,15 @@ $error-line-height: 14px;
         pointer-events: none;
     }
 
+    &.readOnly {
+        :global {
+            .editor-statusbar,
+            .editor-toolbar {
+                pointer-events: none;
+            }
+        }
+    }
+
     :global {
         .EasyMDEContainer {
             height: 100px;

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.spec.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.spec.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, waitFor } from '@testing-library/react'
+
+import { FieldMarkdownEditor } from './FieldMarkdownEditor'
+
+const mockEasyMDEInstances: any[] = []
+
+jest.mock('~/apps/admin/src/lib/hooks', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        useOnComponentDidMount: (onMounted: () => void): void => {
+            React.useEffect(() => {
+                onMounted()
+            }, [])
+        },
+    }
+}, { virtual: true })
+
+jest.mock('../../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({
+            challengeId: 'challenge-id',
+        }),
+    }
+})
+
+jest.mock('../../services', () => ({
+    uploadReviewAttachment: jest.fn(),
+}))
+
+jest.mock('../../utils', () => ({
+    humanFileSize: jest.fn(() => '1 KB'),
+}))
+
+jest.mock('easymde', () => {
+    class EasyMDEMock {
+        constructor(options: any) {
+            const wrapper = globalThis.document.createElement('div')
+            wrapper.appendChild(globalThis.document.createElement('div'))
+
+            let editorValue = options.initialValue ?? ''
+            const imageInput = { value: '' }
+            const codemirror = {
+                focus: jest.fn(),
+                getCursor: jest.fn(() => ({
+                    ch: 0,
+                    line: 0,
+                })),
+                getLine: jest.fn(() => ''),
+                getSelection: jest.fn(() => ''),
+                getTokenAt: jest.fn(() => ({
+                    type: '',
+                })),
+                getValue: jest.fn(() => editorValue),
+                getWrapperElement: jest.fn(() => wrapper),
+                indexFromPos: jest.fn(() => 0),
+                on: jest.fn(),
+                replaceRange: jest.fn(),
+                replaceSelection: jest.fn(),
+                setOption: jest.fn(),
+                setSelection: jest.fn(),
+            }
+            Object.assign(this, {
+                codemirror,
+                gui: {
+                    toolbar: {
+                        getElementsByClassName: jest.fn(() => [imageInput]),
+                    },
+                },
+                options,
+                updateStatusBar: jest.fn(),
+                value: jest.fn((incomingValue?: string) => {
+                    if (incomingValue === undefined) {
+                        return editorValue
+                    }
+
+                    editorValue = incomingValue
+                    return undefined
+                }),
+            })
+
+            mockEasyMDEInstances.push(this)
+        }
+    }
+
+    Object.assign(EasyMDEMock, {
+        drawImage: jest.fn(),
+        drawLink: jest.fn(),
+        drawTable: jest.fn(),
+        drawUploadedImage: jest.fn(),
+        toggleBlockquote: jest.fn(),
+        toggleCodeBlock: jest.fn(),
+        toggleHeading1: jest.fn(),
+        toggleHeading2: jest.fn(),
+        toggleHeading3: jest.fn(),
+        toggleOrderedList: jest.fn(),
+        toggleStrikethrough: jest.fn(),
+        toggleUnorderedList: jest.fn(),
+    })
+
+    return {
+        __esModule: true,
+        default: EasyMDEMock,
+    }
+})
+
+describe('FieldMarkdownEditor', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockEasyMDEInstances.length = 0
+    })
+
+    it('uses the latest read-only state for the EasyMDE upload callback', async () => {
+        const uploadAttachment = jest.fn()
+            .mockResolvedValue({
+                url: 'https://example.com/uploaded.png',
+            })
+
+        const rendered: ReturnType<typeof render> = render(
+            <FieldMarkdownEditor uploadAttachment={uploadAttachment} />,
+        )
+
+        await waitFor(() => {
+            expect(mockEasyMDEInstances)
+                .toHaveLength(1)
+        })
+
+        const easyMDE = mockEasyMDEInstances[0]
+        rendered.rerender(
+            <FieldMarkdownEditor
+                readOnly
+                uploadAttachment={uploadAttachment}
+            />,
+        )
+
+        await easyMDE.options.imageUploadFunction(
+            new File(['image'], 'uploaded.png', { type: 'image/png' }),
+        )
+
+        expect(uploadAttachment)
+            .not
+            .toHaveBeenCalled()
+    })
+
+    it('installs EasyMDE upload handlers so editable transitions can upload', async () => {
+        render(<FieldMarkdownEditor readOnly />)
+
+        await waitFor(() => {
+            expect(mockEasyMDEInstances)
+                .toHaveLength(1)
+        })
+
+        expect(mockEasyMDEInstances[0].options.uploadImage)
+            .toBe(true)
+    })
+})

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
@@ -153,11 +153,24 @@ const toggleStrategy = {
 }
 
 type CodeMirrorType = keyof typeof stateStrategy | 'variable-2'
+type UploadImageHandler = (file: File) => Promise<void>
+
+const readOnlyUploadEvents = [
+    'dragend',
+    'dragenter',
+    'dragleave',
+    'dragover',
+    'drop',
+    'paste',
+]
 
 export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
     const elementRef = useRef<HTMLTextAreaElement>(null)
     const easyMDE = useRef<any>(null)
+    const customUploadImageRef = useRef<UploadImageHandler>(async () => undefined)
+    const isReadOnlyRef = useRef(false)
     const isReadOnly = !!props.disabled || !!props.readOnly
+    isReadOnlyRef.current = isReadOnly
     const [remainingCharacters, setRemainingCharacters] = useState(
         (props.maxCharactersAllowed || 0) - (props.initialValue?.length || 0),
     )
@@ -529,7 +542,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
      * Upload image
      */
     const customUploadImage = useCallback(async (file: File) => {
-        if (isReadOnly) {
+        if (isReadOnlyRef.current) {
             return
         }
 
@@ -653,11 +666,11 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
         afterFileUploaded,
         beforeUploadingFile,
         challengeId,
-        isReadOnly,
         resetFileInput,
         uploadAttachment,
         uploadCategory,
     ])
+    customUploadImageRef.current = customUploadImage
 
     useOnComponentDidMount(() => {
         easyMDE.current = new EasyMDE({
@@ -680,7 +693,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
                 sbProgress: 'Uploading #file_name#: #progress#%',
                 sizeUnits: ' B, KB, MB',
             },
-            imageUploadFunction: file => customUploadImage(file),
+            imageUploadFunction: file => customUploadImageRef.current(file),
             initialValue: props.initialValue ?? '',
             insertTexts: {
                 file: ['[](', '#url#)'],
@@ -841,7 +854,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
                     title: 'Quote',
                 },
             ],
-            uploadImage: !isReadOnly,
+            uploadImage: true,
         })
 
         easyMDE.current.codemirror.on('beforeChange', (cm: CodeMirror.Editor, change: EditorChangeCancellable) => {
@@ -877,12 +890,35 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
 
     useEffect(() => {
         if (!easyMDE.current) {
-            return
+            return undefined
         }
 
         easyMDE.current.codemirror.setOption('readOnly', isReadOnly
             ? 'nocursor'
             : false)
+
+        const wrapper = easyMDE.current.codemirror.getWrapperElement()
+        const blockReadOnlyUpload = (event: Event): void => {
+            if (!isReadOnlyRef.current) {
+                return
+            }
+
+            event.preventDefault()
+            event.stopPropagation()
+            event.stopImmediatePropagation()
+        }
+
+        if (isReadOnly) {
+            readOnlyUploadEvents.forEach(eventName => {
+                wrapper.addEventListener(eventName, blockReadOnlyUpload, true)
+            })
+        }
+
+        return () => {
+            readOnlyUploadEvents.forEach(eventName => {
+                wrapper.removeEventListener(eventName, blockReadOnlyUpload, true)
+            })
+        }
     }, [isReadOnly])
 
     useEffect(() => {

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
@@ -51,6 +51,7 @@ interface Props {
     maxCharactersAllowed?: number
     textareaId?: string
     ariaLabel?: string
+    readOnly?: boolean
 }
 const errorMessages = {
     fileTooLarge:
@@ -156,6 +157,7 @@ type CodeMirrorType = keyof typeof stateStrategy | 'variable-2'
 export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
     const elementRef = useRef<HTMLTextAreaElement>(null)
     const easyMDE = useRef<any>(null)
+    const isReadOnly = !!props.disabled || !!props.readOnly
     const [remainingCharacters, setRemainingCharacters] = useState(
         (props.maxCharactersAllowed || 0) - (props.initialValue?.length || 0),
     )
@@ -527,6 +529,10 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
      * Upload image
      */
     const customUploadImage = useCallback(async (file: File) => {
+        if (isReadOnly) {
+            return
+        }
+
         const editor = easyMDE.current
         if (!editor) {
             return
@@ -647,6 +653,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
         afterFileUploaded,
         beforeUploadingFile,
         challengeId,
+        isReadOnly,
         resetFileInput,
         uploadAttachment,
         uploadCategory,
@@ -834,7 +841,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
                     title: 'Quote',
                 },
             ],
-            uploadImage: true,
+            uploadImage: !isReadOnly,
         })
 
         easyMDE.current.codemirror.on('beforeChange', (cm: CodeMirror.Editor, change: EditorChangeCancellable) => {
@@ -873,6 +880,16 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
             return
         }
 
+        easyMDE.current.codemirror.setOption('readOnly', isReadOnly
+            ? 'nocursor'
+            : false)
+    }, [isReadOnly])
+
+    useEffect(() => {
+        if (!easyMDE.current) {
+            return
+        }
+
         const incomingValue = props.initialValue ?? ''
         const editorValue = easyMDE.current.value()
 
@@ -886,6 +903,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
             className={classNames(styles.container, props.className, {
                 [styles.isError]: !!props.error,
                 [styles.disabled]: !!props.disabled,
+                [styles.readOnly]: !!props.readOnly,
                 [styles.showBorder]: !!props.showBorder,
             })}
         >

--- a/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.tsx
+++ b/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.tsx
@@ -24,6 +24,7 @@ export interface FormMarkdownEditorProps {
     name: string
     onBlur?: () => void
     placeholder?: string
+    readOnly?: boolean
     required?: boolean
     uploadCategory?: string
 }
@@ -37,6 +38,7 @@ export const FormMarkdownEditor: FC<FormMarkdownEditorProps> = (props: FormMarkd
     const name = props.name
     const onBlur = props.onBlur
     const placeholder = props.placeholder
+    const readOnly = props.readOnly
     const required = props.required
     const uploadCategory = props.uploadCategory
 
@@ -93,6 +95,7 @@ export const FormMarkdownEditor: FC<FormMarkdownEditorProps> = (props: FormMarkd
                     onBlur={handleBlur}
                     onChange={field.onChange}
                     placeholder={placeholder}
+                    readOnly={readOnly}
                     showBorder
                     uploadAttachment={handleUploadAttachment}
                     uploadCategory={uploadCategory}

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.spec.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import { ChallengeDescriptionField } from './ChallengeDescriptionField'
+
+jest.mock('../../../../lib/components/form', () => ({
+    FormMarkdownEditor: (props: {
+        label: string
+        name: string
+        readOnly?: boolean
+        required?: boolean
+    }) => (
+        <div
+            data-read-only={props.readOnly === true ? 'true' : 'false'}
+            data-required={props.required === true ? 'true' : 'false'}
+            data-testid={props.name}
+        >
+            {props.label}
+        </div>
+    ),
+}))
+
+describe('ChallengeDescriptionField', () => {
+    it('renders the public specification editor with the template link', () => {
+        render(<ChallengeDescriptionField />)
+
+        expect(screen.getByTestId('description'))
+            .toHaveTextContent('Public Specification')
+        expect(screen.getByTestId('description'))
+            .toHaveAttribute('data-required', 'true')
+        expect(screen.getByRole('link', {
+            name: 'here',
+        }))
+            .toHaveAttribute('href', 'https://github.com/topcoder-platform-templates/specification-templates')
+    })
+
+    it('passes read-only mode to the public specification editor', () => {
+        render(<ChallengeDescriptionField readOnly />)
+
+        expect(screen.getByTestId('description'))
+            .toHaveAttribute('data-read-only', 'true')
+    })
+})

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.tsx
@@ -6,7 +6,13 @@ import styles from './ChallengeDescriptionField.module.scss'
 
 const specificationTemplateLink = 'https://github.com/topcoder-platform-templates/specification-templates'
 
-export const ChallengeDescriptionField: FC = () => (
+export interface ChallengeDescriptionFieldProps {
+    readOnly?: boolean
+}
+
+export const ChallengeDescriptionField: FC<ChallengeDescriptionFieldProps> = (
+    props: ChallengeDescriptionFieldProps,
+) => (
     <div className={styles.container}>
         <p className={styles.templateLink}>
             Access specification templates
@@ -23,6 +29,7 @@ export const ChallengeDescriptionField: FC = () => (
         <FormMarkdownEditor
             label='Public Specification'
             name='description'
+            readOnly={props.readOnly}
             required
         />
     </div>

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.module.scss
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.module.scss
@@ -17,6 +17,15 @@
 
     &[disabled] {
         pointer-events: none;
+
+        :global(.EasyMDEContainer) {
+            pointer-events: auto;
+        }
+
+        :global(.EasyMDEContainer .editor-statusbar),
+        :global(.EasyMDEContainer .editor-toolbar) {
+            pointer-events: none;
+        }
     }
 }
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -251,7 +251,14 @@ jest.mock('./AttachmentsField', () => {
     }
 })
 jest.mock('./ChallengeDescriptionField', () => ({
-    ChallengeDescriptionField: () => <></>,
+    ChallengeDescriptionField: (props: {
+        readOnly?: boolean
+    }) => (
+        <div
+            data-read-only={props.readOnly === true ? 'true' : 'false'}
+            data-testid='challenge-description-field'
+        />
+    ),
 }))
 jest.mock('./ChallengeScheduleSection', () => ({
     ChallengeScheduleSection: function ChallengeScheduleSection(props: {
@@ -358,7 +365,14 @@ jest.mock('./ChallengeNameField', () => {
     }
 })
 jest.mock('./ChallengePrivateDescriptionField', () => ({
-    ChallengePrivateDescriptionField: () => <></>,
+    ChallengePrivateDescriptionField: (props: {
+        readOnly?: boolean
+    }) => (
+        <div
+            data-read-only={props.readOnly === true ? 'true' : 'false'}
+            data-testid='challenge-private-description-field'
+        />
+    ),
 }))
 jest.mock('./ChallengePrizesField', () => ({
     ChallengePrizesField: () => <></>,
@@ -1000,6 +1014,10 @@ describe('ChallengeEditorForm', () => {
         expect(screen.getByTestId('challenge-schedule-section')
             .closest('fieldset[disabled]'))
             .toBeNull()
+        expect(screen.getByTestId('challenge-description-field'))
+            .toHaveAttribute('data-read-only', 'true')
+        expect(screen.getByTestId('challenge-private-description-field'))
+            .toHaveAttribute('data-read-only', 'true')
         expect(screen.queryByRole('button', { name: 'Cancel' }))
             .toBeNull()
         expect(screen.queryByRole('button', { name: 'Save Challenge' }))

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -3128,8 +3128,8 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                                 <section className={styles.section}>
                                     <h3 className={styles.sectionTitle}>Specification</h3>
                                     <div className={styles.block}>
-                                        <ChallengeDescriptionField />
-                                        <ChallengePrivateDescriptionField />
+                                        <ChallengeDescriptionField readOnly={isReadOnly} />
+                                        <ChallengePrivateDescriptionField readOnly={isReadOnly} />
                                     </div>
                                 </section>
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.spec.tsx
@@ -15,8 +15,12 @@ jest.mock('../../../../lib/components/form', () => ({
     FormMarkdownEditor: (props: {
         label: string
         name: string
+        readOnly?: boolean
     }) => (
-        <div data-testid={props.name}>
+        <div
+            data-read-only={props.readOnly === true ? 'true' : 'false'}
+            data-testid={props.name}
+        >
             {props.label}
         </div>
     ),
@@ -40,6 +44,7 @@ jest.mock('~/libs/ui', () => ({
 
 interface TestHarnessProps {
     privateDescription?: string
+    readOnly?: boolean
 }
 
 const TestHarness = (props: TestHarnessProps): JSX.Element => {
@@ -57,7 +62,7 @@ const TestHarness = (props: TestHarnessProps): JSX.Element => {
 
     return (
         <FormProvider {...formMethods}>
-            <ChallengePrivateDescriptionField />
+            <ChallengePrivateDescriptionField readOnly={props.readOnly} />
         </FormProvider>
     )
 }
@@ -95,5 +100,14 @@ describe('ChallengePrivateDescriptionField', () => {
             .not.toBeInTheDocument()
         expect(screen.getByTestId('privateDescription'))
             .toHaveTextContent('Private Specification')
+    })
+
+    it('passes read-only mode to the private specification editor', () => {
+        render(
+            <TestHarness privateDescription='Private specification' readOnly />,
+        )
+
+        expect(screen.getByTestId('privateDescription'))
+            .toHaveAttribute('data-read-only', 'true')
     })
 })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.tsx
@@ -14,7 +14,13 @@ import styles from './ChallengePrivateDescriptionField.module.scss'
 
 const specificationTemplateLink = 'https://github.com/topcoder-platform-templates/specification-templates'
 
-export const ChallengePrivateDescriptionField: FC = () => {
+export interface ChallengePrivateDescriptionFieldProps {
+    readOnly?: boolean
+}
+
+export const ChallengePrivateDescriptionField: FC<ChallengePrivateDescriptionFieldProps> = (
+    props: ChallengePrivateDescriptionFieldProps,
+) => {
     const formContext = useFormContext()
     const privateDescription = formContext.watch('privateDescription') as string | undefined
     const [isVisible, setIsVisible] = useState<boolean>(!!privateDescription)
@@ -65,6 +71,7 @@ export const ChallengePrivateDescriptionField: FC = () => {
             <FormMarkdownEditor
                 label='Private Specification'
                 name='privateDescription'
+                readOnly={props.readOnly}
             />
         </div>
     )


### PR DESCRIPTION
What was broken

Long challenge public/private specifications were clipped in view mode because the fixed-height Markdown editor could not be scrolled.

Root cause

Read-only challenge forms disable the surrounding fieldset and apply pointer-events: none across the whole form content, which also blocked pointer and wheel events from the EasyMDE scroll container.

What was changed

Added a read-only path for the shared Markdown editor that sets CodeMirror to nocursor read-only mode and disables upload/editor toolbar interactions without blocking the scroll container. Challenge specification fields now receive read-only state from the challenge form, and disabled fieldsets re-enable pointer events only for the EasyMDE container so existing content can scroll.

Any added/updated tests

Added ChallengeDescriptionField coverage and updated private specification and ChallengeEditorForm tests to assert read-only propagation.

Validation

- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing CSS order and lint-style warnings.
- yarn test:no-watch currently fails in unrelated src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx: expected a challenge view URL but received the project URL.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
