### PR TITLE
PM-4904: Allow billing-free drafts and clear launch errors

### DIFF
--- a/src/apps/work/src/lib/models/Project.model.ts
+++ b/src/apps/work/src/lib/models/Project.model.ts
@@ -54,7 +54,7 @@ export interface CreateProjectPayload {
 export interface UpdateProjectPayload {
     name: string
     description: string
-    billingAccountId?: number | string
+    billingAccountId?: null | number | string
     details?: ProjectDetails
     status?: ProjectStatus
     cancelReason?: string

--- a/src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts
@@ -11,6 +11,17 @@ import {
 } from './project-billing-account.utils'
 
 describe('project-billing-account challenge gating helpers', () => {
+    it('treats missing billing accounts as blocked only when required', () => {
+        expect(getProjectBillingAccountChallengeIssue(undefined))
+            .toBeUndefined()
+        expect(getProjectBillingAccountChallengeIssue(undefined, true))
+            .toBe('missing')
+        expect(getProjectBillingAccountNoticeMessage('missing'))
+            .toBe('This project does not have a billing account.')
+        expect(getProjectBillingAccountChallengeErrorMessage('missing'))
+            .toBe('Cannot launch challenges because this project does not have a billing account.')
+    })
+
     it('treats inactive billing accounts as blocked for challenges', () => {
         const billingAccount: ProjectBillingAccount = {
             active: false,

--- a/src/apps/work/src/lib/utils/project-billing-account.utils.ts
+++ b/src/apps/work/src/lib/utils/project-billing-account.utils.ts
@@ -1,6 +1,6 @@
 import type { ProjectBillingAccount } from '../services'
 
-type ProjectBillingAccountChallengeIssue = 'expired' | 'inactive' | 'insufficient-funds'
+type ProjectBillingAccountChallengeIssue = 'expired' | 'inactive' | 'insufficient-funds' | 'missing'
 export type BillingAccountBudgetStatus = 'healthy' | 'warning' | 'critical'
 
 export interface BillingAccountBudgetSource {
@@ -301,13 +301,19 @@ function isBillingAccountExpired(
  * Resolves whether a project billing account should block challenge launch actions.
  *
  * @param billingAccount Project billing-account payload resolved in the work app.
+ * @param requiresBillingAccount Whether a missing billing account should block the action.
  * @returns The blocking reason, or `undefined` when the billing account can be used.
  * @remarks Used by the challenge editor and project billing notices so the work app
  * matches the legacy launch restriction for inactive, expired, and depleted billing accounts.
  */
 export function getProjectBillingAccountChallengeIssue(
     billingAccount: ProjectBillingAccount | undefined,
+    requiresBillingAccount: boolean = false,
 ): ProjectBillingAccountChallengeIssue | undefined {
+    if (!billingAccount && requiresBillingAccount) {
+        return 'missing'
+    }
+
     const active = resolveBillingAccountActive(billingAccount)
 
     if (active === false) {
@@ -338,6 +344,8 @@ export function getProjectBillingAccountNoticeMessage(
     issue: ProjectBillingAccountChallengeIssue,
 ): string {
     switch (issue) {
+        case 'missing':
+            return 'This project does not have a billing account.'
         case 'inactive':
             return 'The billing account for this project is inactive.'
         case 'expired':
@@ -361,6 +369,8 @@ export function getProjectBillingAccountChallengeErrorMessage(
     issue: ProjectBillingAccountChallengeIssue,
 ): string {
     switch (issue) {
+        case 'missing':
+            return 'Cannot launch challenges because this project does not have a billing account.'
         case 'inactive':
             return 'Cannot launch challenges because the project billing account is inactive.'
         case 'expired':

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -1617,6 +1617,14 @@ describe('ChallengeEditorForm', () => {
     it('returns to view mode after launching from an edit route', async () => {
         let launchAction: (() => Promise<void>) | undefined
 
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: {
+                active: true,
+                id: '80001063',
+                totalBudgetRemaining: 500,
+            },
+            isLoading: false,
+        })
         mockedPatchChallenge.mockResolvedValue({
             ...validDraftChallenge,
             status: 'ACTIVE',
@@ -2731,6 +2739,89 @@ describe('ChallengeEditorForm', () => {
         expect(mockedShowErrorToast)
             .toHaveBeenCalledWith(
                 'Cannot launch challenges because the project billing account is inactive.',
+            )
+        expect(mockedShowErrorToast)
+            .not.toHaveBeenCalledWith('Failed to save challenge')
+    })
+
+    it('blocks launch with a clear reason when the project has no billing account', async () => {
+        let launchAction: (() => Promise<void>) | undefined
+        let launchError: Error | undefined
+
+        mockedUseFetchChallengeTracks.mockReturnValue({
+            isLoading: false,
+            tracks: [{
+                id: 'design-track',
+                name: 'Design',
+                track: 'DESIGN',
+            }],
+        })
+        mockedUseFetchChallengeTypes.mockReturnValue({
+            challengeTypes: [{
+                abbreviation: 'F2F',
+                id: 'design-first2finish',
+                isTask: false,
+                name: 'First2Finish',
+            }],
+            isLoading: false,
+        })
+        mockedUseFetchResourceRoles.mockReturnValue({
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            resourceRoles: [{
+                id: 'iterative-reviewer-role-id',
+                name: 'Iterative Reviewer',
+            }],
+        })
+        mockedUseFetchResources.mockReturnValue({
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            mutate: jest.fn(),
+            resources: [{
+                challengeId: '12345',
+                memberHandle: 'taasiintake300',
+                memberId: 'manual-reviewer-member-id',
+                role: 'Iterative Reviewer',
+                roleId: 'iterative-reviewer-role-id',
+            }],
+        })
+
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm
+                    challenge={first2FinishDraftChallenge}
+                    projectId='100578'
+                    onRegisterLaunchAction={action => {
+                        launchAction = action
+                    }}
+                />
+            </MemoryRouter>,
+        )
+
+        await waitFor(() => {
+            expect(launchAction)
+                .toEqual(expect.any(Function))
+        })
+
+        await act(async () => {
+            try {
+                await (launchAction as () => Promise<void>)()
+            } catch (error) {
+                launchError = error as Error
+            }
+        })
+
+        expect(launchError)
+            .toEqual(expect.objectContaining({
+                message: 'Cannot launch challenges because this project does not have a billing account.',
+            }))
+        expect(mockedPatchChallenge)
+            .not.toHaveBeenCalled()
+        expect(mockedShowErrorToast)
+            .toHaveBeenCalledWith(
+                'Cannot launch challenges because this project does not have a billing account.',
             )
         expect(mockedShowErrorToast)
             .not.toHaveBeenCalledWith('Failed to save challenge')

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -2731,7 +2731,10 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
             try {
                 const resolvedProjectBillingAccount = await resolveProjectBillingAccount()
                 const projectBillingAccountIssue = isChallengeBeingActivated
-                    ? getProjectBillingAccountChallengeIssue(resolvedProjectBillingAccount)
+                    ? getProjectBillingAccountChallengeIssue(
+                        resolvedProjectBillingAccount,
+                        !!fallbackProjectId,
+                    )
                     : undefined
                 const projectBillingAccountErrorMessage = projectBillingAccountIssue
                     ? getProjectBillingAccountChallengeErrorMessage(projectBillingAccountIssue)

--- a/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../../lib/hooks'
 import {
     createProject,
+    updateProject,
 } from '../../../../../lib/services'
 
 import { ProjectEditorForm } from './ProjectEditorForm'
@@ -172,6 +173,7 @@ const mockedUseFetchProjectBillingAccount = useFetchProjectBillingAccount as jes
     typeof useFetchProjectBillingAccount
 >
 const mockedCreateProject = createProject as jest.MockedFunction<typeof createProject>
+const mockedUpdateProject = updateProject as jest.MockedFunction<typeof updateProject>
 
 describe('ProjectEditorForm', () => {
     beforeEach(() => {
@@ -184,6 +186,11 @@ describe('ProjectEditorForm', () => {
             id: 'project-1',
             name: 'Payments Project',
             status: 'draft',
+        })
+        mockedUpdateProject.mockResolvedValue({
+            id: 'project-1',
+            name: 'Payments Project',
+            status: 'active',
         })
     })
 
@@ -238,5 +245,44 @@ describe('ProjectEditorForm', () => {
                     displayMemberPaymentDetailsToCopilots: true,
                 },
             })))
+    })
+
+    it('submits null when clearing an existing project billing account', async () => {
+        render(
+            <MemoryRouter>
+                <ProjectEditorForm
+                    canManage
+                    isEdit
+                    projectDetail={{
+                        billingAccountId: '80001063',
+                        description: 'Project with billing',
+                        id: 'project-1',
+                        name: 'Payments Project',
+                        status: 'active',
+                    }}
+                    projectTypes={[]}
+                />
+            </MemoryRouter>,
+        )
+
+        fireEvent.change(screen.getByLabelText('Select New Billing Account'), {
+            target: {
+                value: '',
+            },
+        })
+
+        await waitFor(() => expect((screen.getByRole('button', {
+            name: 'Save project',
+        }) as HTMLButtonElement).disabled)
+            .toBe(false))
+
+        fireEvent.click(screen.getByRole('button', {
+            name: 'Save project',
+        }))
+
+        await waitFor(() => expect(mockedUpdateProject)
+            .toHaveBeenCalledWith('project-1', expect.any(Object)))
+        expect(mockedUpdateProject.mock.calls[0]?.[1].billingAccountId)
+            .toBeNull()
     })
 })

--- a/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
+++ b/src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.tsx
@@ -393,7 +393,8 @@ export const ProjectEditorForm: FC<ProjectEditorFormProps> = (props: ProjectEdit
                 }
 
                 const payload: UpdateProjectPayload = {
-                    billingAccountId: normalizedBillingAccountId || '',
+                    // eslint-disable-next-line unicorn/no-null
+                    billingAccountId: normalizedBillingAccountId || null,
                     description: formData.description,
                     details: {
                         ...(props.projectDetail.details || {}),


### PR DESCRIPTION
What was broken
The previous fix made billing account optional in project form validation, but QA still saw two gaps: clearing an existing project billing account did not reliably remove it, and launching a project-backed challenge without a billing account showed a generic save failure instead of the reason.

Root cause
The work app sent an empty string when the billing account selector was cleared instead of the Projects API's explicit clear value. Challenge launch validation also allowed a missing project billing account to proceed until the save request failed.

What was changed
Project updates now send a null billingAccountId when the selector is cleared. Challenge launch validation now blocks project-backed launches with a specific missing billing account message while leaving draft challenge creation and non-launch saves billing-account optional.

Any added/updated tests
Added regression tests for clearing project billing accounts, missing billing account launch messaging, and the billing-account challenge gating helper.

Validation
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts src/apps/work/src/pages/projects/ProjectEditorPage/components/ProjectEditorForm/ProjectEditorForm.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
- yarn lint
- yarn run build
- yarn test:no-watch (fails on existing unrelated wallet-admin PaymentView.spec.tsx URL expectation: expected challenge URL, received project URL)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
