### PR TITLE
PM-4973: Restrict project user management actions

### DIFF
--- a/src/apps/work/src/pages/users/UsersManagementPage/UsersManagementPage.spec.tsx
+++ b/src/apps/work/src/pages/users/UsersManagementPage/UsersManagementPage.spec.tsx
@@ -96,7 +96,6 @@ jest.mock('../../../lib/services', () => ({
 }))
 jest.mock('../../../lib/utils', () => ({
     checkCanManageProject: jest.fn(() => true),
-    checkIsCopilotOrManager: jest.fn(() => false),
     showErrorToast: jest.fn(),
     showSuccessToast: jest.fn(),
 }))
@@ -209,6 +208,48 @@ describe('UsersManagementPage', () => {
             .getByText('Project Status: active'))
             .toBeTruthy()
         expect(screen.queryByTestId('page-back-link'))
+            .toBeNull()
+    })
+
+    it('hides member management actions when a global manager role cannot manage the project', () => {
+        mockedCheckCanManageProject.mockReturnValue(false)
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+            project: {
+                id: 200,
+                name: 'Restricted Project',
+                status: 'active',
+            },
+        })
+
+        renderPage('/projects/200/users', {
+            ...defaultContextValue,
+            isAdmin: false,
+            isManager: true,
+            loginUserInfo: {
+                email: 'manager@example.com',
+                exp: 0,
+                handle: 'manager-user',
+                iat: 0,
+                roles: ['project manager'],
+                userId: 12345,
+            } as WorkAppContextModel['loginUserInfo'],
+            userRoles: ['project manager'],
+        })
+
+        const pageRightHeader = screen.getByTestId('page-right-header')
+        const pageTitleAction = screen.getByTestId('page-title-action')
+
+        expect(within(pageRightHeader)
+            .queryByRole('button', { name: 'Add User' }))
+            .toBeNull()
+        expect(within(pageRightHeader)
+            .queryByRole('button', { name: 'Invite User' }))
+            .toBeNull()
+        expect(within(pageTitleAction)
+            .queryByRole('link', { name: 'Edit project' }))
             .toBeNull()
     })
 })

--- a/src/apps/work/src/pages/users/UsersManagementPage/UsersManagementPage.tsx
+++ b/src/apps/work/src/pages/users/UsersManagementPage/UsersManagementPage.tsx
@@ -39,7 +39,6 @@ import {
 } from '../../../lib/services'
 import {
     checkCanManageProject,
-    checkIsCopilotOrManager,
     showErrorToast,
     showSuccessToast,
 } from '../../../lib/utils'
@@ -98,9 +97,6 @@ export const UsersManagementPage: FC = () => {
     const [showInviteUserModal, setShowInviteUserModal] = useState<boolean>(false)
 
     const {
-        isAdmin,
-        isCopilot,
-        isManager,
         loginUserInfo,
         userRoles,
     }: WorkAppContextModel = useContext(WorkAppContext)
@@ -116,15 +112,13 @@ export const UsersManagementPage: FC = () => {
 
     const selectedProjectName = toOptionalString(projectResult.project?.name)
     const pageTitle = selectedProjectName || 'Project users'
-    const loginHandle = loginUserInfo?.handle || ''
-    const canManageMembers = (isAdmin || isCopilot || isManager)
-        || checkIsCopilotOrManager(members, loginHandle)
     const canManageProject = !!projectResult.project
         && checkCanManageProject(
             userRoles,
             loginUserInfo?.userId,
             projectResult.project,
         )
+    const canManageMembers = canManageProject
 
     const hasMembers = members.length > 0
     const hasDeclinedInvites = declinedInvites.length > 0
@@ -392,7 +386,7 @@ export const UsersManagementPage: FC = () => {
                 )
                 : undefined}
 
-            {showAddUserModal && projectId
+            {showAddUserModal && projectId && canManageMembers
                 ? (
                     <AddUserModal
                         onClose={closeAddUserModal}
@@ -404,7 +398,7 @@ export const UsersManagementPage: FC = () => {
                 )
                 : undefined}
 
-            {showInviteUserModal && projectId
+            {showInviteUserModal && projectId && canManageMembers
                 ? (
                     <InviteUserModal
                         invitedMembers={invites}


### PR DESCRIPTION
What was broken

Work Manager users with global Copilot, Project Manager, or Talent Manager access could open a project users URL directly and still get member-management controls for a project they could not manage.

Root cause (if identifiable)

The users page enabled add, invite, remove, and role-edit controls from global Work Manager role flags instead of requiring manage access to the loaded project.

What was changed

The users page now derives member-management permission from the existing project management access helper for the loaded project. The same permission guards the header actions, editable member cards, and add/invite modal rendering.

Any added/updated tests

Added a UsersManagementPage regression test that verifies a global Project Manager who cannot manage the loaded project does not see add, invite, or edit controls.

Validation:

- `yarn test:no-watch --runTestsByPath src/apps/work/src/pages/users/UsersManagementPage/UsersManagementPage.spec.tsx` passed.
- `yarn lint` passed.
- `yarn run build` passed with existing warnings.
- `yarn test:no-watch` still fails in `src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx`, and that spec also fails when run by itself. The failure expects a challenge URL but receives a project URL, outside the PM-4973 users-page change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/platform-ui/pull/1789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
