### PR TITLE
PM-4393: Restrict project challenge access

### DIFF
--- a/src/apps/work/src/lib/utils/permissions.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/permissions.utils.spec.ts
@@ -7,6 +7,7 @@ import {
     canViewAllEngagements,
     checkCanManageProject,
     checkIsUserInvitedToProject,
+    checkProjectAccess,
     checkProjectMembership,
     getProjectMemberRole,
 } from './permissions.utils'
@@ -105,6 +106,17 @@ describe('permissions.utils project management helpers', () => {
             .toBe(true)
         expect(getProjectMemberRole(managedProject, '123'))
             .toBe('manager')
+    })
+
+    it('allows project workspace access for admins and project members only', () => {
+        expect(checkProjectAccess(['administrator'], '999', managedProject))
+            .toBe(true)
+        expect(checkProjectAccess(['Project Manager'], '123', managedProject))
+            .toBe(true)
+        expect(checkProjectAccess(['Project Manager'], '999', managedProject))
+            .toBe(false)
+        expect(checkProjectAccess(['Project Manager'], '123', undefined))
+            .toBe(false)
     })
 
     it('matches invited users by normalized user id or email', () => {

--- a/src/apps/work/src/lib/utils/permissions.utils.ts
+++ b/src/apps/work/src/lib/utils/permissions.utils.ts
@@ -268,6 +268,30 @@ export function checkProjectMembership(
 }
 
 /**
+ * Returns whether the caller can open project-scoped workspace pages.
+ *
+ * Admins can access every project. Other work-app users must be listed in the
+ * project's membership payload before project details or child records can be
+ * displayed.
+ *
+ * @param userRoles caller roles from the decoded auth token or app context.
+ * @param userId logged-in user identifier used for project membership checks.
+ * @param project project whose access should be evaluated.
+ * @returns `true` when the caller may view the project workspace; otherwise `false`.
+ */
+export function checkProjectAccess(
+    userRoles: string[],
+    userId: number | string | undefined,
+    project: Project | undefined,
+): boolean {
+    if (!project) {
+        return false
+    }
+
+    return hasAdminRole(userRoles) || checkProjectMembership(project, userId)
+}
+
+/**
  * Returns whether the caller can manage project ownership and billing flows.
  *
  * Admins always qualify. Copilots, Project Managers, and Talent Managers can

--- a/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.spec.tsx
@@ -20,6 +20,7 @@ import {
 import {
     buildProjectLandingPath,
     canCreateEngagement,
+    checkProjectAccess,
     getAuthAccessToken,
 } from '../../../lib/utils'
 
@@ -88,6 +89,7 @@ jest.mock('../../../lib/components', () => ({
         </button>
     ),
     ChallengesTable: () => <div>Challenges Table</div>,
+    ErrorMessage: (props: { message: string }) => <div>{props.message}</div>,
     Pagination: (props: { onPerPageChange: (perPage: number) => void }) => {
         function handlePerPageChange(): void {
             props.onPerPageChange(25)
@@ -130,11 +132,17 @@ jest.mock('../../../lib/utils', () => ({
     buildProjectLandingPath: jest.fn((project: { id?: string | number }) => `/projects/${project.id}/challenges`),
     canCreateEngagement: jest.fn(() => false),
     checkCanManageProject: jest.fn(() => false),
+    checkProjectAccess: jest.fn((
+        _userRoles: string[],
+        _userId: number | string | undefined,
+        project?: { id?: string | number },
+    ) => !!project),
     getAuthAccessToken: jest.fn(() => 'token'),
     getStatusText: jest.fn((status?: string) => status || ''),
 }))
 
 const mockedBuildProjectLandingPath = buildProjectLandingPath as jest.Mock
+const mockedCheckProjectAccess = checkProjectAccess as jest.Mock
 const mockedUseFetchChallenges = useFetchChallenges as jest.Mock
 const mockedUseFetchChallengeTypes = useFetchChallengeTypes as jest.Mock
 const mockedUseFetchProject = useFetchProject as jest.Mock
@@ -185,6 +193,12 @@ describe('ChallengesListPage', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
+        mockedCanCreateEngagement.mockReturnValue(false)
+        mockedCheckProjectAccess.mockImplementation((
+            _userRoles: string[],
+            _userId: number | string | undefined,
+            project?: { id?: string | number },
+        ) => !!project)
         mockedUseFetchChallenges.mockReturnValue({
             challenges: [],
             error: undefined,
@@ -251,6 +265,21 @@ describe('ChallengesListPage', () => {
     })
 
     it('does not scope project challenge queries by member id', () => {
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            project: {
+                id: 200,
+                members: [
+                    {
+                        userId: 12345,
+                    },
+                ],
+                name: 'Authorized Project',
+                status: 'active',
+            },
+        })
+
         renderPage('/projects/200/challenges', '/projects/:projectId/challenges')
 
         const fetchParams = mockedUseFetchChallenges.mock.calls[0][0]
@@ -259,6 +288,79 @@ describe('ChallengesListPage', () => {
             .toBe('200')
         expect(fetchParams.memberId)
             .toBeUndefined()
+        expect(fetchParams.enabled)
+            .toBe(true)
+    })
+
+    it('waits for project access before fetching project challenges', () => {
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: true,
+            project: undefined,
+        })
+
+        renderPage('/projects/200/challenges', '/projects/:projectId/challenges')
+
+        expect(mockedUseFetchChallenges)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                enabled: false,
+                projectId: '200',
+            }))
+        expect(screen.getByText('Loading'))
+            .toBeTruthy()
+    })
+
+    it('blocks project challenge details when the project cannot be loaded', () => {
+        mockedUseFetchProject.mockReturnValue({
+            error: new Error('Forbidden'),
+            isLoading: false,
+            project: undefined,
+        })
+        mockedCheckProjectAccess.mockReturnValue(false)
+
+        renderPage('/projects/200/challenges', '/projects/:projectId/challenges')
+
+        expect(mockedUseFetchChallenges)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                enabled: false,
+                projectId: '200',
+            }))
+        expect(screen.getByText('You don’t have access to this project. Please contact support@topcoder.com.'))
+            .toBeTruthy()
+        expect(screen.queryByText('Challenges Table'))
+            .toBeNull()
+    })
+
+    it('blocks project challenge details when the caller is not a project member', () => {
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            project: {
+                id: 200,
+                members: [
+                    {
+                        userId: 99999,
+                    },
+                ],
+                name: 'Restricted Project',
+                status: 'active',
+            },
+        })
+        mockedCheckProjectAccess.mockReturnValue(false)
+
+        renderPage('/projects/200/challenges', '/projects/:projectId/challenges')
+
+        expect(mockedUseFetchChallenges)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                enabled: false,
+                projectId: '200',
+            }))
+        expect(screen.getByText('You don’t have access to this project. Please contact support@topcoder.com.'))
+            .toBeTruthy()
+        expect(screen.queryByText('Restricted Project'))
+            .toBeNull()
+        expect(screen.queryByText('Challenges Table'))
+            .toBeNull()
     })
 
     it('redirects invited users from the challenges route to the invitation modal route', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.tsx
@@ -33,6 +33,7 @@ import {
 import {
     ChallengesFilter,
     ChallengesTable,
+    ErrorMessage,
     Pagination,
     ProjectBillingAccountExpiredNotice,
     ProjectListTabs,
@@ -60,12 +61,14 @@ import {
     buildProjectLandingPath,
     canCreateEngagement,
     checkCanManageProject,
+    checkProjectAccess,
     getAuthAccessToken,
     getStatusText,
 } from '../../../lib/utils'
 
 import styles from './ChallengesListPage.module.scss'
 
+const PROJECT_ACCESS_DENIED_MESSAGE = 'You don’t have access to this project. Please contact support@topcoder.com.'
 const DEFAULT_FILTERS: ChallengeFilters = {
     endDateEnd: undefined,
     endDateStart: undefined,
@@ -344,6 +347,22 @@ interface DashboardMemberScopeState {
     scopedMemberId?: number
 }
 
+interface ProjectRouteAccessParams {
+    isProjectLoading: boolean
+    project?: Project
+    projectError?: Error
+    projectId?: string
+    shouldRedirectToProjectLanding: boolean
+    userId?: number | string
+    userRoles: string[]
+}
+
+interface ProjectRouteAccessState {
+    canFetchProjectChallenges: boolean
+    isDenied: boolean
+    isLoading: boolean
+}
+
 interface ResolveDashboardMemberScopeParams {
     isPrivilegedUser: boolean
     selectedProjectId?: number | string
@@ -374,6 +393,35 @@ function resolveDashboardMemberScope(
     return {
         isWaitingForMemberScope: params.userId === undefined,
         scopedMemberId: params.userId,
+    }
+}
+
+/**
+ * Resolves project-route access state before project-scoped child records load.
+ *
+ * @param params current route, project loading, redirect, and caller identity state.
+ * @returns whether child challenge records can load and whether to show loading or denial UI.
+ * @remarks Used by direct project challenge URLs so unauthorized callers do not
+ * receive challenge listings before project membership is verified.
+ */
+function resolveProjectRouteAccess(
+    params: ProjectRouteAccessParams,
+): ProjectRouteAccessState {
+    if (!params.projectId) {
+        return {
+            canFetchProjectChallenges: true,
+            isDenied: false,
+            isLoading: false,
+        }
+    }
+
+    const hasProjectAccess = checkProjectAccess(params.userRoles, params.userId, params.project)
+    const isLoading = params.isProjectLoading || params.shouldRedirectToProjectLanding
+
+    return {
+        canFetchProjectChallenges: hasProjectAccess && !params.projectError,
+        isDenied: !isLoading && (!!params.projectError || !hasProjectAccess),
+        isLoading,
     }
 }
 
@@ -449,6 +497,32 @@ export const ChallengesListPage: FC = () => {
     const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(DEFAULT_SORT_ORDER)
     const isPrivilegedUser = isAdmin || isManager
     const selectedProjectId = projectIdFromRoute || filters.projectId
+    const projectResult: UseFetchProjectResult = useFetchProject(projectIdFromRoute)
+    const accessToken = useMemo(
+        () => getAuthAccessToken(loginUserInfo),
+        [loginUserInfo],
+    )
+    const currentProjectChallengesPath = useMemo(
+        () => getProjectChallengesPath(projectIdFromRoute),
+        [projectIdFromRoute],
+    )
+    const projectLandingPath = useMemo(
+        () => getProjectLandingPath(projectIdFromRoute, projectResult.project, accessToken),
+        [accessToken, projectIdFromRoute, projectResult.project],
+    )
+    const shouldRedirectToProjectLanding = useMemo(
+        () => shouldRedirectToProjectLandingPath(currentProjectChallengesPath, projectLandingPath),
+        [currentProjectChallengesPath, projectLandingPath],
+    )
+    const projectRouteAccess = resolveProjectRouteAccess({
+        isProjectLoading: projectResult.isLoading,
+        project: projectResult.project,
+        projectError: projectResult.error,
+        projectId: projectIdFromRoute,
+        shouldRedirectToProjectLanding,
+        userId: loginUserInfo?.userId,
+        userRoles,
+    })
     const {
         isWaitingForMemberScope,
         scopedMemberId,
@@ -460,7 +534,7 @@ export const ChallengesListPage: FC = () => {
 
     const fetchParams: UseFetchChallengesParams = {
         ...filters,
-        enabled: !isWaitingForMemberScope,
+        enabled: !isWaitingForMemberScope && projectRouteAccess.canFetchProjectChallenges,
         memberId: scopedMemberId,
         page,
         perPage,
@@ -471,7 +545,6 @@ export const ChallengesListPage: FC = () => {
 
     const challengesResult: UseFetchChallengesResult = useFetchChallenges(fetchParams)
     const challengeTypesResult: UseFetchChallengeTypesResult = useFetchChallengeTypes()
-    const projectResult: UseFetchProjectResult = useFetchProject(projectIdFromRoute)
     const projectsResult: UseFetchProjectsResult = useFetchProjects({
         memberOnly: !isPrivilegedUser,
     })
@@ -587,22 +660,6 @@ export const ChallengesListPage: FC = () => {
             .sort((projectA, projectB) => projectA.label.localeCompare(projectB.label)),
         [projectsResult.projects],
     )
-    const accessToken = useMemo(
-        () => getAuthAccessToken(loginUserInfo),
-        [loginUserInfo],
-    )
-    const currentProjectChallengesPath = useMemo(
-        () => getProjectChallengesPath(projectIdFromRoute),
-        [projectIdFromRoute],
-    )
-    const projectLandingPath = useMemo(
-        () => getProjectLandingPath(projectIdFromRoute, projectResult.project, accessToken),
-        [accessToken, projectIdFromRoute, projectResult.project],
-    )
-    const shouldRedirectToProjectLanding = useMemo(
-        () => shouldRedirectToProjectLandingPath(currentProjectChallengesPath, projectLandingPath),
-        [currentProjectChallengesPath, projectLandingPath],
-    )
 
     useEffect(() => {
         setFilters(currentFilters => ({
@@ -656,8 +713,19 @@ export const ChallengesListPage: FC = () => {
         projectStatus: projectResult.project?.status,
     })
 
-    if (shouldRedirectToProjectLanding) {
+    if (projectRouteAccess.isLoading) {
         return <TableLoading />
+    }
+
+    if (projectRouteAccess.isDenied) {
+        return (
+            <PageWrapper
+                pageTitle='Challenges'
+                breadCrumb={[]}
+            >
+                <ErrorMessage message={PROJECT_ACCESS_DENIED_MESSAGE} />
+            </PageWrapper>
+        )
     }
 
     return (


### PR DESCRIPTION
What was broken

Users could open a project-scoped Work Manager challenges URL before the app confirmed that they had access to the project. The page could expose challenge listings even when project details were not available to the caller.

Root cause (if identifiable)

The challenges list fetched child challenge records directly from the route projectId while project membership checks were only used for page title and action rendering.

What was changed

Added a project workspace access helper that allows admins or project members. The project challenges route now waits for project access to resolve, disables challenge fetching until access is confirmed, and shows the required validation message when access is denied.

Any added/updated tests

Added permission utility coverage for project workspace access and ChallengesListPage coverage for loading, denied project fetches, denied non-member access, and authorized project challenge fetches.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
