### PR TITLE
PM-4945: Preserve work tab state on new-tab clicks

### DIFF
--- a/src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx
+++ b/src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx
@@ -98,4 +98,22 @@ describe('NavTabs', () => {
         expect(screen.getByTestId('location-pathname').textContent)
             .toBe('/projects')
     })
+
+    it('leaves the current tab active when a menu link is opened with a modifier click', () => {
+        renderNavTabs('/challenges')
+
+        fireEvent.click(screen.getByRole('link', { name: 'Projects' }), {
+            ctrlKey: true,
+        })
+
+        expect(screen.getByTestId('location-pathname').textContent)
+            .toBe('/challenges')
+        expect(screen.getByRole('link', { name: 'Challenges' })
+            .closest('li')?.className)
+            .toContain('active')
+        expect(screen.getByRole('link', { name: 'Projects' })
+            .closest('li')?.className)
+            .not
+            .toContain('active')
+    })
 })

--- a/src/apps/work/src/lib/components/NavTabs/NavTabs.tsx
+++ b/src/apps/work/src/lib/components/NavTabs/NavTabs.tsx
@@ -57,6 +57,16 @@ const NavTabs: FC = () => {
 
     const handleTabClick = useCallback(
         (event: MouseEvent<HTMLAnchorElement>) => {
+            if (
+                event.button !== 0
+                || event.altKey
+                || event.ctrlKey
+                || event.metaKey
+                || event.shiftKey
+            ) {
+                return
+            }
+
             const { tabId }: { tabId?: string } = event.currentTarget.dataset
 
             if (!tabId) {


### PR DESCRIPTION
What was broken
The prior PM-4945 fix made the work menu href-backed, but modifier-clicking an internal menu link to open it in a new tab still ran the current-page click handler and changed the active tab state in the original tab.

Root cause
NavTabs treated every anchor click as current-tab navigation and updated active state before React Router's Link could ignore modified clicks.

What was changed
NavTabs now ignores modified or non-left clicks in the internal tab handler, leaving browser link actions to behave like normal links while preserving plain left-click navigation.

Any added/updated tests
Updated NavTabs tests to cover ctrl-click/new-tab behavior, confirming the current route and active tab stay unchanged. Validation run: yarn lint; yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/NavTabs/NavTabs.spec.tsx; yarn test:no-watch; yarn test:no-watch --runTestsByPath src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx; yarn run build. The full test command remains blocked by the existing unrelated wallet-admin PaymentView.spec.tsx URL expectation.
