### PR TITLE
PM-5003: Show BA spent totals for PMs

### DIFF
--- a/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx
@@ -279,6 +279,47 @@ describe('ProjectsTable', () => {
             .toHaveBeenCalledWith('80001063')
     })
 
+    it('loads billing account detail budgets for project managers when the list '
+        + 'lookup has no budget', () => {
+        mockedUseFetchBillingAccounts.mockReturnValue({
+            billingAccounts: [
+                {
+                    id: 80001063,
+                    name: 'Access BA',
+                },
+            ],
+            error: undefined,
+            isError: false,
+            isLoading: false,
+        })
+        mockedUseFetchBillingAccountDetails.mockImplementation(billingAccountId => ({
+            billingAccountDetails: billingAccountId === '80001063'
+                ? billingAccountDetails
+                : undefined,
+            error: undefined,
+            isError: false,
+            isLoading: false,
+        }))
+
+        renderTable(
+            [{
+                ...invitedProject,
+                billingAccountId: 80001063,
+                billingAccountName: 'Access BA',
+            }],
+            {
+                ...defaultContextValue,
+                isManager: true,
+                userRoles: ['Topcoder Project Manager'],
+            },
+        )
+
+        expect(screen.getAllByText('$350 / $1,000 spent').length)
+            .toBeGreaterThan(0)
+        expect(mockedUseFetchBillingAccountDetails)
+            .toHaveBeenCalledWith('80001063')
+    })
+
     it('shows member payments remaining for copilot project rows', () => {
         mockedUseFetchBillingAccounts.mockReturnValue({
             billingAccounts: [

--- a/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.tsx
+++ b/src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.tsx
@@ -408,7 +408,9 @@ function renderProjectBillingAccountModal(
 
 /**
  * Renders a project billing-account summary and lazily loads the line-item
- * modal only after the details button is opened.
+ * modal only after the details button is opened. When the list lookup does
+ * not include budget totals, it uses the billing-account detail payload as
+ * the inline budget fallback.
  *
  * @param props Project row and matching billing-account summary from the list API.
  * @returns Billing-account label, with budget and line-item details shown only when enabled.
@@ -420,16 +422,29 @@ const ProjectBillingAccountCell: FC<ProjectBillingAccountCellProps> = (
     const normalizedBillingAccountId = normalizeOptionalString(props.project.billingAccountId)
         || normalizeOptionalString(props.billingAccount?.id)
     const showDetailsButton = props.showPaymentAmounts
-    const billingAccountDetailsResult: UseFetchBillingAccountDetailsResult = useFetchBillingAccountDetails(
-        canFetchProjectBillingAccountDetails(isModalOpen, showDetailsButton)
-            ? normalizedBillingAccountId
-            : undefined,
-    )
-    const budgetDisplayState = getProjectBillingBudgetDisplayState(
+    const summaryBudgetDisplayState = getProjectBillingBudgetDisplayState(
         props.billingAccount,
         props.showPaymentAmounts,
         props.showMemberPaymentsRemaining,
     )
+    const shouldFetchBillingAccountDetailsForBudget = !!normalizedBillingAccountId
+        && props.showPaymentAmounts
+        && !summaryBudgetDisplayState.budgetInfo
+        && (BILLING_ACCOUNT_BUDGET_DISPLAY_ENABLED || props.showMemberPaymentsRemaining)
+    const billingAccountDetailsResult: UseFetchBillingAccountDetailsResult = useFetchBillingAccountDetails(
+        shouldFetchBillingAccountDetailsForBudget
+        || canFetchProjectBillingAccountDetails(isModalOpen, showDetailsButton)
+            ? normalizedBillingAccountId
+            : undefined,
+    )
+    const detailsBudgetDisplayState = getProjectBillingBudgetDisplayState(
+        billingAccountDetailsResult.billingAccountDetails,
+        props.showPaymentAmounts,
+        props.showMemberPaymentsRemaining,
+    )
+    const budgetDisplayState = summaryBudgetDisplayState.budgetInfo
+        ? summaryBudgetDisplayState
+        : detailsBudgetDisplayState
     const billingAccountBudget = renderProjectBillingAccountBudget(
         budgetDisplayState,
         props.showMemberPaymentsRemaining,


### PR DESCRIPTION
What was broken
Project Managers could see billing account names and detail buttons in the Work projects list, but rows did not show the spent / total budget amount when the shared billing-account list lookup did not include budget totals for that PM.

Root cause
The projects table rendered inline budget amounts only from the /billing-accounts list lookup. Project Managers can read project-assigned billing-account details by id, but the list lookup can omit those budget fields because it is limited to accounts granted directly to the PM user.

What was changed
ProjectsTable now uses the existing billing-account detail request as a fallback for inline budget rendering when the list summary lacks budget data. It still prefers list summary budgets when available and keeps the existing modal/detail behavior.

Any added/updated tests
Added a ProjectsTable regression test that covers a Project Manager row where the billing-account list result has no budget totals and verifies that the spent / total amount is rendered from the detail payload.

Validation run:
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/ProjectsTable/ProjectsTable.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing CSS/order and lint warnings emitted by the production build.
- yarn test:no-watch was run and currently fails in unrelated ChallengeEditorForm launch tests; rerunning that spec alone reproduces the same failures without PM-5003 files involved.
