### PR TITLE
PM-5043: Correct billing line item member payments

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -125,31 +125,33 @@ describe('BillingAccountLineItemsModal', () => {
             .toBe('/work/challenges/challenge%20%2F%20100')
     })
 
-    it('shows challenge member payments and calculated challenge fees for non-copilot users', () => {
+    it('shows challenge member payments without recalculating fees on the ledger total', () => {
         renderModal({
             ...baseBillingAccountDetails,
             lockedAmounts: [
                 {
-                    amount: '50',
+                    amount: '13.3',
                     date: '2026-02-10T00:00:00.000Z',
                     externalId: 'challenge-100',
                     externalName: 'Markup Challenge',
                     externalType: 'CHALLENGE',
                 },
             ],
-            lockedBudget: 66.5,
+            lockedBudget: 13.3,
             markup: 0.33,
-            totalBudgetRemaining: 933.5,
+            totalBudgetRemaining: 986.7,
         })
 
         expect(screen.getByText('Member Payments'))
             .toBeTruthy()
         expect(screen.getByText('Challenge Fee'))
             .toBeTruthy()
-        expect(screen.getAllByText('$50.00'))
+        expect(screen.getAllByText('$10.00'))
             .toHaveLength(1)
-        expect(screen.getByText('$16.50'))
+        expect(screen.getByText('$3.30'))
             .toBeTruthy()
+        expect(screen.queryByText('$4.39'))
+            .toBeNull()
     })
 
     it('builds engagement links from assignment-backed billing rows', () => {
@@ -361,7 +363,7 @@ describe('BillingAccountLineItemsModal', () => {
             .toBeTruthy()
     })
 
-    it('shows only remaining member payments and challenge row amounts for copilots', () => {
+    it('shows only remaining member payments and derived row amounts for copilots', () => {
         renderModal({
             ...baseBillingAccountDetails,
             consumedBudget: 500,
@@ -384,9 +386,9 @@ describe('BillingAccountLineItemsModal', () => {
             .toBeTruthy()
         expect(screen.getByText('$200.00'))
             .toBeTruthy()
-        expect(screen.getByText('$50.00'))
+        expect(screen.getByText('$37.59'))
             .toBeTruthy()
-        expect(screen.queryByText('$37.59'))
+        expect(screen.queryByText('$50.00'))
             .toBeNull()
         expect(screen.queryByText('Consumed'))
             .toBeNull()

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -224,11 +224,9 @@ function formatLineItemChallengeFee(item: BillingAccountModalLineItem): string {
  * @param showMemberPaymentsRemaining Whether the caller needs the copilot-safe view.
  * @returns Member payment amount, or `undefined` for copilot rows when it cannot
  * be safely calculated.
- * @remarks Challenge budget rows already expose the member-payment subtotal
- * for every caller. Engagement budget rows store the billing ledger total, so
- * they still need markup removed before display. Copilot engagement rows prefer
- * API-provided member-payment amounts and fall back to markup math only when
- * that safe field is missing.
+ * @remarks Billing budget rows store member payments plus markup. Copilot rows
+ * prefer API-provided member-payment amounts and fall back to markup math only
+ * when that safe field is missing.
  */
 function getLineItemMemberPaymentAmount(
     item: BillingAccountLineItem,
@@ -237,10 +235,6 @@ function getLineItemMemberPaymentAmount(
 ): number | undefined {
     if (item.memberPaymentAmount !== undefined) {
         return item.memberPaymentAmount
-    }
-
-    if (item.externalType === 'CHALLENGE') {
-        return item.amount
     }
 
     const memberPaymentAmount = calculateMemberPaymentAmount(
@@ -261,10 +255,9 @@ function getLineItemMemberPaymentAmount(
  * @param showMemberPaymentsRemaining Whether the caller needs the copilot-safe view.
  * @returns A line item with `displayAmount` set to the visible member-payment
  * amount and, for non-copilots, `challengeFeeAmount` set to the billing markup fee.
- * @remarks Challenge rows use the raw member-payment subtotal for all callers.
- * Non-copilot challenge rows also calculate the hidden fee from markup.
- * Engagement rows derive member payments from the raw ledger amount and
- * billing-account markup.
+ * @remarks Billing rows derive member payments from the raw ledger amount and
+ * billing-account markup. Non-copilot rows also calculate the hidden fee from
+ * the derived subtotal.
  */
 function getDisplayLineItem(
     item: BillingAccountLineItem,


### PR DESCRIPTION
What was broken
Completed challenge billing rows displayed the billing ledger amount as member payments, so the challenge fee was calculated again on top of an amount that already included markup.

Root cause
The billing account modal assumed challenge line items already exposed the member-payment subtotal for privileged users, but the billing ledger row amount includes member payments plus markup.

What was changed
The billing account modal now derives the visible member-payment amount from the ledger amount and billing markup before calculating the challenge fee column, while still preferring API-provided member payment values when present.

Any added/updated tests
Updated BillingAccountLineItemsModal coverage to assert a $13.30 ledger row with 33% markup renders as $10.00 member payments and a $3.30 challenge fee, not a $4.39 fee.

Validation run:
- yarn lint passed.
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch failed in unrelated ChallengeEditorForm.spec.tsx launch-validation cases on dev; this change does not touch those files.
