### PR TITLE
MM Fixes

### DIFF
--- a/src/apps/work/src/lib/components/SubmissionRunnerLogsModal/SubmissionRunnerLogsModal.module.scss
+++ b/src/apps/work/src/lib/components/SubmissionRunnerLogsModal/SubmissionRunnerLogsModal.module.scss
@@ -26,7 +26,8 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    padding: 18px 20px 12px;
+    padding: 18px 52px 12px 20px;
+    position: relative;
 }
 
 .title {
@@ -42,6 +43,26 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.closeButton {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    position: absolute;
+    right: 16px;
+    top: 14px;
+}
+
+.closeIcon {
+    color: $black-60;
+    height: 20px;
+    width: 20px;
+}
+
+.closeButton:hover .closeIcon {
+    color: $black-80;
 }
 
 .body {

--- a/src/apps/work/src/lib/components/SubmissionRunnerLogsModal/SubmissionRunnerLogsModal.tsx
+++ b/src/apps/work/src/lib/components/SubmissionRunnerLogsModal/SubmissionRunnerLogsModal.tsx
@@ -5,7 +5,10 @@ import {
     useMemo,
 } from 'react'
 
-import { LoadingSpinner } from '~/libs/ui'
+import {
+    IconOutline,
+    LoadingSpinner,
+} from '~/libs/ui'
 
 import { useFetchSubmissionRunnerLogs } from '../../hooks'
 import {
@@ -98,6 +101,14 @@ export const SubmissionRunnerLogsModal: FC<SubmissionRunnerLogsModalProps> = (
             >
                 <header className={styles.header}>
                     <h4 className={styles.title}>Runner Logs</h4>
+                    <button
+                        aria-label='Close'
+                        className={styles.closeButton}
+                        onClick={props.onClose}
+                        type='button'
+                    >
+                        <IconOutline.XIcon className={styles.closeIcon} />
+                    </button>
                     <span className={styles.submissionId} title={props.submissionId}>
                         {props.submissionId}
                     </span>

--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
@@ -28,6 +28,20 @@ jest.mock('../../utils', () => ({
     getSubmissionInitialScore: (submission: { review?: Array<{ initialScore?: number }> }) => (
         submission.review?.[0]?.initialScore ?? 0
     ),
+    getSubmissionProvisionalScore: (
+        submission: { reviewSummation?: Array<{ aggregateScore?: number, isProvisional?: boolean }> },
+    ) => (
+        submission.reviewSummation
+            ?.find(item => item.isProvisional === true)
+            ?.aggregateScore
+    ),
+    getSubmissionSystemScore: (
+        submission: { reviewSummation?: Array<{ aggregateScore?: number, isFinal?: boolean }> },
+    ) => (
+        submission.reviewSummation
+            ?.find(item => item.isFinal === true)
+            ?.aggregateScore
+    ),
     getSubmissionTestProgress: (
         submission: {
             reviewSummation?: Array<{
@@ -313,5 +327,67 @@ describe('SubmissionsTable', () => {
             .toBeTruthy()
         expect(screen.getByRole('img', { name: 'Test status: FAILED' }))
             .toBeTruthy()
+    })
+
+    it('renders marathon scores from provisional and system summations only', () => {
+        render(
+            <SubmissionsTable
+                canDownloadSubmissions
+                challengeId='challenge-123'
+                onDownloadSubmission={jest.fn()}
+                onOpenArtifacts={jest.fn()}
+                onSort={jest.fn()}
+                showMarathonMatchTestProgress
+                sortBy='createdAt'
+                sortOrder='desc'
+                submissions={[
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-1',
+                        id: 'submission-1',
+                        review: [
+                            {
+                                finalScore: 95,
+                                initialScore: 90,
+                            },
+                        ],
+                        reviewSummation: [
+                            {
+                                aggregateScore: 12,
+                                isProvisional: true,
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-2',
+                        id: 'submission-2',
+                        review: [
+                            {
+                                finalScore: 85,
+                                initialScore: 80,
+                            },
+                        ],
+                        reviewSummation: [
+                            {
+                                aggregateScore: 20,
+                                isFinal: true,
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                ]}
+            />,
+        )
+
+        expect(screen.getByRole('link', { name: '12.00 / -' }))
+            .toBeTruthy()
+        expect(screen.getByRole('link', { name: '- / 20.00' }))
+            .toBeTruthy()
+        expect(screen.queryByRole('link', { name: '90.00 / 95.00' }))
+            .toBeNull()
+        expect(screen.queryByRole('link', { name: '80.00 / 85.00' }))
+            .toBeNull()
     })
 })

--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
@@ -21,6 +21,8 @@ import {
     getRatingLevel,
     getSubmissionFinalScore,
     getSubmissionInitialScore,
+    getSubmissionProvisionalScore,
+    getSubmissionSystemScore,
     getSubmissionTestProgress,
 } from '../../utils'
 
@@ -131,9 +133,9 @@ function getCreatedAt(submission: Submission): string {
         || ''
 }
 
-function formatScore(value?: number): string {
+function formatScore(value?: number, emptyValue: string = 'N/A'): string {
     if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return 'N/A'
+        return emptyValue
     }
 
     return value.toFixed(2)
@@ -325,8 +327,17 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                         const handleDisplay = getHandleDisplay(submission, !!props.isLoadingMembers)
                         const emailDisplay = getEmailDisplay(submission, !!props.isLoadingMembers)
                         const submissionDate = formatDateTime(getCreatedAt(submission))
-                        const initialScore = formatScore(getSubmissionInitialScore(submission))
-                        const finalScore = formatScore(getSubmissionFinalScore(submission))
+                        const initialScoreValue = props.showMarathonMatchTestProgress
+                            ? getSubmissionProvisionalScore(submission)
+                            : getSubmissionInitialScore(submission)
+                        const finalScoreValue = props.showMarathonMatchTestProgress
+                            ? getSubmissionSystemScore(submission)
+                            : getSubmissionFinalScore(submission)
+                        const emptyScoreValue = props.showMarathonMatchTestProgress
+                            ? '-'
+                            : 'N/A'
+                        const initialScore = formatScore(initialScoreValue, emptyScoreValue)
+                        const finalScore = formatScore(finalScoreValue, emptyScoreValue)
                         const testProgress = props.showMarathonMatchTestProgress
                             ? getSubmissionTestProgress(submission)
                             : undefined

--- a/src/apps/work/src/lib/models/Submission.model.ts
+++ b/src/apps/work/src/lib/models/Submission.model.ts
@@ -43,6 +43,7 @@ export interface ReviewSummation {
     aggregateScore?: number
     createdAt?: string
     id?: string
+    isExample?: boolean
     isFinal?: boolean
     isPassing?: boolean
     isProvisional?: boolean

--- a/src/apps/work/src/lib/services/submissions.service.ts
+++ b/src/apps/work/src/lib/services/submissions.service.ts
@@ -216,6 +216,7 @@ function normalizeReviewSummation(reviewSummation: unknown): ReviewSummation | u
         aggregateScore: toOptionalNumber(typedReviewSummation.aggregateScore),
         createdAt: toOptionalString(typedReviewSummation.createdAt ?? typedReviewSummation.created),
         id: toOptionalString(typedReviewSummation.id),
+        isExample: toOptionalBoolean(typedReviewSummation.isExample),
         isFinal: toOptionalBoolean(typedReviewSummation.isFinal),
         isPassing: toOptionalBoolean(typedReviewSummation.isPassing),
         isProvisional: toOptionalBoolean(typedReviewSummation.isProvisional),

--- a/src/apps/work/src/lib/utils/challenge.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.spec.ts
@@ -1,0 +1,146 @@
+import {
+    getSubmissionProvisionalScore,
+    getSubmissionSystemScore,
+} from './challenge.utils'
+
+jest.mock('../constants', () => ({
+    CHALLENGE_STATUS: {
+        ACTIVE: 'ACTIVE',
+        CANCELLED: 'CANCELLED',
+        COMPLETED: 'COMPLETED',
+        DRAFT: 'DRAFT',
+    },
+}))
+
+describe('challenge utils', () => {
+    describe('getSubmissionProvisionalScore', () => {
+        it('returns only provisional marathon scores', () => {
+            expect(getSubmissionProvisionalScore({
+                review: [
+                    {
+                        finalScore: 95,
+                        initialScore: 90,
+                    },
+                ],
+                reviewSummation: [
+                    {
+                        aggregateScore: 12,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                    },
+                    {
+                        aggregateScore: 20,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                        },
+                    },
+                ],
+            }))
+                .toBe(12)
+        })
+
+        it('returns undefined when provisional scoring is unavailable', () => {
+            expect(getSubmissionProvisionalScore({
+                review: [
+                    {
+                        finalScore: 95,
+                        initialScore: 90,
+                    },
+                ],
+                reviewSummation: [
+                    {
+                        aggregateScore: 20,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                        },
+                    },
+                ],
+            }))
+                .toBeUndefined()
+        })
+
+        it('does not treat example summations as provisional scores', () => {
+            expect(getSubmissionProvisionalScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: 10,
+                        isExample: true,
+                        isFinal: false,
+                    },
+                ],
+            }))
+                .toBeUndefined()
+        })
+    })
+
+    describe('getSubmissionSystemScore', () => {
+        it('returns only system marathon scores', () => {
+            expect(getSubmissionSystemScore({
+                review: [
+                    {
+                        finalScore: 95,
+                        initialScore: 90,
+                    },
+                ],
+                reviewSummation: [
+                    {
+                        aggregateScore: 12,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                    },
+                    {
+                        aggregateScore: 20,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                        },
+                    },
+                ],
+            }))
+                .toBe(20)
+        })
+
+        it('returns undefined when system scoring is unavailable', () => {
+            expect(getSubmissionSystemScore({
+                review: [
+                    {
+                        finalScore: 95,
+                        initialScore: 90,
+                    },
+                ],
+                reviewSummation: [
+                    {
+                        aggregateScore: 12,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                    },
+                ],
+            }))
+                .toBeUndefined()
+        })
+
+        it('ignores in-progress placeholder scores', () => {
+            expect(getSubmissionSystemScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: -1,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                            testStatus: 'IN PROGRESS',
+                        },
+                    },
+                ],
+            }))
+                .toBeUndefined()
+        })
+    })
+})

--- a/src/apps/work/src/lib/utils/challenge.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.ts
@@ -127,6 +127,48 @@ function getScoreFromSummation(
     return toValidScore(matchedSummation?.aggregateScore)
 }
 
+/**
+ * Resolves the marathon scoring phase represented by a review summation.
+ * @param entry Review summation returned by Review API.
+ * @returns `provisional`, `system`, or `undefined` when the summation is not a scored marathon phase.
+ * Used by strict marathon score helpers so progress/example reviews do not leak into score display.
+ */
+function getReviewSummationTestProcess(
+    entry: ReviewSummation,
+): 'provisional' | 'system' | undefined {
+    const metadataProcess = normalizeTestProcess(
+        entry.metadata?.testProcess
+        ?? entry.metadata?.testType,
+    )
+
+    if (metadataProcess) {
+        return metadataProcess
+    }
+
+    const metadataStage = typeof entry.metadata?.stage === 'string'
+        ? entry.metadata.stage.trim()
+            .toLowerCase()
+        : ''
+
+    if (metadataStage === 'final') {
+        return 'system'
+    }
+
+    if (entry.isFinal === true) {
+        return 'system'
+    }
+
+    if (entry.isProvisional === true) {
+        return 'provisional'
+    }
+
+    if (entry.isFinal === false && entry.isExample !== true) {
+        return 'provisional'
+    }
+
+    return undefined
+}
+
 function getChallengeTypeName(type: string | ChallengeTypeRef | undefined): string | undefined {
     if (!type) {
         return undefined
@@ -382,6 +424,28 @@ export function getProvisionalScore(submission: ScoredSubmissionLike): number {
     return getSubmissionInitialScore(submission)
 }
 
+/**
+ * Returns only the provisional marathon score for a submission.
+ * @param submission Submission-like object containing legacy phase scores or Review API summations.
+ * @returns Provisional score, or `undefined` when provisional scoring has not produced a valid score.
+ * Used by marathon submission score display to avoid falling back to unrelated review scores.
+ */
+export function getSubmissionProvisionalScore(
+    submission: ScoredSubmissionLike,
+): number | undefined {
+    const legacyProvisionalScore = toValidScore(
+        submission.submissions?.[0]?.provisionalScore,
+    )
+    if (legacyProvisionalScore !== undefined) {
+        return legacyProvisionalScore
+    }
+
+    return getScoreFromSummation(
+        submission.reviewSummation,
+        item => getReviewSummationTestProcess(item) === 'provisional',
+    )
+}
+
 export function getSubmissionInitialScore(submission: ScoredSubmissionLike): number {
     const initialScoreFromReviews = getAverageScore(
         (submission.review || [])
@@ -392,17 +456,7 @@ export function getSubmissionInitialScore(submission: ScoredSubmissionLike): num
         return initialScoreFromReviews
     }
 
-    const legacyProvisionalScore = toValidScore(
-        submission.submissions?.[0]?.provisionalScore,
-    )
-    if (legacyProvisionalScore !== undefined) {
-        return legacyProvisionalScore
-    }
-
-    const provisionalSummationScore = getScoreFromSummation(
-        submission.reviewSummation,
-        item => item.isProvisional === true || item.isFinal === false,
-    )
+    const provisionalSummationScore = getSubmissionProvisionalScore(submission)
     if (provisionalSummationScore !== undefined) {
         return provisionalSummationScore
     }
@@ -419,6 +473,28 @@ export function getFinalScore(submission: ScoredSubmissionLike): number {
     return getSubmissionFinalScore(submission)
 }
 
+/**
+ * Returns only the system marathon score for a submission.
+ * @param submission Submission-like object containing legacy phase scores or Review API summations.
+ * @returns System score, or `undefined` when system scoring has not produced a valid score.
+ * Used by marathon submission score display to show pending/unavailable system scores as empty.
+ */
+export function getSubmissionSystemScore(
+    submission: ScoredSubmissionLike,
+): number | undefined {
+    const legacyFinalScore = toValidScore(
+        submission.submissions?.[0]?.finalScore,
+    )
+    if (legacyFinalScore !== undefined) {
+        return legacyFinalScore
+    }
+
+    return getScoreFromSummation(
+        submission.reviewSummation,
+        item => getReviewSummationTestProcess(item) === 'system',
+    )
+}
+
 export function getSubmissionFinalScore(submission: ScoredSubmissionLike): number {
     const finalScoreFromReviews = getAverageScore(
         (submission.review || [])
@@ -428,17 +504,7 @@ export function getSubmissionFinalScore(submission: ScoredSubmissionLike): numbe
         return finalScoreFromReviews
     }
 
-    const legacyFinalScore = toValidScore(
-        submission.submissions?.[0]?.finalScore,
-    )
-    if (legacyFinalScore !== undefined) {
-        return legacyFinalScore
-    }
-
-    const finalSummationScore = getScoreFromSummation(
-        submission.reviewSummation,
-        item => item.isFinal === true,
-    )
+    const finalSummationScore = getSubmissionSystemScore(submission)
     if (finalSummationScore !== undefined) {
         return finalSummationScore
     }

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionsSection/SubmissionsSection.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionsSection/SubmissionsSection.tsx
@@ -34,6 +34,8 @@ import {
     canViewMarathonMatchRunnerLogs,
     getSubmissionFinalScore,
     getSubmissionInitialScore,
+    getSubmissionProvisionalScore,
+    getSubmissionSystemScore,
     isMarathonMatchChallenge,
     showErrorToast,
 } from '../../../../../lib/utils'
@@ -125,6 +127,7 @@ function parseDateToTimestamp(value: string): number {
 function resolveSortValue(
     submission: Submission,
     sortBy: SubmissionSortBy,
+    useMarathonMatchScores: boolean,
 ): number | string {
     if (sortBy === 'memberHandle') {
         return normalizeValue(submission.memberHandle)
@@ -137,11 +140,15 @@ function resolveSortValue(
     }
 
     if (sortBy === 'initialScore') {
-        return getSubmissionInitialScore(submission)
+        return useMarathonMatchScores
+            ? getSubmissionProvisionalScore(submission) ?? -1
+            : getSubmissionInitialScore(submission)
     }
 
     if (sortBy === 'finalScore') {
-        return getSubmissionFinalScore(submission)
+        return useMarathonMatchScores
+            ? getSubmissionSystemScore(submission) ?? -1
+            : getSubmissionFinalScore(submission)
     }
 
     if (sortBy === 'submissionId') {
@@ -156,12 +163,13 @@ function sortSubmissions(
     submissions: Submission[],
     sortBy: SubmissionSortBy,
     sortOrder: SortOrder,
+    useMarathonMatchScores: boolean,
 ): Submission[] {
     const sortedSubmissions = [...submissions]
 
     sortedSubmissions.sort((submissionA, submissionB) => {
-        const valueA = resolveSortValue(submissionA, sortBy)
-        const valueB = resolveSortValue(submissionB, sortBy)
+        const valueA = resolveSortValue(submissionA, sortBy, useMarathonMatchScores)
+        const valueB = resolveSortValue(submissionB, sortBy, useMarathonMatchScores)
 
         if (valueA === valueB) {
             return 0
@@ -288,7 +296,11 @@ function matchesFilterDateRange(
     return true
 }
 
-function matchesFilterScore(submission: Submission, minScore: string): boolean {
+function matchesFilterScore(
+    submission: Submission,
+    minScore: string,
+    useMarathonMatchScores: boolean,
+): boolean {
     if (!minScore) {
         return true
     }
@@ -298,7 +310,11 @@ function matchesFilterScore(submission: Submission, minScore: string): boolean {
         return true
     }
 
-    return getSubmissionFinalScore(submission) >= minimumScore
+    const score = useMarathonMatchScores
+        ? getSubmissionSystemScore(submission)
+        : getSubmissionFinalScore(submission)
+
+    return score !== undefined && score >= minimumScore
 }
 
 function matchesFilterHandle(submission: Submission, handleFilter: string): boolean {
@@ -314,7 +330,11 @@ function matchesFilterHandle(submission: Submission, handleFilter: string): bool
         .includes(normalizedHandleFilter)
 }
 
-function matchesFilters(submission: Submission, filters: FilterState): boolean {
+function matchesFilters(
+    submission: Submission,
+    filters: FilterState,
+    useMarathonMatchScores: boolean,
+): boolean {
     if (!matchesFilterHandle(submission, filters.handle)) {
         return false
     }
@@ -323,7 +343,7 @@ function matchesFilters(submission: Submission, filters: FilterState): boolean {
         return false
     }
 
-    return matchesFilterScore(submission, filters.minScore)
+    return matchesFilterScore(submission, filters.minScore, useMarathonMatchScores)
 }
 
 function toDownloadAllItems(submissions: Submission[]): DownloadAllItem[] {
@@ -465,17 +485,21 @@ export const SubmissionsSection: FC<SubmissionsSectionProps> = (
     )
 
     const filteredSubmissions = useMemo<Submission[]>(() => (
-        enrichedSubmissions.filter(submission => matchesFilters(submission, filters))
+        enrichedSubmissions.filter(
+            submission => matchesFilters(submission, filters, isMarathonMatch),
+        )
     ), [
         enrichedSubmissions,
         filters,
+        isMarathonMatch,
     ])
 
     const sortedSubmissions = useMemo<Submission[]>(() => sortSubmissions(
         filteredSubmissions,
         sortBy,
         sortOrder,
-    ), [filteredSubmissions, sortBy, sortOrder])
+        isMarathonMatch,
+    ), [filteredSubmissions, isMarathonMatch, sortBy, sortOrder])
 
     const paginatedSubmissions = useMemo<Submission[]>(() => {
         const startIndex = (page - 1) * perPage
@@ -494,8 +518,10 @@ export const SubmissionsSection: FC<SubmissionsSectionProps> = (
         ),
         sortBy,
         sortOrder,
+        isMarathonMatch,
     ), [
         checkpointSubmissions,
+        isMarathonMatch,
         memberCache,
         sortBy,
         sortOrder,


### PR DESCRIPTION
The initial and final score display isn't quite right.  The initial score should only show the provisional score.  The final score should only show the system score.  If the system tests are still running / not available, for the final score we'll show '-'.  Same for provisional scoring

2.  On the ECS logs dialog popup, can we add an X button in the upper right of the dialog to dismiss it please?
