### PR TITLE
PM-4962: Block expired or inactive BA payments

### DIFF
--- a/src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts
@@ -7,6 +7,8 @@ import {
     getCopilotMemberPaymentsBudgetInfo,
     getProjectBillingAccountChallengeErrorMessage,
     getProjectBillingAccountChallengeIssue,
+    getProjectBillingAccountEngagementPaymentErrorMessage,
+    getProjectBillingAccountEngagementPaymentIssue,
     getProjectBillingAccountNoticeMessage,
 } from './project-billing-account.utils'
 
@@ -30,10 +32,14 @@ describe('project-billing-account challenge gating helpers', () => {
 
         expect(getProjectBillingAccountChallengeIssue(billingAccount))
             .toBe('inactive')
+        expect(getProjectBillingAccountEngagementPaymentIssue(billingAccount))
+            .toBe('inactive')
         expect(getProjectBillingAccountNoticeMessage('inactive'))
             .toBe('The billing account for this project is inactive.')
         expect(getProjectBillingAccountChallengeErrorMessage('inactive'))
             .toBe('Cannot launch challenges because the project billing account is inactive.')
+        expect(getProjectBillingAccountEngagementPaymentErrorMessage('inactive'))
+            .toBe('Cannot create engagement payments because the project billing account is inactive.')
     })
 
     it('treats expired billing accounts as blocked for challenges', () => {
@@ -45,6 +51,10 @@ describe('project-billing-account challenge gating helpers', () => {
 
         expect(getProjectBillingAccountChallengeIssue(billingAccount))
             .toBe('expired')
+        expect(getProjectBillingAccountEngagementPaymentIssue(billingAccount))
+            .toBe('expired')
+        expect(getProjectBillingAccountEngagementPaymentErrorMessage('expired'))
+            .toBe('Cannot create engagement payments because the project billing account is expired.')
     })
 
     it('treats depleted billing accounts as blocked for challenges', () => {

--- a/src/apps/work/src/lib/utils/project-billing-account.utils.ts
+++ b/src/apps/work/src/lib/utils/project-billing-account.utils.ts
@@ -1,6 +1,7 @@
 import type { ProjectBillingAccount } from '../services'
 
 type ProjectBillingAccountChallengeIssue = 'expired' | 'inactive' | 'insufficient-funds' | 'missing'
+type ProjectBillingAccountEngagementPaymentIssue = 'expired' | 'inactive'
 export type BillingAccountBudgetStatus = 'healthy' | 'warning' | 'critical'
 
 export interface BillingAccountBudgetSource {
@@ -334,6 +335,31 @@ export function getProjectBillingAccountChallengeIssue(
 }
 
 /**
+ * Resolves whether a project billing account should block engagement payment creation.
+ *
+ * @param billingAccount Project billing-account payload resolved in the work app.
+ * @returns The lifecycle blocking reason, or `undefined` when engagement payments can proceed.
+ * @remarks Engagement payments are blocked only by billing-account lifecycle
+ * state here. Missing billing account ids are handled by the payment submission
+ * flow because it can fall back to the project payload id.
+ */
+export function getProjectBillingAccountEngagementPaymentIssue(
+    billingAccount: ProjectBillingAccount | undefined,
+): ProjectBillingAccountEngagementPaymentIssue | undefined {
+    const active = resolveBillingAccountActive(billingAccount)
+
+    if (active === false) {
+        return 'inactive'
+    }
+
+    if (isBillingAccountExpired(billingAccount)) {
+        return 'expired'
+    }
+
+    return undefined
+}
+
+/**
  * Builds the project-page notice text for an invalid billing account.
  *
  * @param issue The billing-account challenge issue that should be shown to the user.
@@ -379,5 +405,26 @@ export function getProjectBillingAccountChallengeErrorMessage(
             return 'Cannot launch challenges because the project billing account has insufficient remaining funds.'
         default:
             return 'Cannot launch challenges because the project billing account is invalid.'
+    }
+}
+
+/**
+ * Builds the payment-time error message for an invalid billing account lifecycle state.
+ *
+ * @param issue The billing-account lifecycle issue that should block engagement payment creation.
+ * @returns The message shown when the work app blocks an engagement payment attempt.
+ * @remarks Used by the engagement assignment payment flow so users get a clear
+ * failure reason before any finance API call is attempted.
+ */
+export function getProjectBillingAccountEngagementPaymentErrorMessage(
+    issue: ProjectBillingAccountEngagementPaymentIssue,
+): string {
+    switch (issue) {
+        case 'inactive':
+            return 'Cannot create engagement payments because the project billing account is inactive.'
+        case 'expired':
+            return 'Cannot create engagement payments because the project billing account is expired.'
+        default:
+            return 'Cannot create engagement payments because the project billing account is invalid.'
     }
 }

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.spec.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.spec.tsx
@@ -26,6 +26,9 @@ import {
 import {
     partiallyUpdateEngagement,
 } from '../../../lib/services'
+import {
+    showErrorToast,
+} from '../../../lib/utils'
 
 import {
     EditAssignmentModal,
@@ -69,7 +72,11 @@ jest.mock('../../../lib/components', () => ({
     CompleteAssignmentModal: (): JSX.Element => <></>,
     ErrorMessage: (props: { message: string }): JSX.Element => <div>{props.message}</div>,
     LoadingSpinner: (): JSX.Element => <div>Loading</div>,
-    PaymentFormModal: (): JSX.Element => <></>,
+    PaymentFormModal: (props: { open: boolean }): JSX.Element => (
+        props.open
+            ? <div>Create Payment</div>
+            : <></>
+    ),
     PaymentHistoryModal: (): JSX.Element => <></>,
     TerminateAssignmentModal: (): JSX.Element => <></>,
 }))
@@ -184,6 +191,7 @@ const mockedUseFetchProjectBillingAccount = useFetchProjectBillingAccount as jes
 const mockedPartiallyUpdateEngagement = partiallyUpdateEngagement as jest.MockedFunction<
     typeof partiallyUpdateEngagement
 >
+const mockedShowErrorToast = showErrorToast as jest.MockedFunction<typeof showErrorToast>
 
 beforeEach(() => {
     jest.clearAllMocks()
@@ -345,6 +353,107 @@ describe('EngagementPaymentPage', () => {
                     memberHandle: 'finished_member',
                 }),
             ]))
+    })
+
+    it('blocks payment creation when the project billing account is expired', () => {
+        mockedUseFetchEngagement.mockReturnValue({
+            engagement: {
+                assignments: [assignment],
+                title: 'Test Engagement',
+            },
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            mutate: jest.fn(),
+        } as unknown as ReturnType<typeof useFetchEngagement>)
+
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+            project: {
+                billingAccountId: 'billing-account-1',
+                name: 'Test Project',
+            },
+        } as unknown as ReturnType<typeof useFetchProject>)
+
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: {
+                active: true,
+                endDate: '2000-01-01T00:00:00.000Z',
+                id: 'billing-account-1',
+                markup: 0.15,
+            },
+            isLoading: false,
+        } as unknown as ReturnType<typeof useFetchProjectBillingAccount>)
+
+        render(
+            <MemoryRouter initialEntries={['/projects/project-1/engagements/engagement-1/assignments']}>
+                <Routes>
+                    <Route
+                        element={<EngagementPaymentPage />}
+                        path='/projects/:projectId/engagements/:engagementId/assignments'
+                    />
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Pay' }))
+
+        expect(mockedShowErrorToast)
+            .toHaveBeenCalledWith('Cannot create engagement payments because the project billing account is expired.')
+        expect(screen.queryByText('Create Payment'))
+            .toBeNull()
+    })
+
+    it('blocks payment creation when the project billing account is inactive', () => {
+        mockedUseFetchEngagement.mockReturnValue({
+            engagement: {
+                assignments: [assignment],
+                title: 'Test Engagement',
+            },
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            mutate: jest.fn(),
+        } as unknown as ReturnType<typeof useFetchEngagement>)
+
+        mockedUseFetchProject.mockReturnValue({
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+            project: {
+                billingAccountId: 'billing-account-1',
+                name: 'Test Project',
+            },
+        } as unknown as ReturnType<typeof useFetchProject>)
+
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: {
+                active: false,
+                id: 'billing-account-1',
+                markup: 0.15,
+            },
+            isLoading: false,
+        } as unknown as ReturnType<typeof useFetchProjectBillingAccount>)
+
+        render(
+            <MemoryRouter initialEntries={['/projects/project-1/engagements/engagement-1/assignments']}>
+                <Routes>
+                    <Route
+                        element={<EngagementPaymentPage />}
+                        path='/projects/:projectId/engagements/:engagementId/assignments'
+                    />
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Pay' }))
+
+        expect(mockedShowErrorToast)
+            .toHaveBeenCalledWith('Cannot create engagement payments because the project billing account is inactive.')
+        expect(screen.queryByText('Create Payment'))
+            .toBeNull()
     })
 })
 

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
@@ -61,10 +61,16 @@ import {
     toPositiveNumber,
     toPositiveNumberWithMaxDecimalPlaces,
 } from '../../../lib/utils'
+import {
+    getProjectBillingAccountEngagementPaymentErrorMessage,
+    getProjectBillingAccountEngagementPaymentIssue,
+} from '../../../lib/utils/project-billing-account.utils'
 import { formatCurrency } from '../../../lib/utils/payment.utils'
 import { ReactComponent as IconComment } from '../../../lib/assets/icons/icon-comment.svg'
 
 import styles from './EngagementPaymentPage.module.scss'
+
+const BILLING_ACCOUNT_DETAILS_LOADING_PAYMENT_MESSAGE = 'Billing account details are still loading. Please try again.'
 
 function formatDate(value?: string): string {
     if (!value) {
@@ -595,6 +601,12 @@ export const EngagementPaymentPage: FC = () => {
     const pageTitle = engagementResult.engagement?.title
         ? `${engagementResult.engagement.title} Assignees`
         : 'Assignees'
+    const billingAccountPaymentIssue = getProjectBillingAccountEngagementPaymentIssue(
+        projectBillingAccountResult.billingAccount,
+    )
+    const billingAccountPaymentErrorMessage = billingAccountPaymentIssue
+        ? getProjectBillingAccountEngagementPaymentErrorMessage(billingAccountPaymentIssue)
+        : undefined
     const backUrl = useMemo(() => {
         const locationState = location.state as AssignmentsLocationState | null
         const stateBackUrl = String(locationState?.backUrl || '')
@@ -613,6 +625,16 @@ export const EngagementPaymentPage: FC = () => {
         data: PaymentFormData,
     ): Promise<void> => {
         if (!paymentMember) {
+            return
+        }
+
+        if (projectBillingAccountResult.isLoading) {
+            showErrorToast(BILLING_ACCOUNT_DETAILS_LOADING_PAYMENT_MESSAGE)
+            return
+        }
+
+        if (billingAccountPaymentErrorMessage) {
+            showErrorToast(billingAccountPaymentErrorMessage)
             return
         }
 
@@ -654,10 +676,26 @@ export const EngagementPaymentPage: FC = () => {
             setIsSubmittingPayment(false)
         }
     }, [
+        billingAccountPaymentErrorMessage,
         paymentMember,
         projectBillingAccountResult.billingAccount?.id,
+        projectBillingAccountResult.isLoading,
         projectResult.project?.billingAccountId,
     ])
+
+    const handlePayClick = useCallback((assignment: Assignment): void => {
+        if (projectBillingAccountResult.isLoading) {
+            showErrorToast(BILLING_ACCOUNT_DETAILS_LOADING_PAYMENT_MESSAGE)
+            return
+        }
+
+        if (billingAccountPaymentErrorMessage) {
+            showErrorToast(billingAccountPaymentErrorMessage)
+            return
+        }
+
+        setPaymentMember(assignment)
+    }, [billingAccountPaymentErrorMessage, projectBillingAccountResult.isLoading])
 
     const handleTerminateConfirm = useCallback(async (reason: string): Promise<void> => {
         if (!terminateMember) {
@@ -939,7 +977,7 @@ export const EngagementPaymentPage: FC = () => {
                                                             />
                                                             <Button
                                                                 label='Pay'
-                                                                onClick={() => setPaymentMember(assignment)}
+                                                                onClick={() => handlePayClick(assignment)}
                                                                 variant='linkblue'
                                                                 primary
                                                                 size='sm'


### PR DESCRIPTION
What was broken
Engagement assignment payments could still be started and submitted when the project billing account was expired or inactive.

Root cause
The engagement payment page only verified that a billing account id existed before calling the finance payment API. It did not check the billing account lifecycle state that the Work app already uses for other project actions.

What was changed
Added engagement-payment-specific billing account lifecycle helpers and messages.
Blocked the Pay action and payment submit path when the project billing account is expired, inactive, or still loading.

Any added/updated tests
Added project billing account utility expectations for engagement payment gating.
Added EngagementPaymentPage coverage for expired and inactive project billing accounts.

Validation
Passed: yarn test:no-watch --runTestsByPath src/apps/work/src/lib/utils/project-billing-account.utils.spec.ts src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.spec.tsx
Passed: yarn lint
Passed: yarn run build
Failed: yarn test:no-watch has existing unrelated failures in src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.spec.tsx and src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx. The same two specs fail when run directly.
