### PR TITLE
PM-4891: Link zero assignment counts

### DIFF
--- a/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.spec.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.spec.tsx
@@ -22,6 +22,7 @@ import {
     canViewAllEngagements,
     checkTalentManager,
     formatEngagementStatus,
+    getAssignedMembersCount,
     showErrorToast,
     showSuccessToast,
 } from '../../../lib/utils'
@@ -182,6 +183,7 @@ const mockedCanCreateEngagement = canCreateEngagement as jest.Mock
 const mockedCanViewAllEngagements = canViewAllEngagements as jest.Mock
 const mockedCheckTalentManager = checkTalentManager as jest.Mock
 const mockedFormatEngagementStatus = formatEngagementStatus as jest.Mock
+const mockedGetAssignedMembersCount = getAssignedMembersCount as jest.Mock
 const mockedShowErrorToast = showErrorToast as jest.Mock
 const mockedShowSuccessToast = showSuccessToast as jest.Mock
 
@@ -517,6 +519,46 @@ describe('EngagementsListPage', () => {
         expect(screen.getByRole('link', { name: sampleEngagement.title })
             .getAttribute('href'))
             .toBe('/projects/200/engagements/111/assignments')
+    })
+
+    it('links zero assigned member counts to the assignees page when completed assignments exist', () => {
+        mockedGetAssignedMembersCount.mockReturnValue(0)
+        mockedUseFetchEngagements.mockReturnValue({
+            engagements: [
+                {
+                    ...sampleEngagement,
+                    assignments: [
+                        {
+                            agreementRate: '1000',
+                            endDate: '2026-04-30T00:00:00.000Z',
+                            engagementId: 111,
+                            id: 'assignment-1',
+                            memberHandle: 'finished_member',
+                            memberId: 123,
+                            otherRemarks: '',
+                            startDate: '2026-04-01T00:00:00.000Z',
+                            status: 'COMPLETED',
+                            termsAccepted: true,
+                        },
+                    ],
+                },
+            ],
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+        })
+
+        renderPage('/engagements', '/engagements')
+
+        const row = screen.getByText(sampleEngagement.title)
+            .closest('tr') as HTMLTableRowElement
+        const zeroCountLinks = within(row)
+            .getAllByRole('link', { name: '0' })
+
+        expect(zeroCountLinks.some(link => (
+            link.getAttribute('href') === '/projects/200/engagements/111/assignments'
+        )))
+            .toBe(true)
     })
 
     it('scopes all-engagements fetches to member projects for talent managers', async () => {

--- a/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.tsx
@@ -241,7 +241,7 @@ function renderMembersAssignedCell(
     const count = getAssignedMembersCount(engagement)
     const handles = getAssignedMemberHandles(engagement)
 
-    const hasAssignmentsRoute = !!engagementProjectId && !!engagement.id && count > 0
+    const hasAssignmentsRoute = !!engagementProjectId && !!engagement.id
     const countElement = hasAssignmentsRoute
         ? (
             <Link


### PR DESCRIPTION
What was broken

The members assigned count only linked to the assignments page when the active assignment count was greater than zero. Engagements with only completed assignment history displayed 0 as plain text, leaving no direct way to open the assignments page from the count.

Root cause (if identifiable)

The engagement list treated a positive active assignment count as part of assignment route availability instead of using the engagement and project identifiers that actually define the route.

What was changed

The members assigned cell now links to the assignments page whenever the engagement assignment route can be constructed, including when the rendered active count is 0.

Any added/updated tests

Added an EngagementsListPage regression test that verifies a zero assigned member count still links to the assignments page when completed assignments exist.

Validation run:
- Passed: yarn test:no-watch --runInBand src/apps/work/src/pages/engagements/EngagementsListPage/EngagementsListPage.spec.tsx
- Passed: yarn lint
- Passed: yarn run build
- Attempted: yarn test:no-watch --runInBand. The full suite has an unrelated existing failure in src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx, where the expected challenge view URL receives the project URL. This branch does not modify wallet-admin files.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
