### PR TITLE
PM-5038: Fix copilot challenge member payment rows

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -396,16 +396,40 @@ describe('BillingAccountLineItemsModal', () => {
             .toBeNull()
     })
 
-    it('uses API-provided member-payment row amounts for copilot responses without markup', () => {
+    it('shows challenge row amounts for copilots when API member-payment aliases include markup math', () => {
+        renderModal({
+            ...baseBillingAccountDetails,
+            lockedAmounts: [
+                {
+                    amount: '9.15',
+                    date: '2026-05-08T00:00:00.000Z',
+                    externalId: 'challenge-100',
+                    externalName: 'Test',
+                    externalType: 'CHALLENGE',
+                    memberPaymentAmount: '6.88',
+                },
+            ],
+            lockedBudget: 9.15,
+            memberPaymentsRemaining: 273413.64,
+            totalBudgetRemaining: 273413.64,
+        }, true)
+
+        expect(screen.getByText('$9.15'))
+            .toBeTruthy()
+        expect(screen.queryByText('$6.88'))
+            .toBeNull()
+    })
+
+    it('uses API-provided engagement member-payment row amounts for copilot responses without markup', () => {
         renderModal({
             ...baseBillingAccountDetails,
             consumedAmounts: [
                 {
                     amount: '125.25',
                     date: '2026-02-10T00:00:00.000Z',
-                    externalId: 'challenge-100',
-                    externalName: 'Consumed Markup Challenge',
-                    externalType: 'CHALLENGE',
+                    externalId: 'engagement-100',
+                    externalName: 'Consumed Markup Engagement',
+                    externalType: 'ENGAGEMENT',
                     memberPaymentAmount: '100.20',
                 },
             ],

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -224,9 +224,10 @@ function formatLineItemChallengeFee(item: BillingAccountModalLineItem): string {
  * @param showMemberPaymentsRemaining Whether the caller needs the copilot-safe view.
  * @returns Member payment amount, or `undefined` for copilot rows when it cannot
  * be safely calculated.
- * @remarks Challenge budget rows already expose the member-payment subtotal
- * for every caller. Engagement budget rows store the billing ledger total, so
- * they still need markup removed before display. Copilot engagement rows prefer
+ * @remarks Challenge budget rows already expose the visible challenge cost for
+ * every caller, so API-provided member-payment aliases are ignored for those
+ * rows. Engagement budget rows store the billing ledger total, so they still
+ * need markup removed before display. Copilot engagement rows prefer
  * API-provided member-payment amounts and fall back to markup math only when
  * that safe field is missing.
  */
@@ -235,12 +236,12 @@ function getLineItemMemberPaymentAmount(
     billingAccountDetails: BillingAccountDetails,
     showMemberPaymentsRemaining: boolean | undefined,
 ): number | undefined {
-    if (item.memberPaymentAmount !== undefined) {
-        return item.memberPaymentAmount
-    }
-
     if (item.externalType === 'CHALLENGE') {
         return item.amount
+    }
+
+    if (item.memberPaymentAmount !== undefined) {
+        return item.memberPaymentAmount
     }
 
     const memberPaymentAmount = calculateMemberPaymentAmount(
@@ -261,7 +262,7 @@ function getLineItemMemberPaymentAmount(
  * @param showMemberPaymentsRemaining Whether the caller needs the copilot-safe view.
  * @returns A line item with `displayAmount` set to the visible member-payment
  * amount and, for non-copilots, `challengeFeeAmount` set to the billing markup fee.
- * @remarks Challenge rows use the raw member-payment subtotal for all callers.
+ * @remarks Challenge rows use the raw visible challenge cost for all callers.
  * Non-copilot challenge rows also calculate the hidden fee from markup.
  * Engagement rows derive member payments from the raw ledger amount and
  * billing-account markup.


### PR DESCRIPTION
What was broken
Copilots viewing billing account details saw challenge member payment rows with a markup-adjusted amount, such as $6.88, instead of the challenge cost shown in challenge billing, such as $9.15.

Root cause
The billing account line item modal used `memberPaymentAmount` before checking the external entry type. Challenge rows can include a `memberPaymentAmount` alias that has markup math applied even though the challenge row `amount` is already the visible challenge cost.

What was changed
Challenge line items now always use the raw challenge row amount for the displayed Member Payments value. Engagement rows still use API-provided member payment amounts when available and retain the existing markup fallback behavior.

Any added/updated tests
Added a PM-5038 regression test covering a challenge row where `amount` is 9.15 and `memberPaymentAmount` is 6.88, and updated the API-provided member payment test to cover engagement rows.

Validation run:
- `yarn test:no-watch BillingAccountLineItemsModal --runInBand` passed.
- `yarn lint` passed.
- `yarn run build` passed with existing webpack/style and hook warnings.
- `yarn test:no-watch --runInBand` was run; it failed in unrelated existing suites `ChallengeEditorForm.spec.tsx` and `PaymentView.spec.tsx`. The PM-5038 modal suite passed.
