### PR TITLE
PM-5043: Use consumed challenge member subtotals

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -204,6 +204,37 @@ describe('BillingAccountLineItemsModal', () => {
             .toBeNull()
     })
 
+    it('uses consumed challenge member-payment subtotals when markup is hidden', async () => {
+        mockedFetchChallenge.mockRejectedValueOnce(new Error('Forbidden'))
+
+        renderModal({
+            ...baseBillingAccountDetails,
+            consumedAmounts: [
+                {
+                    amount: '33.25',
+                    date: '2026-05-12T00:00:00.000Z',
+                    externalId: '2864601d-320a-45e2-85b4-a14f9f19785e',
+                    externalName: 'May 12 challenge',
+                    externalType: 'CHALLENGE',
+                    memberPaymentAmount: '25',
+                },
+            ],
+            consumedBudget: 33.25,
+            totalBudgetRemaining: 966.75,
+        })
+
+        await waitFor(() => {
+            expect(screen.getByText('$25.00'))
+                .toBeTruthy()
+            expect(screen.getByText('$8.25'))
+                .toBeTruthy()
+        })
+        expect(screen.getAllByText('$33.25'))
+            .toHaveLength(1)
+        expect(screen.queryByText('$10.97'))
+            .toBeNull()
+    })
+
     it('uses zero challenge markup instead of billing-account default markup for consumed charges', async () => {
         challengeMarkupById.set('0f4c801c-4d4d-4ac2-8e2e-60aeb16379d2', 0)
 
@@ -518,6 +549,36 @@ describe('BillingAccountLineItemsModal', () => {
             ],
             consumedBudget: 33.25,
             markup: 0.33,
+            memberPaymentsRemaining: 200,
+            totalBudgetRemaining: 966.75,
+        }, true)
+
+        await waitFor(() => {
+            expect(screen.getByText('$25.00'))
+                .toBeTruthy()
+        })
+        expect(screen.queryByText('$33.25'))
+            .toBeNull()
+        expect(screen.queryByText('Challenge Fee'))
+            .toBeNull()
+    })
+
+    it('uses consumed challenge member-payment subtotals for copilots when markup is hidden', async () => {
+        mockedFetchChallenge.mockRejectedValueOnce(new Error('Forbidden'))
+
+        renderModal({
+            ...baseBillingAccountDetails,
+            consumedAmounts: [
+                {
+                    amount: '33.25',
+                    date: '2026-05-12T00:00:00.000Z',
+                    externalId: '2864601d-320a-45e2-85b4-a14f9f19785e',
+                    externalName: 'May 12 challenge',
+                    externalType: 'CHALLENGE',
+                    memberPaymentAmount: '25',
+                },
+            ],
+            consumedBudget: 33.25,
             memberPaymentsRemaining: 200,
             totalBudgetRemaining: 966.75,
         }, true)

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -301,8 +301,9 @@ function getLineItemChallengeMarkup(
  * @param challengeDetailsById Hydrated challenge details, or `undefined` while loading.
  * @returns Member payment amount for the challenge row.
  * @remarks Locked challenge rows store member payments directly. Consumed
- * challenge rows store the final billing-account charge, so the billing markup
- * is removed once using the challenge's own billing markup.
+ * challenge rows prefer the API-provided member-payment subtotal when present.
+ * Older payloads only expose the final billing-account charge, so the billing
+ * markup is removed once using the challenge's own billing markup.
  */
 function getChallengeMemberPaymentAmount(
     item: BillingAccountLineItem,
@@ -311,6 +312,10 @@ function getChallengeMemberPaymentAmount(
 ): number | undefined {
     if (item.status === 'locked') {
         return item.amount
+    }
+
+    if (item.memberPaymentAmount !== undefined) {
+        return item.memberPaymentAmount
     }
 
     const challengeMarkup = getLineItemChallengeMarkup(
@@ -327,6 +332,65 @@ function getChallengeMemberPaymentAmount(
         item.amount,
         challengeMarkup,
     )
+}
+
+/**
+ * Resolves a persisted challenge fee from a consumed billing row.
+ *
+ * @param item Raw billing-account line item.
+ * @returns Fee amount derived from the ledger charge and API-provided member
+ * payment subtotal, or `undefined` when the row does not expose both values.
+ * @remarks Completed challenge rows can expose the exact member-payment
+ * subtotal even when markup is hidden from the current caller, so the
+ * difference is the safest fee value for the manager/admin fee column.
+ */
+function getConsumedChallengeFeeAmount(
+    item: BillingAccountLineItem,
+): number | undefined {
+    if (
+        item.externalType !== 'CHALLENGE'
+        || item.status !== 'consumed'
+        || item.memberPaymentAmount === undefined
+    ) {
+        return undefined
+    }
+
+    const feeAmount = Number((item.amount - item.memberPaymentAmount).toFixed(2))
+
+    return feeAmount >= 0
+        ? feeAmount
+        : undefined
+}
+
+/**
+ * Resolves the row challenge fee amount for callers allowed to see markup.
+ *
+ * @param item Raw locked or consumed billing-account line item.
+ * @param displayAmount Member-payment amount selected for display.
+ * @param billingAccountDetails Billing account detail payload containing hidden markup when available.
+ * @param challengeDetailsById Hydrated challenge details, or `undefined` while loading.
+ * @returns Persisted consumed challenge fee, calculated markup fee, or
+ * `undefined` when the fee cannot be derived.
+ * @remarks Consumed challenge rows with an explicit member subtotal do not
+ * need challenge markup hydration to show the correct fee.
+ */
+function getLineItemChallengeFeeAmount(
+    item: BillingAccountLineItem,
+    displayAmount: number | undefined,
+    billingAccountDetails: BillingAccountDetails,
+    challengeDetailsById: ChallengeDetailsById | undefined,
+): number | undefined {
+    const consumedChallengeFeeAmount = getConsumedChallengeFeeAmount(item)
+
+    if (consumedChallengeFeeAmount !== undefined) {
+        return consumedChallengeFeeAmount
+    }
+
+    const challengeMarkup = item.externalType === 'CHALLENGE'
+        ? getLineItemChallengeMarkup(item, billingAccountDetails, challengeDetailsById)
+        : billingAccountDetails.markup
+
+    return calculatePaymentChallengeFee(displayAmount, challengeMarkup)
 }
 
 /**
@@ -392,11 +456,13 @@ function getDisplayLineItem(
         billingAccountDetails,
         challengeDetailsById,
     )
-    const challengeMarkup = item.externalType === 'CHALLENGE'
-        ? getLineItemChallengeMarkup(item, billingAccountDetails, challengeDetailsById)
-        : billingAccountDetails.markup
     const challengeFeeAmount = showChallengeFee
-        ? calculatePaymentChallengeFee(displayAmount, challengeMarkup)
+        ? getLineItemChallengeFeeAmount(
+            item,
+            displayAmount,
+            billingAccountDetails,
+            challengeDetailsById,
+        )
         : undefined
 
     return {


### PR DESCRIPTION
What was broken
Completed challenge billing rows could still show the consumed billing ledger total as Member Payments for non-admin users when markup data was hidden or unavailable. That left examples such as a $33.25 completed challenge row showing $33.25 member payments and a $10.97 challenge fee instead of $25.00 member payments and an $8.25 challenge fee.

Root cause
The previous fixes corrected the locked-row and markup fallback paths, but the modal ignored `memberPaymentAmount` for every challenge row. That was necessary for active/locked challenge rows because those aliases can be markup-adjusted, but it was wrong for consumed challenge rows where the API can provide the exact completed member-payment subtotal.

What was changed
Consumed challenge rows now prefer `memberPaymentAmount` when present. Fee-visible views derive the consumed-row challenge fee from the ledger amount minus that member-payment subtotal before falling back to markup calculation, while locked challenge rows keep using the stored row amount.

Any added/updated tests
Added BillingAccountLineItemsModal regression coverage for consumed challenge rows where challenge markup cannot be loaded, covering both manager/admin fee-visible views and copilot-safe views.

Validation run:
- `yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx` passed.
- `yarn lint` passed.
- `yarn run build` passed with existing warnings.
- `yarn test:no-watch` was run and failed in unrelated suites: `PaymentView.spec.tsx` has an existing wallet-admin project-link expectation mismatch, and `ChallengeEditorForm.spec.tsx` cannot resolve the existing virtual `~/libs/core` import through the components barrel.
