### PR TITLE
PM-4393: Restrict direct challenge project access

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
@@ -16,12 +16,16 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
 import {
     useFetchChallenge,
+    useFetchProject,
     useFetchResourceRoles,
     useFetchResources,
     type UseFetchChallengeResult,
 } from '../../../lib/hooks'
 import { deleteChallenge } from '../../../lib/services'
-import { isChallengeCompletedOrCancelled } from '../../../lib/utils'
+import {
+    checkProjectAccess,
+    isChallengeCompletedOrCancelled,
+} from '../../../lib/utils'
 import {
     getAssignedTaskMember,
     shouldShowCompleteTaskAction,
@@ -156,6 +160,7 @@ jest.mock('../../../lib/contexts', () => {
 })
 jest.mock('../../../lib/hooks', () => ({
     useFetchChallenge: jest.fn(),
+    useFetchProject: jest.fn(),
     useFetchResourceRoles: jest.fn(() => ({
         resourceRoles: [],
     })),
@@ -169,6 +174,7 @@ jest.mock('../../../lib/services', () => ({
     patchChallenge: jest.fn(),
 }))
 jest.mock('../../../lib/utils', () => ({
+    checkProjectAccess: jest.fn(() => true),
     extractErrorMessage: jest.fn(() => 'Error'),
     getStatusText: jest.fn((status?: string) => status || ''),
     isChallengeCompletedOrCancelled: jest.fn(),
@@ -241,9 +247,11 @@ jest.mock('./ChallengeEditorPage.utils', () => ({
 }))
 
 const mockedUseFetchChallenge = useFetchChallenge as jest.Mock
+const mockedUseFetchProject = useFetchProject as jest.Mock
 const mockedUseFetchResourceRoles = useFetchResourceRoles as jest.Mock
 const mockedUseFetchResources = useFetchResources as jest.Mock
 const mockedDeleteChallenge = deleteChallenge as jest.Mock
+const mockedCheckProjectAccess = checkProjectAccess as jest.Mock
 const mockedIsChallengeCompletedOrCancelled = isChallengeCompletedOrCancelled as jest.Mock
 const mockedGetAssignedTaskMember = getAssignedTaskMember as jest.Mock
 const mockedShouldShowCompleteTaskAction = shouldShowCompleteTaskAction as jest.Mock
@@ -301,12 +309,26 @@ describe('ChallengeEditorPage', () => {
                 id: '456',
                 name: 'Edit test',
                 prizeSets: [],
+                projectId: '123',
                 status: 'DRAFT',
             },
             error: undefined,
             isLoading: false,
             mutate: jest.fn(),
         })
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            project: {
+                id: '123',
+                members: [{
+                    userId: 12345,
+                }],
+                name: 'Allowed Project',
+                status: 'active',
+            },
+        })
+        mockedCheckProjectAccess.mockReturnValue(true)
         mockedUseFetchResourceRoles.mockReturnValue({
             resourceRoles: [],
         })
@@ -413,6 +435,76 @@ describe('ChallengeEditorPage', () => {
                 .getAttribute('data-size'),
         )
             .toBe('lg')
+    })
+
+    it('blocks project-scoped challenge views when project access is denied', async () => {
+        mockedCheckProjectAccess.mockReturnValue(false)
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            project: {
+                id: '123',
+                members: [{
+                    userId: 99999,
+                }],
+                name: 'Restricted Project',
+                status: 'active',
+            },
+        })
+
+        renderPage(
+            '/projects/123/challenges/456/view',
+            '/projects/:projectId/challenges/:challengeId/view',
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText('You don’t have access to this project. Please contact support@topcoder.com.'))
+                .toBeTruthy()
+        })
+
+        expect(mockedUseFetchChallenge)
+            .toHaveBeenCalledWith(undefined)
+        expect(screen.queryByText('Challenge View Form'))
+            .toBeNull()
+        expect(screen.queryByRole('heading', { name: 'View Edit test' }))
+            .toBeNull()
+        expect(screen.queryByRole('button', { name: 'Edit' }))
+            .toBeNull()
+    })
+
+    it('blocks unscoped challenge views after resolving the challenge project', async () => {
+        mockedCheckProjectAccess.mockReturnValue(false)
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            project: {
+                id: '123',
+                members: [{
+                    userId: 99999,
+                }],
+                name: 'Restricted Project',
+                status: 'active',
+            },
+        })
+
+        renderPage(
+            '/challenges/456/view',
+            '/challenges/:challengeId/view',
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText('You don’t have access to this project. Please contact support@topcoder.com.'))
+                .toBeTruthy()
+        })
+
+        expect(mockedUseFetchChallenge)
+            .toHaveBeenCalledWith('456')
+        expect(mockedUseFetchProject)
+            .toHaveBeenCalledWith('123')
+        expect(screen.queryByText('Challenge View Form'))
+            .toBeNull()
+        expect(screen.queryByRole('heading', { name: 'View Edit test' }))
+            .toBeNull()
     })
 
     it('treats trailing-slash view routes as read-only mode', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
@@ -34,15 +34,20 @@ import {
 import { WorkAppContext } from '../../../lib/contexts'
 import {
     useFetchChallenge,
+    useFetchProject,
     useFetchResourceRoles,
     useFetchResources,
 } from '../../../lib/hooks'
-import type { UseFetchChallengeResult } from '../../../lib/hooks'
+import type {
+    UseFetchChallengeResult,
+    UseFetchProjectResult,
+} from '../../../lib/hooks'
 import {
     deleteChallenge,
     patchChallenge,
 } from '../../../lib/services'
 import {
+    checkProjectAccess,
     extractErrorMessage,
     getStatusText,
     isChallengeCompletedOrCancelled,
@@ -85,6 +90,7 @@ const CANCEL_CHALLENGE_STATUSES: string[] = [
 const NO_TASK_ASSIGNEE_MESSAGE = 'Task is not assigned yet'
 const MARK_COMPLETE_TOOLTIP_MESSAGE
     = 'This will close the task and generate a payment for the assignee and copilot.'
+const PROJECT_ACCESS_DENIED_MESSAGE = 'You don’t have access to this project. Please contact support@topcoder.com.'
 
 interface EditorTabsProps {
     activeTab: EditorTab
@@ -122,6 +128,8 @@ interface ChallengeEditorBodyProps {
     canLaunchChallenge: boolean
     challengeId?: string
     challengeResult: UseFetchChallengeResult
+    isProjectAccessDenied: boolean
+    isProjectAccessLoading: boolean
     isExistingChallenge: boolean
     isLaunchDisabled: boolean
     isReadOnly: boolean
@@ -140,6 +148,75 @@ interface ChallengeEditorBodyProps {
 
 interface ChallengeQuickLinksProps {
     challenge: UseFetchChallengeResult['challenge']
+}
+
+interface ChallengeProjectAccessParams {
+    hasChallengeProjectMismatch: boolean
+    isProjectLoading: boolean
+    project?: UseFetchProjectResult['project']
+    projectError?: Error
+    projectId?: string
+    userId?: number | string
+    userRoles: string[]
+}
+
+interface ChallengeProjectAccessState {
+    isDenied: boolean
+    isLoading: boolean
+}
+
+/**
+ * Normalizes a project identifier from route, challenge, or created challenge data.
+ *
+ * @param projectId project id value that may be a number, string, or absent.
+ * @returns trimmed project id text when present; otherwise `undefined`.
+ */
+function normalizeProjectId(projectId: number | string | undefined): string | undefined {
+    if (projectId === undefined || projectId === null) {
+        return undefined
+    }
+
+    const normalizedProjectId = String(projectId)
+        .trim()
+
+    return normalizedProjectId || undefined
+}
+
+/**
+ * Resolves whether challenge editor content can render for a project-owned challenge.
+ *
+ * @param params project lookup, route/challenge ownership, and caller identity state.
+ * @returns loading and denied flags used to hide challenge details until access is confirmed.
+ */
+function resolveChallengeProjectAccess(
+    params: ChallengeProjectAccessParams,
+): ChallengeProjectAccessState {
+    if (!params.projectId) {
+        return {
+            isDenied: params.hasChallengeProjectMismatch,
+            isLoading: false,
+        }
+    }
+
+    if (params.isProjectLoading) {
+        return {
+            isDenied: false,
+            isLoading: true,
+        }
+    }
+
+    const hasProjectAccess = checkProjectAccess(
+        params.userRoles,
+        params.userId,
+        params.project,
+    )
+
+    return {
+        isDenied: params.hasChallengeProjectMismatch
+            || !!params.projectError
+            || !hasProjectAccess,
+        isLoading: false,
+    }
 }
 
 function getErrorMessage(error: Error | undefined): string {
@@ -861,6 +938,14 @@ const ChallengeEditorContent: FC<ChallengeEditorContentProps> = (
 const ChallengeEditorBody: FC<ChallengeEditorBodyProps> = (
     props: ChallengeEditorBodyProps,
 ) => {
+    if (props.isProjectAccessLoading) {
+        return <LoadingSpinner />
+    }
+
+    if (props.isProjectAccessDenied) {
+        return <ErrorMessage message={PROJECT_ACCESS_DENIED_MESSAGE} />
+    }
+
     if (props.challengeResult.isLoading) {
         return <LoadingSpinner />
     }
@@ -963,7 +1048,7 @@ export const ChallengeEditorPage: FC = () => {
     const params: Readonly<{ challengeId?: string; projectId?: string }>
         = useParams<'challengeId' | 'projectId'>()
     const challengeId = params.challengeId
-    const routeProjectId = params.projectId
+    const routeProjectId = normalizeProjectId(params.projectId)
 
     const isExistingChallenge = !!challengeId
     const isViewMode = isChallengeEditorViewPath(location.pathname)
@@ -976,7 +1061,23 @@ export const ChallengeEditorPage: FC = () => {
     const [createdChallenge, setCreatedChallenge] = useState<CreatedChallengeState | undefined>()
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
     const [showLaunchModal, setShowLaunchModal] = useState<boolean>(false)
-    const challengeResult: UseFetchChallengeResult = useFetchChallenge(challengeId)
+    const workAppContext = useContext(WorkAppContext)
+    const routeProjectResult: UseFetchProjectResult = useFetchProject(routeProjectId)
+    const canFetchProjectRouteChallenge = !routeProjectId
+        || (
+            !routeProjectResult.isLoading
+            && !routeProjectResult.error
+            && checkProjectAccess(
+                workAppContext.userRoles,
+                workAppContext.loginUserInfo?.userId,
+                routeProjectResult.project,
+            )
+        )
+    const challengeResult: UseFetchChallengeResult = useFetchChallenge(
+        canFetchProjectRouteChallenge
+            ? challengeId
+            : undefined,
+    )
     const [
         challengeStatus,
         handleChallengeStatusChange,
@@ -1013,12 +1114,13 @@ export const ChallengeEditorPage: FC = () => {
         handleChallengeStatusChange(challenge.status)
     }, [handleChallengeStatusChange])
 
-    const challengeProjectId = challengeResult.challenge?.projectId
-        ? String(challengeResult.challenge.projectId)
-        : undefined
-    const createdChallengeProjectId = createdChallenge?.projectId
-        ? String(createdChallenge.projectId)
-        : undefined
+    const challengeProjectId = normalizeProjectId(challengeResult.challenge?.projectId)
+    const createdChallengeProjectId = normalizeProjectId(createdChallenge?.projectId)
+    const challengeProjectResult: UseFetchProjectResult = useFetchProject(
+        routeProjectId
+            ? undefined
+            : challengeProjectId,
+    )
     const projectId = routeProjectId || challengeProjectId || createdChallengeProjectId
     const persistedChallengeId = challengeId || createdChallenge?.id
     const isCreatedChallenge = !isExistingChallenge && !!createdChallenge?.id
@@ -1051,11 +1153,6 @@ export const ChallengeEditorPage: FC = () => {
         }
     }, [challengeId])
 
-    const pageTitle = getChallengeEditorPageTitle(
-        challengeId,
-        isViewMode,
-        challengeResult.challenge?.name,
-    )
     const hasSuccessfulCurrentChallengeFetch = !isExistingChallenge
         || (
             !challengeResult.isError
@@ -1197,21 +1294,51 @@ export const ChallengeEditorPage: FC = () => {
 
         navigate(editChallengePath)
     }, [editChallengePath, navigate])
+    const projectAccessResult = routeProjectId
+        ? routeProjectResult
+        : challengeProjectResult
+    const hasChallengeProjectMismatch = !!routeProjectId
+        && !!challengeProjectId
+        && routeProjectId !== challengeProjectId
+    const projectAccessState = resolveChallengeProjectAccess({
+        hasChallengeProjectMismatch,
+        isProjectLoading: projectAccessResult.isLoading,
+        project: projectAccessResult.project,
+        projectError: projectAccessResult.error,
+        projectId,
+        userId: workAppContext.loginUserInfo?.userId,
+        userRoles: workAppContext.userRoles,
+    })
+    const canRenderChallengeDetails = !projectAccessState.isDenied && !projectAccessState.isLoading
+    const pageTitle = getChallengeEditorPageTitle(
+        challengeId,
+        isViewMode,
+        canRenderChallengeDetails
+            ? challengeResult.challenge?.name
+            : undefined,
+    )
     const challengeQuickLinks = renderChallengeQuickLinks({
-        challenge: currentChallenge,
+        challenge: canRenderChallengeDetails
+            ? currentChallenge
+            : undefined,
     })
     const canEditChallenge = hasSuccessfulCurrentChallengeFetch
+        && canRenderChallengeDetails
         && isViewMode
         && !!editChallengePath
         && !isChallengeCompletedOrCancelled(effectiveChallengeStatus)
     const rightHeader = renderHeaderAction({
-        canCancelChallenge,
-        canCompleteTask,
-        canDeleteChallenge,
+        canCancelChallenge: canRenderChallengeDetails && canCancelChallenge,
+        canCompleteTask: canRenderChallengeDetails && canCompleteTask,
+        canDeleteChallenge: canRenderChallengeDetails && canDeleteChallenge,
         canEditChallenge,
-        canLaunchChallenge,
-        challenge: headerChallenge,
-        challengeId: persistedChallengeId,
+        canLaunchChallenge: canRenderChallengeDetails && canLaunchChallenge,
+        challenge: canRenderChallengeDetails
+            ? headerChallenge
+            : undefined,
+        challengeId: canRenderChallengeDetails
+            ? persistedChallengeId
+            : undefined,
         challengeName: launchChallengeName,
         challengeQuickLinks,
         isDeleting,
@@ -1223,7 +1350,7 @@ export const ChallengeEditorPage: FC = () => {
         onLaunchOpen: handleLaunchOpen,
     })
     const deleteModal = renderDeleteModal({
-        canDeleteChallenge,
+        canDeleteChallenge: canRenderChallengeDetails && canDeleteChallenge,
         challengeName: deleteChallengeName,
         isDeleting,
         onDeleteCancel: handleDeleteCancel,
@@ -1231,7 +1358,7 @@ export const ChallengeEditorPage: FC = () => {
         showDeleteModal,
     })
     const launchModal = renderLaunchModal({
-        canLaunchChallenge,
+        canLaunchChallenge: canRenderChallengeDetails && canLaunchChallenge,
         challengeName: launchChallengeName,
         isLaunching,
         onLaunchCancel: handleLaunchCancel,
@@ -1239,18 +1366,22 @@ export const ChallengeEditorPage: FC = () => {
         showLaunchModal,
     })
     const titleAction = renderTitleAction(
-        (isExistingChallenge && hasSuccessfulCurrentChallengeFetch) || isCreatedChallenge,
+        canRenderChallengeDetails
+            && ((isExistingChallenge && hasSuccessfulCurrentChallengeFetch) || isCreatedChallenge),
         effectiveChallengeStatus,
     )
     const launchButtonLabel = isLaunching
         ? 'Launching...'
         : 'Launch'
     const isLaunchDisabled = isLaunching || isSavingChallenge
+    const backUrl = canRenderChallengeDetails
+        ? challengesListPath
+        : getChallengesListPath()
 
     return (
         <>
             <PageWrapper
-                backUrl={challengesListPath}
+                backUrl={backUrl}
                 breadCrumb={[]}
                 pageTitle={pageTitle}
                 rightHeader={rightHeader}
@@ -1262,6 +1393,8 @@ export const ChallengeEditorPage: FC = () => {
                         canLaunchChallenge={canLaunchChallenge}
                         challengeId={challengeId}
                         challengeResult={challengeResult}
+                        isProjectAccessDenied={projectAccessState.isDenied}
+                        isProjectAccessLoading={projectAccessState.isLoading}
                         isExistingChallenge={isExistingChallenge}
                         isLaunchDisabled={isLaunchDisabled}
                         isReadOnly={isViewMode}


### PR DESCRIPTION
What was broken
Unauthorized Work Manager users could still open direct challenge edit or view URLs for projects they could not access, even though direct project challenge list URLs were already blocked.

Root cause
The previous fix guarded the project-scoped challenges list fetch, but ChallengeEditorPage fetched and rendered individual challenge details without confirming project membership first.

What was changed
ChallengeEditorPage now checks project access with the existing checkProjectAccess helper before rendering challenge details. Project-scoped challenge routes wait for project access before fetching the challenge, unscoped challenge routes hide details until the challenge project is verified, and mismatched project/challenge routes are denied.

Any added/updated tests
Updated ChallengeEditorPage tests to cover denied project-scoped challenge views and denied unscoped challenge views after resolving the challenge project.

Validation run:
- yarn test:no-watch src/apps/work/src/lib/utils/permissions.utils.spec.ts src/apps/work/src/pages/challenges/ChallengesListPage/ChallengesListPage.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch --silent was run and still fails in the unrelated wallet-admin PaymentView assertion expecting a challenge URL while receiving a project URL.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
