### PR TITLE
PM-4944: Preserve specification edits during autosave

### DIFF
--- a/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.module.scss
+++ b/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.module.scss
@@ -1,7 +1,15 @@
 .editor {
+    height: 420px;
     min-height: 280px;
+    overflow: hidden;
+    resize: vertical;
 
     :global(.EasyMDEContainer) {
         min-height: 280px;
     }
+}
+
+.editor .markdownEditor {
+    height: 100%;
+    min-height: 280px;
 }

--- a/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.tsx
+++ b/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.tsx
@@ -86,6 +86,7 @@ export const FormMarkdownEditor: FC<FormMarkdownEditorProps> = (props: FormMarkd
             <div className={styles.editor}>
                 <FieldMarkdownEditor
                     ariaLabel={label}
+                    className={styles.markdownEditor}
                     disabled={disabled}
                     error={fieldState.error?.message}
                     hideErrorMessage

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -48,6 +48,8 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - Autosave is implemented via `useAutosave`.
 - Delay defaults to `AUTOSAVE_DELAY_MS` (10s).
 - Autosave runs when form is dirty and valid, except in read-only view mode.
+- Autosave keeps the current editor values in place after patch responses so in-flight typing is
+  not replaced by challenge-api normalized content.
 - Status values: `idle`, `saving`, `saved`, `error`.
 - Last save time is shown in the footer.
 
@@ -63,8 +65,8 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - `Submission Settings`: shown for Design `Challenge` and Design `First2Finish` types, and contains the final-deliverables, stock-art, and submission-visibility controls.
 - `FinalDeliverablesField`: design-challenge file-type editor that persists the legacy `fileTypes` metadata payload used on challenge draft pages.
 - `MaximumSubmissionsField`: non-visual compatibility field that rewrites the legacy `submissionLimit` metadata to the unlimited-only payload so design challenges no longer expose submission-cap controls. It defers dirtying that automatic normalization until the editor finishes its initial resource hydration, which preserves copilot restoration before autosave/manual-save starts treating the metadata rewrite as a user change.
-- `ChallengeDescriptionField`: public markdown spec editor.
-- `ChallengePrivateDescriptionField`: optional private markdown spec editor.
+- `ChallengeDescriptionField`: public markdown spec editor with a vertically resizable editing area.
+- `ChallengePrivateDescriptionField`: optional private markdown spec editor with a vertically resizable editing area.
 - `TermsField`: advanced-option multi-select for challenge terms. The create route seeds the standard Topcoder terms entry automatically once the terms list loads, including immediately after the first draft-creation step assigns a challenge id, so the editor matches legacy work-manager defaults while still allowing the NDA toggle to add or remove the NDA term separately.
 - `ChallengeTagsField`: multi creatable tag picker excluding special challenge tags.
 - `ChallengeSkillsField`: async multi skills picker with billing-account-based required behavior.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -252,14 +252,33 @@ jest.mock('./AttachmentsField', () => {
     }
 })
 jest.mock('./ChallengeDescriptionField', () => ({
-    ChallengeDescriptionField: (props: {
+    ChallengeDescriptionField: function ChallengeDescriptionField(props: {
         readOnly?: boolean
-    }) => (
-        <div
-            data-read-only={props.readOnly === true ? 'true' : 'false'}
-            data-testid='challenge-description-field'
-        />
-    ),
+    }) {
+        const reactHookForm: typeof import('react-hook-form') = jest.requireActual('react-hook-form')
+        const controller = reactHookForm.useController({
+            control: reactHookForm.useFormContext().control,
+            name: 'description',
+        })
+
+        return (
+            <div
+                data-read-only={props.readOnly === true ? 'true' : 'false'}
+                data-testid='challenge-description-field'
+            >
+                <label htmlFor='description'>
+                    Public Specification
+                    <textarea
+                        id='description'
+                        onBlur={controller.field.onBlur}
+                        onChange={controller.field.onChange}
+                        readOnly={props.readOnly}
+                        value={controller.field.value || ''}
+                    />
+                </label>
+            </div>
+        )
+    },
 }))
 jest.mock('./ChallengeScheduleSection', () => ({
     ChallengeScheduleSection: function ChallengeScheduleSection(props: {
@@ -2102,6 +2121,61 @@ describe('ChallengeEditorForm', () => {
         expect(screen.getByTestId('reviewers-field')
             .getAttribute('data-reviewers'))
             .toContain('"memberId":"manual-reviewer-member-id"')
+    })
+
+    it('keeps public specification edits made while autosave is in flight', async () => {
+        const user = userEvent.setup()
+        let resolvePatch: ((challenge: Challenge) => void) | undefined
+
+        mockedPatchChallenge.mockImplementation(
+            () => new Promise(resolve => {
+                resolvePatch = resolve as (challenge: Challenge) => void
+            }),
+        )
+
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm challenge={validDraftChallenge} />
+            </MemoryRouter>,
+        )
+
+        const specificationInput = screen.getByLabelText('Public Specification') as HTMLTextAreaElement
+        const autosavedDescription = `${validDraftChallenge.description} Autosaved markdown`
+        const currentDescription = `${autosavedDescription} plus unsaved text`
+
+        await user.type(specificationInput, ' Autosaved markdown')
+
+        const autosaveParams = mockedUseAutosave.mock
+            .calls[mockedUseAutosave.mock.calls.length - 1][0] as {
+                formValues: ChallengeEditorFormData
+                onSave: (formData: ChallengeEditorFormData) => Promise<void>
+            }
+        let autosavePromise: Promise<void> = Promise.resolve()
+
+        await act(async () => {
+            autosavePromise = autosaveParams.onSave({
+                ...autosaveParams.formValues,
+                description: autosavedDescription,
+            })
+            await Promise.resolve()
+        })
+
+        await user.type(specificationInput, ' plus unsaved text')
+
+        await act(async () => {
+            resolvePatch?.({
+                ...validDraftChallenge,
+                description: 'Rendered specification from challenge-api',
+            })
+            await autosavePromise
+        })
+
+        expect(mockedPatchChallenge)
+            .toHaveBeenCalledWith('12345', expect.objectContaining({
+                description: autosavedDescription,
+            }))
+        expect(specificationInput)
+            .toHaveValue(currentDescription)
     })
 
     it('keeps the review section after submission settings in read-only mode', () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -2769,7 +2769,15 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                 setLastSaved(savedAt)
                 setSaveStatus('saved')
 
-                reset(nextValues)
+                // Autosave should advance the saved baseline without replacing inputs users may still be editing.
+                reset(
+                    options.isAutosave
+                        ? formDataWithProjectBilling
+                        : nextValues,
+                    options.isAutosave
+                        ? { keepValues: true }
+                        : undefined,
+                )
                 onChallengeStatusChange?.(normalizeStatus(nextValues.status))
 
                 if (!options.isAutosave) {


### PR DESCRIPTION
What was broken
The challenge specification editor reset from patch responses during autosave, which could move the cursor and replace text typed while the request was in flight. The editor area was also fixed to a small height.

Root cause (if identifiable)
Autosave reused the normal save reset path, so challenge-api response values were pushed back into active form inputs after every patch.

What was changed
Autosave now advances the saved baseline with the submitted payload while keeping current form input values mounted. The work markdown editor wrapper is taller by default and vertically resizable. Challenge editor docs now describe the behavior.

Any added/updated tests
Added a ChallengeEditorForm regression test that keeps public specification edits made while an autosave patch is in flight.

Validation run: yarn lint passed, yarn run build passed with existing CRA warning output, and the focused ChallengeEditorForm spec passed. The full yarn test:no-watch command was also run and failed only the existing wallet-admin PaymentView project-link expectation, outside this PM-4944 change area.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
