### PR TITLE
PM-4971: Left align member payments header

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.module.scss
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.module.scss
@@ -216,6 +216,7 @@
     font-weight: 600;
     gap: 4px;
     padding: 0;
+    text-align: left;
 }
 
 .sortButton:hover {


### PR DESCRIPTION
What was broken
The Member Payments column heading in the Billing Account Details modal wrapped with centered button text, so the label did not line up with the values in that column.

Root cause
The header is rendered as a sorting button, and the button did not override the browser's default centered text alignment when the label wraps.

What was changed
Set the billing-account modal sortable header button text alignment to left so wrapped labels align with the table column.

Any added/updated tests
No tests were added. This is a CSS-only alignment fix; the existing billing account modal spec was run for regression coverage.

Validation
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch currently fails in unrelated PaymentView and ChallengeEditorForm specs on origin/dev.
