### PR TITLE
PM-4989: Add billing account details to payment history

### DIFF
--- a/src/apps/work/src/lib/components/PaymentHistoryModal/PaymentHistoryModal.spec.tsx
+++ b/src/apps/work/src/lib/components/PaymentHistoryModal/PaymentHistoryModal.spec.tsx
@@ -64,6 +64,8 @@ describe('PaymentHistoryModal', () => {
                     createdByHandle: 'payment.manager',
                     details: [
                         {
+                            billingAccount: '80001063',
+                            billingAccountName: 'BA For Marios',
                             challengeFee: 18.6,
                             grossAmount: 120,
                             totalAmount: 120,
@@ -99,6 +101,14 @@ describe('PaymentHistoryModal', () => {
         expect(screen.getByText('Fee:'))
             .toBeTruthy()
         expect(screen.getByText('$18.60'))
+            .toBeTruthy()
+        expect(screen.getByText('BA ID:'))
+            .toBeTruthy()
+        expect(screen.getByText('80001063'))
+            .toBeTruthy()
+        expect(screen.getByText('BA Name:'))
+            .toBeTruthy()
+        expect(screen.getByText('BA For Marios'))
             .toBeTruthy()
     })
 })

--- a/src/apps/work/src/lib/components/PaymentHistoryModal/PaymentHistoryModal.tsx
+++ b/src/apps/work/src/lib/components/PaymentHistoryModal/PaymentHistoryModal.tsx
@@ -14,6 +14,8 @@ import {
 import {
     formatCurrency,
     getPaymentAmount,
+    getPaymentBillingAccountId,
+    getPaymentBillingAccountName,
     getPaymentChallengeFee,
     getPaymentCreatorLabel,
     getPaymentHoursWorked,
@@ -46,6 +48,45 @@ function formatDate(value?: string): string {
         month: 'short',
         year: 'numeric',
     })
+}
+
+/**
+ * Renders billing account ID and name rows for a payment history entry.
+ *
+ * @param billingAccountId billing account id resolved from the payment detail.
+ * @param billingAccountName billing account name resolved from the payment detail.
+ * @returns billing account metadata rows, or `undefined` when no billing account
+ * data is available.
+ *
+ * @remarks Used inside each payment history row after finance payment details
+ * have been hydrated with billing account names.
+ *
+ * @throws This helper does not raise exceptions.
+ */
+const renderPaymentBillingAccountDetails = (
+    billingAccountId: string,
+    billingAccountName: string,
+): JSX.Element | undefined => {
+    if (!billingAccountId && !billingAccountName) {
+        return undefined
+    }
+
+    return (
+        <>
+            <div className={styles.metaRow}>
+                <span className={styles.metaLabel}>
+                    BA ID:
+                </span>
+                <span>{billingAccountId || '-'}</span>
+            </div>
+            <div className={styles.metaRow}>
+                <span className={styles.metaLabel}>
+                    BA Name:
+                </span>
+                <span>{billingAccountName || '-'}</span>
+            </div>
+        </>
+    )
 }
 
 const PaymentHistoryModal: FC<PaymentHistoryModalProps> = (
@@ -98,6 +139,8 @@ const PaymentHistoryModal: FC<PaymentHistoryModalProps> = (
                                 const paymentHoursWorked = getPaymentHoursWorked(payment)
                                 const paymentRemarks = getPaymentRemarks(payment)
                                 const paymentCreator = getPaymentCreatorLabel(payment)
+                                const paymentBillingAccountId = getPaymentBillingAccountId(payment)
+                                const paymentBillingAccountName = getPaymentBillingAccountName(payment)
                                 const normalizedPaymentStatus = paymentStatus
                                     .trim()
                                     .toLowerCase()
@@ -153,6 +196,10 @@ const PaymentHistoryModal: FC<PaymentHistoryModalProps> = (
                                                 </span>
                                                 <span>{paymentCreator || '-'}</span>
                                             </div>
+                                            {renderPaymentBillingAccountDetails(
+                                                paymentBillingAccountId,
+                                                paymentBillingAccountName,
+                                            )}
                                             <div className={styles.date}>
                                                 {formatDate(payment.createdAt || payment.updatedAt)}
                                             </div>

--- a/src/apps/work/src/lib/models/Engagement.model.ts
+++ b/src/apps/work/src/lib/models/Engagement.model.ts
@@ -110,6 +110,8 @@ export interface AssignmentPayment {
     description?: string
     details?: Array<{
         amount?: number
+        billingAccount?: number | string
+        billingAccountName?: string
         challengeFee?: number | string
         grossAmount?: number
         hoursWorked?: number | string

--- a/src/apps/work/src/lib/services/payments.service.spec.ts
+++ b/src/apps/work/src/lib/services/payments.service.spec.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    xhrGetAsync,
+} from '~/libs/core'
+
+import {
+    fetchBillingAccountById,
+} from './billing-accounts.service'
+import {
+    fetchAssignmentPayments,
+} from './payments.service'
+import {
+    searchProfilesByUserIds,
+} from './users.service'
+
+jest.mock('~/libs/core', () => ({
+    xhrGetAsync: jest.fn(),
+    xhrPostAsync: jest.fn(),
+}), {
+    virtual: true,
+})
+jest.mock('../constants', () => ({
+    TC_FINANCE_API_URL: 'https://example.com/finance',
+}))
+jest.mock('./billing-accounts.service', () => ({
+    fetchBillingAccountById: jest.fn(),
+}))
+jest.mock('./users.service', () => ({
+    searchProfilesByUserIds: jest.fn(),
+}))
+
+describe('fetchAssignmentPayments', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('hydrates creator handles and billing account names for payment history', async () => {
+        const mockedGetAsync = xhrGetAsync as jest.Mock
+        const mockedSearchProfilesByUserIds = searchProfilesByUserIds as jest.Mock
+        const mockedFetchBillingAccountById = fetchBillingAccountById as jest.Mock
+
+        mockedGetAsync.mockResolvedValue([
+            {
+                createdBy: '1001',
+                details: [
+                    {
+                        billingAccount: '80001063',
+                        grossAmount: 120,
+                        totalAmount: 120,
+                    },
+                ],
+                id: 'payment-1',
+            },
+        ])
+        mockedSearchProfilesByUserIds.mockResolvedValue([
+            {
+                handle: 'payment.manager',
+                userId: '1001',
+            },
+        ])
+        mockedFetchBillingAccountById.mockResolvedValue({
+            id: 80001063,
+            name: 'BA For Marios',
+        })
+
+        const result = await fetchAssignmentPayments('assignment-1')
+
+        expect(mockedGetAsync)
+            .toHaveBeenCalledWith('https://example.com/finance/winnings/by-external-id/assignment-1')
+        expect(mockedSearchProfilesByUserIds)
+            .toHaveBeenCalledWith(['1001'])
+        expect(mockedFetchBillingAccountById)
+            .toHaveBeenCalledWith('80001063')
+        expect(result)
+            .toEqual([
+                {
+                    createdBy: '1001',
+                    createdByHandle: 'payment.manager',
+                    details: [
+                        {
+                            billingAccount: '80001063',
+                            billingAccountName: 'BA For Marios',
+                            grossAmount: 120,
+                            totalAmount: 120,
+                        },
+                    ],
+                    id: 'payment-1',
+                },
+            ])
+    })
+})

--- a/src/apps/work/src/lib/services/payments.service.ts
+++ b/src/apps/work/src/lib/services/payments.service.ts
@@ -11,6 +11,9 @@ import type {
 } from '../models'
 
 import {
+    fetchBillingAccountById,
+} from './billing-accounts.service'
+import {
     searchProfilesByUserIds,
 } from './users.service'
 
@@ -146,6 +149,89 @@ async function hydratePaymentCreatorHandles(
     }
 }
 
+/**
+ * Hydrates payment details with billing account names for payment history rows.
+ *
+ * @param payments payment rows returned by the finance API.
+ * @returns the original rows with `details[].billingAccountName` added when a
+ * billing account lookup succeeds.
+ *
+ * @remarks Lookup failures are ignored so payment history can still display
+ * the stored BA ID returned by finance.
+ *
+ * @throws This helper does not raise exceptions.
+ */
+async function hydratePaymentBillingAccountNames(
+    payments: AssignmentPayment[],
+): Promise<AssignmentPayment[]> {
+    const billingAccountIds = Array.from(new Set(
+        payments
+            .flatMap(payment => payment.details || [])
+            .map(detail => String(detail.billingAccount || '')
+                .trim())
+            .filter(Boolean),
+    ))
+
+    if (!billingAccountIds.length) {
+        return payments
+    }
+
+    const billingAccountNamesById = new Map<string, string>()
+
+    await Promise.all(billingAccountIds.map(async billingAccountId => {
+        try {
+            const billingAccount = await fetchBillingAccountById(billingAccountId)
+            const billingAccountName = String(billingAccount.name || '')
+                .trim()
+
+            if (billingAccountName) {
+                billingAccountNamesById.set(billingAccountId, billingAccountName)
+            }
+        } catch {
+            // Keep payment history usable even when a billing-account lookup fails.
+        }
+    }))
+
+    if (!billingAccountNamesById.size) {
+        return payments
+    }
+
+    return payments.map(payment => {
+        if (!payment.details?.length) {
+            return payment
+        }
+
+        let changed = false
+        const details = payment.details.map(detail => {
+            if (detail.billingAccountName) {
+                return detail
+            }
+
+            const billingAccountId = String(detail.billingAccount || '')
+                .trim()
+            const billingAccountName = billingAccountNamesById.get(billingAccountId)
+
+            if (!billingAccountName) {
+                return detail
+            }
+
+            changed = true
+
+            return {
+                ...detail,
+                billingAccountName,
+            }
+        })
+
+        return changed
+            ? {
+                ...payment,
+                details,
+            }
+            : payment
+    })
+}
+
 export async function createMemberPayment(
     assignmentId: number | string,
     memberId: number | string,
@@ -207,7 +293,9 @@ export async function fetchAssignmentPayments(
             `${TC_FINANCE_API_URL}/winnings/by-external-id/${assignmentId}`,
         )
 
-        return hydratePaymentCreatorHandles(normalizePaymentsResponse(response))
+        const payments = await hydratePaymentCreatorHandles(normalizePaymentsResponse(response))
+
+        return hydratePaymentBillingAccountNames(payments)
     } catch (error) {
         throw normalizeError(error, 'Failed to fetch payment history')
     }

--- a/src/apps/work/src/lib/utils/payment.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/payment.utils.spec.ts
@@ -4,6 +4,8 @@ import type {
 } from '../models'
 import {
     calculatePaymentChallengeFee,
+    getPaymentBillingAccountId,
+    getPaymentBillingAccountName,
     getPaymentChallengeFee,
 } from './payment.utils'
 
@@ -42,5 +44,23 @@ describe('payment.utils', () => {
 
         expect(getPaymentChallengeFee(payment))
             .toBe(72)
+    })
+
+    it('reads billing account details from the first payment detail', () => {
+        const payment: AssignmentPayment = {
+            details: [
+                {
+                    billingAccount: 80001063,
+                    billingAccountName: 'BA For Marios',
+                    grossAmount: 480,
+                    totalAmount: 480,
+                },
+            ],
+        }
+
+        expect(getPaymentBillingAccountId(payment))
+            .toBe('80001063')
+        expect(getPaymentBillingAccountName(payment))
+            .toBe('BA For Marios')
     })
 })

--- a/src/apps/work/src/lib/utils/payment.utils.ts
+++ b/src/apps/work/src/lib/utils/payment.utils.ts
@@ -30,6 +30,17 @@ function toOptionalString(value: unknown): string | undefined {
     return normalized || undefined
 }
 
+function toOptionalDisplayString(value: unknown): string | undefined {
+    if (value === null || value === undefined) {
+        return undefined
+    }
+
+    const normalized = String(value)
+        .trim()
+
+    return normalized || undefined
+}
+
 type AssignmentPaymentDetail = NonNullable<AssignmentPayment['details']>[number]
 
 function getFirstPaymentDetail(
@@ -167,6 +178,38 @@ export function getPaymentHoursWorked(payment: AssignmentPayment): string {
 
     return Number(parsedValue.toFixed(2))
         .toString()
+}
+
+/**
+ * Resolves the billing account id stored on a payment detail.
+ *
+ * @param payment payment record returned by the finance API.
+ * @returns billing account id from the first payment detail, or an empty
+ * string when finance did not return one.
+ *
+ * @remarks Used by the payment history modal to show the BA ID charged for a
+ * member payment.
+ *
+ * @throws This helper does not raise exceptions.
+ */
+export function getPaymentBillingAccountId(payment: AssignmentPayment): string {
+    return toOptionalDisplayString(getFirstPaymentDetail(payment)?.billingAccount) || ''
+}
+
+/**
+ * Resolves the hydrated billing account name stored on a payment detail.
+ *
+ * @param payment payment record returned by the finance API.
+ * @returns billing account name from the first payment detail, or an empty
+ * string when it has not been hydrated.
+ *
+ * @remarks Used by the payment history modal to show the BA name charged for a
+ * member payment.
+ *
+ * @throws This helper does not raise exceptions.
+ */
+export function getPaymentBillingAccountName(payment: AssignmentPayment): string {
+    return toOptionalDisplayString(getFirstPaymentDetail(payment)?.billingAccountName) || ''
 }
 
 export function getAssignmentStatus(member: Partial<Assignment>): string {


### PR DESCRIPTION
What was broken
Payment history rows only showed payment amount, remarks, hours worked, and creator details. Managers could not see the BA ID or BA name associated with a payment from the modal.

Root cause
Finance payment history includes the billing account ID on payment details, but the work app model and modal did not expose it. The finance response does not include the billing account name, so the UI also had no hydrated name to render.

What was changed
Typed assignment payment details to include billing account ID and hydrated billing account name fields.
Hydrated unique payment billing account IDs through the existing billing accounts service while keeping payment history usable if a lookup fails.
Rendered BA ID and BA Name rows in each payment history item when billing account data is available.

Any added/updated tests
Added payments service coverage for hydrating creator handles and billing account names.
Updated payment utility coverage for reading billing account details from payment details.
Updated the payment history modal test to assert the BA ID and BA Name rows render.

Validation note
Focused payment history tests, lint, and build passed. The full non-watch test suite currently fails in existing ChallengeEditorForm launch and budget-approval assertions that are outside the payment history change scope.
