### PR TITLE
PM-4959: Link billing account engagement names

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -85,6 +85,7 @@ function renderModal(
 
 describe('BillingAccountLineItemsModal', () => {
     beforeEach(() => {
+        mockedUseFetchEngagements.mockReset()
         mockedUseFetchEngagements.mockReturnValue({
             engagements: [],
             error: undefined,
@@ -225,6 +226,12 @@ describe('BillingAccountLineItemsModal', () => {
 
         expect(engagementLink.getAttribute('href'))
             .toBe('/work/projects/project%20200/engagements/engagement-300')
+        expect(mockedUseFetchEngagements)
+            .toHaveBeenLastCalledWith(
+                'project 200',
+                { includePrivate: true },
+                { enabled: true },
+            )
     })
 
     it('builds engagement links from assignment-backed billing rows for copilot views', () => {
@@ -300,6 +307,12 @@ describe('BillingAccountLineItemsModal', () => {
 
         expect(engagementLink.getAttribute('href'))
             .toBe('/work/projects/project%20200/engagements/engagement-300')
+        expect(mockedUseFetchEngagements)
+            .toHaveBeenLastCalledWith(
+                'project 200',
+                { includePrivate: true },
+                { enabled: true },
+            )
     })
 
     it('renders legacy-only challenge rows as plain text', () => {

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -36,7 +36,9 @@ interface BillingAccountModalLineItem extends BillingAccountLineItem {
     displayAmount?: number
 }
 
-const EMPTY_ENGAGEMENT_FILTERS = {}
+const ENGAGEMENT_ASSIGNMENT_FILTERS = {
+    includePrivate: true,
+}
 
 const EXTERNAL_TYPE_LABELS: Record<BillingAccountLineItem['externalType'], string> = {
     CHALLENGE: 'Challenge',
@@ -364,7 +366,7 @@ export const BillingAccountLineItemsModal: FC<BillingAccountLineItemsModalProps>
     const showChallengeFeeColumn = !props.showMemberPaymentsRemaining
     const engagementResult = useFetchEngagements(
         normalizedProjectId,
-        EMPTY_ENGAGEMENT_FILTERS,
+        ENGAGEMENT_ASSIGNMENT_FILTERS,
         {
             enabled: !!normalizedProjectId && hasEngagementLineItems,
         },


### PR DESCRIPTION
What was broken
Engagement rows in the billing account details popup could render as plain text even though challenge rows linked to their details pages.

Root cause
The modal resolved engagement URLs from assignment ids, but it fetched project engagements without the includePrivate flag needed for the assignment data that builds that lookup.

What was changed
Fetch engagement data with includePrivate enabled whenever the modal has engagement line items and a project id, preserving the existing challenge link behavior.

Any added/updated tests
Updated BillingAccountLineItemsModal regression tests to verify the engagement lookup is requested with includePrivate and still produces engagement links in standard and copilot views.

Validation run:
- yarn test:no-watch BillingAccountLineItemsModal passed.
- yarn lint passed.
- yarn run build passed with existing CSS/order and lint warnings emitted during build.
- yarn test:no-watch was run and failed in existing unrelated wallet-admin PaymentView.spec.tsx, where the task-payment project link expected a challenge URL but rendered the project URL.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
