### PR TITLE
PM-4945: Make work menu tabs real links

### DIFF
--- a/src/apps/work/src/lib/components/NavTabs/NavTabs.module.scss
+++ b/src/apps/work/src/lib/components/NavTabs/NavTabs.module.scss
@@ -74,12 +74,7 @@
             li {
                 font-family: 'Nunito Sans', sans-serif;
                 margin-left: $sp-8;
-                cursor: pointer;
                 color: var(--FontColor);
-                line-height: 32px;
-                display: flex;
-                align-items: center;
-                gap: $sp-2;
 
                 &.active {
                     font-weight: 700;
@@ -125,6 +120,17 @@
             }
         }
     }
+}
+
+.tabLink {
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: $sp-2;
+    line-height: 32px;
+    text-decoration: none;
+    width: 100%;
 }
 
 .tabLabel {

--- a/src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx
+++ b/src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    fireEvent,
+    render,
+    screen,
+} from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+
+import { WorkAppContext } from '../../contexts/WorkAppContext'
+import { WorkAppContextModel } from '../../models/WorkAppContextModel.model'
+import NavTabs from './NavTabs'
+
+jest.mock('~/config', () => ({
+    AppSubdomain: {
+        work: 'work',
+    },
+    EnvironmentConfig: {
+        SUBDOMAIN: 'work',
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/shared/lib/hooks', () => ({
+    useClickOutside: jest.fn(),
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/ui', () => ({
+    IconOutline: {
+        ExternalLinkIcon: (props: object) => jest.requireActual('react')
+            .createElement('svg', props),
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('../../utils/permissions.utils', () => ({
+    canViewAllEngagements: (userRoles: string[]) => (
+        userRoles.includes('administrator') || userRoles.includes('talent manager')
+    ),
+}))
+
+const LocationViewer = (): JSX.Element => {
+    const location = useLocation()
+
+    return <div data-testid='location-pathname'>{location.pathname}</div>
+}
+
+function renderNavTabs(pathname: string = '/challenges'): void {
+    const contextValue: WorkAppContextModel = {
+        isAdmin: true,
+        isAnonymous: false,
+        isCopilot: false,
+        isManager: false,
+        isReadOnly: false,
+        loginUserInfo: undefined,
+        userRoles: ['administrator'],
+    }
+
+    render(
+        <WorkAppContext.Provider value={contextValue}>
+            <MemoryRouter initialEntries={[pathname]}>
+                <NavTabs />
+                <LocationViewer />
+            </MemoryRouter>
+        </WorkAppContext.Provider>,
+    )
+}
+
+describe('NavTabs', () => {
+    it('renders work app menu items as links so browser link actions are available', () => {
+        renderNavTabs()
+
+        expect(screen.getByRole('link', { name: 'Challenges' })
+            .getAttribute('href'))
+            .toBe('/challenges')
+        expect(screen.getByRole('link', { name: 'Engagements' })
+            .getAttribute('href'))
+            .toBe('/engagements')
+        expect(screen.getByRole('link', { name: 'Projects' })
+            .getAttribute('href'))
+            .toBe('/projects')
+        expect(screen.getByRole('link', { name: 'TaaS Projects' })
+            .getAttribute('href'))
+            .toBe('/taas')
+        expect(screen.getByRole('link', { name: 'Groups' })
+            .getAttribute('href'))
+            .toBe('/groups')
+    })
+
+    it('keeps normal left-click navigation working for internal tabs', () => {
+        renderNavTabs('/challenges')
+
+        fireEvent.click(screen.getByRole('link', { name: 'Projects' }))
+
+        expect(screen.getByTestId('location-pathname').textContent)
+            .toBe('/projects')
+    })
+})

--- a/src/apps/work/src/lib/components/NavTabs/NavTabs.tsx
+++ b/src/apps/work/src/lib/components/NavTabs/NavTabs.tsx
@@ -10,20 +10,19 @@ import {
     useRef,
     useState,
 } from 'react'
-import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import classNames from 'classnames'
 
 import { useClickOutside } from '~/libs/shared/lib/hooks'
 import { IconOutline } from '~/libs/ui'
 
-import { WorkAppContext } from '../../contexts'
+import { WorkAppContext } from '../../contexts/WorkAppContext'
 import { WorkAppContextModel } from '../../models'
 
 import { getTabIdFromPathName, getTabsConfig } from './config'
 import styles from './NavTabs.module.scss'
 
 const NavTabs: FC = () => {
-    const navigate: NavigateFunction = useNavigate()
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const triggerRef = useRef<HTMLDivElement>(null)
     const { pathname }: { pathname: string } = useLocation()
@@ -57,28 +56,22 @@ const NavTabs: FC = () => {
     }, [isOpen])
 
     const handleTabClick = useCallback(
-        (event: MouseEvent<HTMLLIElement>) => {
-            const {
-                tabId,
-                tabUrl,
-            }: { tabId?: string; tabUrl?: string } = event.currentTarget.dataset
+        (event: MouseEvent<HTMLAnchorElement>) => {
+            const { tabId }: { tabId?: string } = event.currentTarget.dataset
 
             if (!tabId) {
                 return
             }
 
-            if (tabUrl) {
-                setIsOpen(false)
-                window.open(tabUrl, '_blank', 'noopener,noreferrer')
-                return
-            }
-
             setActiveTab(tabId)
             setIsOpen(false)
-            navigate(tabId)
         },
-        [navigate],
+        [],
     )
+
+    const handleExternalTabClick = useCallback(() => {
+        setIsOpen(false)
+    }, [])
 
     useClickOutside(triggerRef.current, () => setIsOpen(false))
 
@@ -102,16 +95,30 @@ const NavTabs: FC = () => {
                             <li
                                 key={tab.id}
                                 className={isActive ? `${styles.active}` : ''}
-                                data-tab-id={tab.id}
-                                data-tab-url={tab.url || undefined}
-                                onClick={handleTabClick}
                             >
-                                <span className={styles.tabLabel}>{tab.title}</span>
-                                {tab.url && (
-                                    <IconOutline.ExternalLinkIcon
-                                        aria-hidden='true'
-                                        className={styles.externalIcon}
-                                    />
+                                {tab.url ? (
+                                    <a
+                                        className={styles.tabLink}
+                                        href={tab.url}
+                                        onClick={handleExternalTabClick}
+                                        rel='noopener noreferrer'
+                                        target='_blank'
+                                    >
+                                        <span className={styles.tabLabel}>{tab.title}</span>
+                                        <IconOutline.ExternalLinkIcon
+                                            aria-hidden='true'
+                                            className={styles.externalIcon}
+                                        />
+                                    </a>
+                                ) : (
+                                    <Link
+                                        className={styles.tabLink}
+                                        data-tab-id={tab.id}
+                                        onClick={handleTabClick}
+                                        to={tab.id}
+                                    >
+                                        <span className={styles.tabLabel}>{tab.title}</span>
+                                    </Link>
                                 )}
                             </li>
                         )


### PR DESCRIPTION
What was broken
The work app top menu rendered its tabs as list items with click handlers, so browser link actions such as right-click and open in new tab were unavailable.

Root cause
The navigation relied on imperative React Router navigation from non-anchor elements instead of rendering actual link targets.

What was changed
Converted the work app menu tabs to render React Router links for internal routes and anchors for external URLs, while preserving active tab styling and dropdown close behavior.

Any added/updated tests
Added NavTabs coverage that verifies the menu items expose hrefs and that normal left-click navigation still works.

Validation run:
- yarn lint
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx
- yarn run build
- yarn test:no-watch currently fails on unrelated wallet-admin PaymentView.spec.tsx URL expectation: expected /projects/42/challenges/challenge-uuid-1/view but received /projects/42.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
