### PR TITLE
PM-5059: Highlight Topgear active review issues

### DIFF
--- a/src/apps/admin/src/lib/components/common/TableMobile/TableMobile.tsx
+++ b/src/apps/admin/src/lib/components/common/TableMobile/TableMobile.tsx
@@ -15,6 +15,7 @@ interface Props<T> {
     readonly columns: ReadonlyArray<MobileTableColumn<T>[]>
     readonly data: ReadonlyArray<T>
     className?: string
+    readonly rowClassName?: (data: T) => string | undefined
 }
 
 function getKey(key: (string | number)[]): string {
@@ -33,10 +34,13 @@ export const TableMobile: <T extends { [propertyName: string]: any }>(
                         {props.columns.map((itemColumns, indexColumns) => (
                             <tr
                                 key={getKey([indexData, indexColumns])}
-                                className={classNames({
-                                    [styles.isEvenRow]: indexData % 2 === 1,
-                                    [styles.isOddRow]: indexData % 2 === 0,
-                                })}
+                                className={classNames(
+                                    props.rowClassName?.(itemData),
+                                    {
+                                        [styles.isEvenRow]: indexData % 2 === 1,
+                                        [styles.isOddRow]: indexData % 2 === 0,
+                                    },
+                                )}
                             >
                                 {itemColumns.map(
                                     (itemItemColumns, indexItemColumns) => (

--- a/src/apps/review/src/lib/components/TableActiveReviews/TableActiveReviews.module.scss
+++ b/src/apps/review/src/lib/components/TableActiveReviews/TableActiveReviews.module.scss
@@ -42,6 +42,22 @@
     vertical-align: middle;
 }
 
+.iterativeReviewIssueRow {
+    td {
+        background-color: rgba($red-25, 0.45) !important;
+        border-bottom: 1px solid $red-140;
+        border-top: 1px solid $red-140;
+
+        &:first-child {
+            border-left: 1px solid $red-140;
+        }
+
+        &:last-child {
+            border-right: 1px solid $red-140;
+        }
+    }
+}
+
 .blockMyRoles {
     display: flex;
     flex-direction: column;

--- a/src/apps/review/src/lib/components/TableActiveReviews/TableActiveReviews.tsx
+++ b/src/apps/review/src/lib/components/TableActiveReviews/TableActiveReviews.tsx
@@ -251,6 +251,13 @@ export const TableActiveReviews: FC<Props> = (props: Props) => {
                 baseColumns.push(
                     {
                         className: styles.tableCell,
+                        isSortable: false,
+                        label: 'Submissions',
+                        propertyName: 'numOfSubmissions',
+                        type: 'text',
+                    },
+                    {
+                        className: styles.tableCell,
                         isSortable: true,
                         label: 'Phase',
                         propertyName: 'currentPhase',
@@ -385,6 +392,23 @@ export const TableActiveReviews: FC<Props> = (props: Props) => {
         [onToggleSort, sortMapping],
     )
 
+    /**
+     * Returns the highlight class for active Topgear Task rows with submissions
+     * where Iterative Review is still closed.
+     *
+     * @param data active challenge row data
+     * @returns row CSS class when the issue condition is met; otherwise undefined
+     * @throws This callback does not throw.
+     */
+    const getRowClassName = useCallback(
+        (data: ActiveReviewAssignment) => (
+            data.hasIterativeReviewIssue
+                ? styles.iterativeReviewIssueRow
+                : undefined
+        ),
+        [],
+    )
+
     return (
         <TableWrapper
             className={classNames(
@@ -394,11 +418,16 @@ export const TableActiveReviews: FC<Props> = (props: Props) => {
             )}
         >
             {isTablet ? (
-                <TableMobile columns={columnsMobile} data={datas} />
+                <TableMobile
+                    columns={columnsMobile}
+                    data={datas}
+                    rowClassName={getRowClassName}
+                />
             ) : (
                 <Table
                     columns={columns}
                     data={datas}
+                    rowClassName={getRowClassName}
                     onToggleSort={handleToggleSort}
                     removeDefaultSort
                     forceSort={displaySort}

--- a/src/apps/review/src/lib/hooks/useFetchActiveReviews.spec.tsx
+++ b/src/apps/review/src/lib/hooks/useFetchActiveReviews.spec.tsx
@@ -10,7 +10,7 @@ import {
     fetchActiveReviews,
 } from '../services'
 
-import { useFetchActiveReviews } from './useFetchActiveReviews'
+import { transformAssignments, useFetchActiveReviews } from './useFetchActiveReviews'
 import type { useFetchActiveReviewsProps } from './useFetchActiveReviews'
 
 jest.mock('~/config', () => ({
@@ -106,5 +106,30 @@ describe('useFetchActiveReviews', () => {
         })
         expect(screen.getByText('No active reviews'))
             .toBeTruthy()
+    })
+
+    it('marks topgear tasks with submissions and closed iterative review phase', () => {
+        const [assignment] = transformAssignments([
+            {
+                challengeEndDate: '2026-01-01T00:00:00.000Z',
+                challengeId: 'challenge-1',
+                challengeName: 'Topgear Problem',
+                challengeTypeId: 'topgear-task-type',
+                challengeTypeName: 'Topgear Task',
+                currentPhaseEndDate: '2026-01-01T00:00:00.000Z',
+                currentPhaseName: 'Topgear Submission',
+                hasAIReview: false,
+                isIterativeReviewPhaseOpen: false,
+                numOfSubmissions: 2,
+                resourceRoleName: 'Reviewer',
+                reviewProgress: 0,
+                timeLeftInCurrentPhase: 0,
+            },
+        ])
+
+        expect(assignment.numOfSubmissions)
+            .toBe(2)
+        expect(assignment.hasIterativeReviewIssue)
+            .toBe(true)
     })
 })

--- a/src/apps/review/src/lib/hooks/useFetchActiveReviews.ts
+++ b/src/apps/review/src/lib/hooks/useFetchActiveReviews.ts
@@ -121,6 +121,11 @@ export const transformAssignments = (
                 / normalizedReviewProgressValues.length,
             )
             : undefined
+        const numOfSubmissions = base.numOfSubmissions ?? 0
+        const hasIterativeReviewIssue = base.challengeTypeName?.trim()
+            .toLowerCase() === 'topgear task'
+            && numOfSubmissions > 0
+            && base.isIterativeReviewPhaseOpen === false
 
         const currentIndex = index
         index += 1
@@ -142,9 +147,11 @@ export const transformAssignments = (
                     .format(TABLE_DATE_FORMAT)
                 : undefined,
             hasAIReview: base.hasAIReview,
+            hasIterativeReviewIssue,
             id: base.challengeId,
             index: currentIndex,
             name: base.challengeName,
+            numOfSubmissions,
             resourceRoles,
             reviewProgress: aggregatedReviewProgress,
             status: base.status,

--- a/src/apps/review/src/lib/models/ActiveReviewAssignment.model.ts
+++ b/src/apps/review/src/lib/models/ActiveReviewAssignment.model.ts
@@ -18,6 +18,8 @@ export interface ActiveReviewAssignment {
     resourceRoles: string[]
     challengeTypeId: string
     challengeTypeName: string
+    numOfSubmissions: number
+    hasIterativeReviewIssue: boolean
     winnerHandle?: string
     winnerHandleColor?: string
     winnerProfileUrl?: string

--- a/src/apps/review/src/lib/models/BackendMyReviewAssignment.model.ts
+++ b/src/apps/review/src/lib/models/BackendMyReviewAssignment.model.ts
@@ -24,6 +24,8 @@ export interface BackendMyReviewAssignment {
     timeLeftInCurrentPhase: number | null
     resourceRoleName: string
     reviewProgress: number | null
+    numOfSubmissions?: number | null
+    isIterativeReviewPhaseOpen?: boolean | null
     winners?: BackendMyReviewAssignmentWinner[] | null
     status?: string
 }

--- a/src/libs/ui/lib/components/table/Table.tsx
+++ b/src/libs/ui/lib/components/table/Table.tsx
@@ -34,6 +34,7 @@ interface TableProps<T> {
     readonly onLoadMoreClick?: () => void
     readonly onRowClick?: (data: T) => void
     readonly onToggleSort?: (sort: Sort | undefined) => void
+    readonly rowClassName?: (data: T) => string | undefined
     readonly removeDefaultSort?: boolean
     readonly colWidth?: colWidthType | undefined,
     readonly setColWidth?: Dispatch<SetStateAction<colWidthType>> | undefined
@@ -248,6 +249,7 @@ const Table: <T extends { [propertyName: string]: any }>(props: TableProps<T>) =
                     allRows={sortedData}
                     onRowClick={props.onRowClick}
                     columns={props.columns}
+                    className={props.rowClassName?.(sorted)}
                     index={index}
                     showExpand={props.showExpand}
                     expandMode={props.expandMode}

--- a/src/libs/ui/lib/components/table/table-row/TableRow.tsx
+++ b/src/libs/ui/lib/components/table/table-row/TableRow.tsx
@@ -78,6 +78,7 @@ export const TableRow: <T extends { [propertyName: string]: any }>(
             <tr
                 className={classNames(
                     styles.tr,
+                    props.className,
                     props.onRowClick ? styles.clickable : undefined,
                     {
                         [styles.isEvenRow]: props.index % 2 === 1,
@@ -97,9 +98,13 @@ export const TableRow: <T extends { [propertyName: string]: any }>(
             </tr>
             {props.showExpand && isExpanded && (
                 <tr
-                    className={classNames(styles.tr, {
-                        [styles.isEvenRow]: props.index % 2 === 1,
-                    })}
+                    className={classNames(
+                        styles.tr,
+                        props.className,
+                        {
+                            [styles.isEvenRow]: props.index % 2 === 1,
+                        },
+                    )}
                 >
                     <td colSpan={displayColumns.length}>
                         {expandColumns.map((col, colIndex) => {


### PR DESCRIPTION
What was broken
The My Active Challenges table did not show submission counts, and support had no visual indicator for Topgear Task challenges with submissions where Iterative Review had not opened.

Root cause (if identifiable)
The review app model and table only used the current active-review assignment fields, so it ignored submission totals and Iterative Review phase state from the backend.

What was changed
Threaded submission count and Iterative Review state through the active review models, added a Submissions column, and highlighted affected Topgear Task rows with a faint red background and red border on desktop and mobile tables.

Any added/updated tests
Added active review assignment transformation coverage for the Topgear Task issue condition.
