### PR TITLE
PM-4669 engagements payment cycles

### DIFF
--- a/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.tsx
+++ b/src/apps/wallet-admin/src/lib/components/payment-view/PaymentView.tsx
@@ -264,9 +264,15 @@ const PaymentView: React.FC<PaymentViewProps> = (props: PaymentViewProps) => {
                                             </p>
                                         </div>
                                         <div className={styles.infoItem}>
-                                            <span className={styles.label}>Standard Hours per Week</span>
+                                            <span className={styles.label}>Standard Hours per Day</span>
                                             <p className={styles.value}>
-                                                {formatOptionalText(paymentDetails?.engagementDetails?.standardHoursPerWeek)}
+                                                {formatOptionalText(paymentDetails?.engagementDetails?.standardHoursPerDay)}
+                                            </p>
+                                        </div>
+                                        <div className={styles.infoItem}>
+                                            <span className={styles.label}>Payment Cycle</span>
+                                            <p className={styles.value}>
+                                                {formatOptionalText(paymentDetails?.engagementDetails?.paymentCycle) || 'WEEKLY'}
                                             </p>
                                         </div>
                                         <div className={styles.infoItem}>

--- a/src/apps/wallet-admin/src/lib/models/WinningDetail.ts
+++ b/src/apps/wallet-admin/src/lib/models/WinningDetail.ts
@@ -28,7 +28,9 @@ export interface PaymentEngagementDetails {
     engagementTitle?: string
     billingStartDate?: string
     durationMonths?: number
+    paymentCycle?: string
     ratePerHour?: string
+    standardHoursPerDay?: number
     standardHoursPerWeek?: number
     otherRemarks?: string
 }

--- a/src/apps/wallet-admin/src/lib/services/wallet.ts
+++ b/src/apps/wallet-admin/src/lib/services/wallet.ts
@@ -27,9 +27,11 @@ interface EngagementAssignmentContextResponse {
     engagementId: string
     engagementTitle: string
     otherRemarks?: string | null
+    paymentCycle?: string | null
     projectId: string
     projectName?: string
     ratePerHour?: string | null
+    standardHoursPerDay?: number | null
     standardHoursPerWeek?: number | null
     startDate?: string | null
 }
@@ -40,7 +42,9 @@ interface EngagementAssignmentResponse {
     memberHandle?: string | null
     memberId?: number | string | null
     otherRemarks?: string | null
+    paymentCycle?: string | null
     ratePerHour?: string | null
+    standardHoursPerDay?: number | string | null
     standardHoursPerWeek?: number | string | null
     startDate?: string | null
 }
@@ -106,6 +110,11 @@ function normalizeOptionalNumber(value: unknown): number | undefined {
 function mapAssignmentContextToEngagementDetails(
     context: EngagementAssignmentContextResponse,
 ): PaymentEngagementDetails {
+    const standardHoursPerDay = normalizeOptionalNumber(context.standardHoursPerDay)
+        ?? (normalizeOptionalNumber(context.standardHoursPerWeek) !== undefined
+            ? Number((Number(context.standardHoursPerWeek) / 5).toFixed(2))
+            : undefined)
+
     return {
         assignmentId: normalizeOptionalString(context.assignmentId),
         billingStartDate: normalizeOptionalString(context.startDate),
@@ -113,9 +122,11 @@ function mapAssignmentContextToEngagementDetails(
         engagementId: normalizeOptionalString(context.engagementId),
         engagementTitle: normalizeOptionalString(context.engagementTitle),
         otherRemarks: normalizeOptionalString(context.otherRemarks),
+        paymentCycle: normalizeOptionalString(context.paymentCycle) || 'WEEKLY',
         projectId: normalizeOptionalString(context.projectId),
         projectName: normalizeOptionalString(context.projectName),
         ratePerHour: normalizeOptionalString(context.ratePerHour),
+        standardHoursPerDay,
         standardHoursPerWeek: normalizeOptionalNumber(context.standardHoursPerWeek),
     }
 }
@@ -198,6 +209,10 @@ function buildEngagementDetailsFromEngagement(
     }
 
     const assignment = findMatchingEngagementAssignment(engagement.assignments, winning)
+    const standardHoursPerDay = normalizeOptionalNumber(assignment?.standardHoursPerDay)
+        ?? (normalizeOptionalNumber(assignment?.standardHoursPerWeek) !== undefined
+            ? Number((Number(assignment?.standardHoursPerWeek) / 5).toFixed(2))
+            : undefined)
 
     return {
         assignmentId: normalizeOptionalString(assignment?.id) || normalizeOptionalString(winning.assignmentId),
@@ -206,6 +221,7 @@ function buildEngagementDetailsFromEngagement(
         engagementId,
         engagementTitle: normalizeOptionalString(engagement.title),
         otherRemarks: normalizeOptionalString(assignment?.otherRemarks),
+        paymentCycle: normalizeOptionalString(assignment?.paymentCycle) || 'WEEKLY',
         projectId:
             normalizeOptionalString(engagement.projectId)
             || normalizeOptionalString(engagement.project?.id),
@@ -213,6 +229,7 @@ function buildEngagementDetailsFromEngagement(
             normalizeOptionalString(engagement.projectName)
             || normalizeOptionalString(engagement.project?.name),
         ratePerHour: normalizeOptionalString(assignment?.ratePerHour),
+        standardHoursPerDay,
         standardHoursPerWeek: normalizeOptionalNumber(assignment?.standardHoursPerWeek),
     }
 }

--- a/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.tsx
+++ b/src/apps/work/src/lib/components/AcceptApplicationModal/AcceptApplicationModal.tsx
@@ -33,8 +33,10 @@ export interface AcceptApplicationFormData {
     agreementRate: string
     durationMonths: number
     otherRemarks?: string
+    paymentCycle: string
     ratePerHour: string
     startDate: string
+    standardHoursPerDay: number
     standardHoursPerWeek: number
 }
 
@@ -48,9 +50,10 @@ interface AcceptApplicationModalProps {
 
 interface ValidationErrors {
     durationMonths?: string
+    paymentCycle?: string
     ratePerHour?: string
     startDate?: string
-    standardHoursPerWeek?: string
+    standardHoursPerDay?: string
 }
 
 const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
@@ -59,9 +62,10 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
     const [durationMonths, setDurationMonths] = useState<string>('')
     const [errors, setErrors] = useState<ValidationErrors>({})
     const [otherRemarks, setOtherRemarks] = useState<string>('')
+    const [paymentCycle, setPaymentCycle] = useState<string>('WEEKLY')
     const [ratePerHour, setRatePerHour] = useState<string>('')
     const [startDate, setStartDate] = useState<Date | undefined>()
-    const [standardHoursPerWeek, setStandardHoursPerWeek] = useState<string>('')
+    const [standardHoursPerDay, setStandardHoursPerDay] = useState<string>('')
 
     const isSubmitting = props.isSubmitting === true
 
@@ -72,17 +76,29 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
         [],
     )
     const agreementRate = useMemo(
-        () => calculateAssignmentRatePerWeek(ratePerHour, standardHoursPerWeek),
-        [ratePerHour, standardHoursPerWeek],
+        () => {
+            const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+                standardHoursPerDay,
+                2,
+            )
+
+            if (parsedStandardHoursPerDay === undefined) {
+                return ''
+            }
+
+            return calculateAssignmentRatePerWeek(ratePerHour, parsedStandardHoursPerDay * 5)
+        },
+        [ratePerHour, standardHoursPerDay],
     )
 
     const resetState = useCallback((): void => {
         setDurationMonths('')
         setErrors({})
         setOtherRemarks('')
+        setPaymentCycle('WEEKLY')
         setRatePerHour('')
         setStartDate(undefined)
-        setStandardHoursPerWeek('')
+        setStandardHoursPerDay('')
     }, [])
 
     const handleCancel = useCallback((): void => {
@@ -94,10 +110,13 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
         const nextErrors: ValidationErrors = {}
         const parsedDurationMonths = toPositiveInteger(durationMonths)
         const parsedRatePerHour = toPositiveNumber(ratePerHour)
-        const parsedStandardHoursPerWeek = toPositiveNumberWithMaxDecimalPlaces(
-            standardHoursPerWeek,
+        const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+            standardHoursPerDay,
             2,
         )
+        const normalizedPaymentCycle = String(paymentCycle || 'WEEKLY')
+            .trim()
+            .toUpperCase()
 
         if (!startDate) {
             nextErrors.startDate = 'Billing start date is required.'
@@ -111,9 +130,13 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
             nextErrors.ratePerHour = 'Rate per hour must be a positive number.'
         }
 
-        if (parsedStandardHoursPerWeek === undefined) {
-            nextErrors.standardHoursPerWeek = 'Standard hours per week must be a '
+        if (parsedStandardHoursPerDay === undefined) {
+            nextErrors.standardHoursPerDay = 'Standard hours per day must be a '
                 + 'positive number with up to 2 decimal places.'
+        }
+
+        if (!['WEEKLY', 'FORTNIGHTLY', 'MONTHLY'].includes(normalizedPaymentCycle)) {
+            nextErrors.paymentCycle = 'Payment cycle must be Weekly, Fortnightly, or Monthly.'
         }
 
         if (Object.keys(nextErrors).length > 0) {
@@ -125,7 +148,7 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
             !startDate
             || parsedDurationMonths === undefined
             || parsedRatePerHour === undefined
-            || parsedStandardHoursPerWeek === undefined
+            || parsedStandardHoursPerDay === undefined
         ) {
             return
         }
@@ -134,8 +157,10 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
             agreementRate,
             durationMonths: parsedDurationMonths,
             otherRemarks: otherRemarks.trim() || undefined,
+            paymentCycle: normalizedPaymentCycle,
             ratePerHour: parsedRatePerHour.toString(),
-            standardHoursPerWeek: parsedStandardHoursPerWeek,
+            standardHoursPerDay: parsedStandardHoursPerDay,
+            standardHoursPerWeek: Number((parsedStandardHoursPerDay * 5).toFixed(2)),
             startDate: serializeTentativeAssignmentDate(startDate),
         })
 
@@ -144,10 +169,11 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
         agreementRate,
         durationMonths,
         otherRemarks,
+        paymentCycle,
         props,
         ratePerHour,
         resetState,
-        standardHoursPerWeek,
+        standardHoursPerDay,
         startDate,
     ])
 
@@ -257,43 +283,52 @@ const AcceptApplicationModal: FC<AcceptApplicationModalProps> = (
 
                 <div className={styles.fieldRow}>
                     <label className={styles.label} htmlFor='accept-application-standard-hours'>
-                        Standard hours per week *
+                        Standard hours per day *
                     </label>
                     <input
                         id='accept-application-standard-hours'
                         className={styles.input}
                         inputMode='decimal'
                         onChange={event => {
-                            setStandardHoursPerWeek(
+                            setStandardHoursPerDay(
                                 sanitizePositiveNumericInput(event.target.value, 2),
                             )
                             setErrors(previous => ({
                                 ...previous,
-                                standardHoursPerWeek: undefined,
+                                standardHoursPerDay: undefined,
                             }))
                         }}
                         pattern='[0-9.]*'
                         type='text'
-                        value={standardHoursPerWeek}
+                        value={standardHoursPerDay}
                     />
-                    {errors.standardHoursPerWeek
-                        ? <p className={styles.error}>{errors.standardHoursPerWeek}</p>
+                    {errors.standardHoursPerDay
+                        ? <p className={styles.error}>{errors.standardHoursPerDay}</p>
                         : undefined}
                 </div>
 
                 <div className={styles.fieldRow}>
-                    <label className={styles.label} htmlFor='accept-application-rate'>
-                        Assignment rate per week *
+                    <label className={styles.label} htmlFor='accept-application-payment-cycle'>
+                        Payment cycle *
                     </label>
-                    <input
-                        id='accept-application-rate'
+                    <select
+                        id='accept-application-payment-cycle'
                         className={styles.input}
-                        readOnly
-                        type='text'
-                        value={agreementRate}
-                    />
-                    {!agreementRate
-                        ? <p className={styles.error}>Assignment rate is calculated after entering hourly details.</p>
+                        onChange={event => {
+                            setPaymentCycle(event.target.value)
+                            setErrors(previous => ({
+                                ...previous,
+                                paymentCycle: undefined,
+                            }))
+                        }}
+                        value={paymentCycle}
+                    >
+                        <option value='WEEKLY'>Weekly</option>
+                        <option value='FORTNIGHTLY'>Fortnightly</option>
+                        <option value='MONTHLY'>Monthly</option>
+                    </select>
+                    {errors.paymentCycle
+                        ? <p className={styles.error}>{errors.paymentCycle}</p>
                         : undefined}
                 </div>
 

--- a/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
+++ b/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
@@ -25,8 +25,10 @@ import {
 } from '../../models'
 import {
     calculatePaymentAmount,
+    getAssignmentPaymentCycle,
     getAssignmentRatePerHour,
-    getAssignmentStandardHoursPerWeek,
+    getAssignmentStandardHoursPerDay,
+    getExpectedHoursLabel,
 } from '../../utils'
 import {
     calculatePaymentChallengeFee,
@@ -55,11 +57,10 @@ interface PaymentFormModalProps {
 }
 
 interface ValidationErrors {
+    fromDate?: string
     hoursWorked?: string
-    weekEnding?: string
+    toDate?: string
 }
-
-const SATURDAY_DAY_INDEX = 6
 
 function normalizeTitleSegment(value?: string): string {
     return String(value || '')
@@ -68,46 +69,32 @@ function normalizeTitleSegment(value?: string): string {
 
 function formatTitleDate(value: Date): string {
     return value.toLocaleDateString('en-US', {
-        day: '2-digit',
+        day: 'numeric',
         month: 'short',
         year: 'numeric',
     })
 }
 
-function formatWeekEndingTitle(value?: Date | null): string {
-    if (!value) {
+function formatWorkPeriodTitle(fromDate?: Date | null, toDate?: Date | null): string {
+    if (!fromDate || !toDate) {
         return ''
     }
 
-    return `Week Ending: ${formatTitleDate(value)}`
+    return `Work Period ${formatTitleDate(fromDate)} - ${formatTitleDate(toDate)}`
 }
 
 function buildPaymentTitle(
     projectName?: string,
     engagementName?: string,
-    weekEndingTitle?: string,
+    workPeriodTitle?: string,
 ): string {
     return [
         normalizeTitleSegment(projectName),
         normalizeTitleSegment(engagementName),
-        normalizeTitleSegment(weekEndingTitle),
+        normalizeTitleSegment(workPeriodTitle),
     ]
         .filter(Boolean)
         .join(' - ')
-}
-
-function getDefaultWeekEndingDate(): Date {
-    const defaultDate = new Date()
-    defaultDate.setHours(0, 0, 0, 0)
-
-    const daysUntilSaturday = (SATURDAY_DAY_INDEX - defaultDate.getDay() + 7) % 7
-    defaultDate.setDate(defaultDate.getDate() + daysUntilSaturday)
-
-    return defaultDate
-}
-
-function isSaturday(value?: Date | null): boolean {
-    return Boolean(value) && value?.getDay() === SATURDAY_DAY_INDEX
 }
 
 function normalizePositiveValue(value: unknown): string {
@@ -125,12 +112,12 @@ function normalizePositiveValue(value: unknown): string {
         .toString()
 }
 
-const WeekEndingInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+const DateInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
     (props, ref): JSX.Element => (
         <input
             {...props}
             className={`${styles.input} ${String(props.className || '')}`.trim()}
-            placeholder='Week ending: ...'
+            placeholder={props.placeholder || 'Select date'}
             readOnly
             ref={ref}
             type='text'
@@ -138,7 +125,7 @@ const WeekEndingInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInp
     ),
 )
 
-WeekEndingInput.displayName = 'WeekEndingInput'
+DateInput.displayName = 'DateInput'
 
 const PaymentFormModal: FC<PaymentFormModalProps> = (
     props: PaymentFormModalProps,
@@ -146,9 +133,10 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
     const isSubmitting = props.isSubmitting === true
 
     const [errors, setErrors] = useState<ValidationErrors>({})
+    const [fromDate, setFromDate] = useState<Date | null>(null)
     const [hoursWorked, setHoursWorked] = useState<string>('')
     const [remarks, setRemarks] = useState<string>('')
-    const [weekEndingDate, setWeekEndingDate] = useState<Date | null>(() => getDefaultWeekEndingDate())
+    const [toDate, setToDate] = useState<Date | null>(null)
 
     const ratePerHour = useMemo(
         () => getAssignmentRatePerHour(props.member || {}),
@@ -164,26 +152,43 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
             : undefined),
         [amount, props.billingAccountMarkup],
     )
+    const paymentCycle = useMemo(
+        () => getAssignmentPaymentCycle(props.member || {}),
+        [props.member],
+    )
+    const standardHoursPerDay = useMemo(
+        () => getAssignmentStandardHoursPerDay(props.member || {}),
+        [props.member],
+    )
+    const expectedHoursLabel = useMemo(
+        () => getExpectedHoursLabel(props.member || {}),
+        [props.member],
+    )
     const paymentTitle = useMemo(
         () => {
-            if (!isSaturday(weekEndingDate)) {
+            if (!fromDate || !toDate) {
+                return ''
+            }
+
+            if (fromDate.getTime() > toDate.getTime()) {
                 return ''
             }
 
             return buildPaymentTitle(
                 props.projectName,
                 props.engagementName,
-                formatWeekEndingTitle(weekEndingDate),
+                formatWorkPeriodTitle(fromDate, toDate),
             )
         },
-        [props.engagementName, props.projectName, weekEndingDate],
+        [fromDate, props.engagementName, props.projectName, toDate],
     )
 
     const resetState = useCallback((): void => {
         setErrors({})
-        setHoursWorked(normalizePositiveValue(getAssignmentStandardHoursPerWeek(props.member || {})))
+        setFromDate(null)
+        setHoursWorked('')
         setRemarks('')
-        setWeekEndingDate(getDefaultWeekEndingDate())
+        setToDate(null)
     }, [props.member])
 
     useEffect(() => {
@@ -204,12 +209,20 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
         const nextErrors: ValidationErrors = {}
         const parsedHoursWorked = Number(hoursWorked)
 
-        if (!weekEndingDate) {
-            nextErrors.weekEnding = 'Week ending date is required.'
-        } else if (!isSaturday(weekEndingDate)) {
-            nextErrors.weekEnding = 'Week ending date must be a Saturday.'
-        } else if (!paymentTitle.trim()) {
-            nextErrors.weekEnding = 'Payment title cannot be generated from week ending.'
+        if (!fromDate) {
+            nextErrors.fromDate = 'From date is required.'
+        }
+
+        if (!toDate) {
+            nextErrors.toDate = 'To date is required.'
+        }
+
+        if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
+            nextErrors.toDate = 'To date must be the same day or after the from date.'
+        }
+
+        if (!paymentTitle.trim()) {
+            nextErrors.fromDate = nextErrors.fromDate || 'Payment title cannot be generated from the selected period.'
         }
 
         if (!Number.isFinite(parsedHoursWorked) || parsedHoursWorked <= 0) {
@@ -230,8 +243,9 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
         }
 
         if (
-            !weekEndingDate
-            || !isSaturday(weekEndingDate)
+            !fromDate
+            || !toDate
+            || fromDate.getTime() > toDate.getTime()
             || !paymentTitle.trim()
             || !Number.isFinite(parsedHoursWorked)
             || parsedHoursWorked <= 0
@@ -256,7 +270,7 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
         })
 
         resetState()
-    }, [amount, hoursWorked, paymentTitle, props, ratePerHour, remarks, resetState, weekEndingDate])
+    }, [amount, fromDate, hoursWorked, paymentTitle, props, ratePerHour, remarks, resetState, toDate])
 
     return (
         <BaseModal
@@ -291,8 +305,12 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
                         <span className={styles.infoValue}>{formatCurrency(ratePerHour)}</span>
                     </div>
                     <div className={styles.infoItem}>
-                        <span className={styles.infoLabel}>Rate Per Week</span>
-                        <span className={styles.infoValue}>{formatCurrency(props.member?.agreementRate)}</span>
+                        <span className={styles.infoLabel}>Payment Cycle</span>
+                        <span className={styles.infoValue}>{paymentCycle}</span>
+                    </div>
+                    <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>Standard Hours Per Day</span>
+                        <span className={styles.infoValue}>{normalizePositiveValue(standardHoursPerDay) || '-'}</span>
                     </div>
                     {BILLING_ACCOUNT_MEMBER_PAYMENT_DETAILS_ENABLED
                         ? (
@@ -306,25 +324,52 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
 
                 <div className={styles.fieldRow}>
                     <span className={styles.label}>
-                        Week ending *
+                        From *
                     </span>
                     <DatePicker
-                        customInput={<WeekEndingInput />}
+                        customInput={<DateInput />}
                         dateFormat='MM/dd/yyyy'
                         disabled={isSubmitting}
-                        filterDate={isSaturday}
                         onChange={date => {
-                            setWeekEndingDate(date)
+                            setFromDate(date)
                             setErrors(previous => ({
                                 ...previous,
-                                weekEnding: undefined,
+                                fromDate: undefined,
                             }))
                         }}
-                        placeholderText='Week ending: ...'
+                        placeholderText='From: ...'
                         preventOpenOnFocus
                         portalId='react-date-portal'
                         popperPlacement='bottom-start'
-                        selected={weekEndingDate}
+                        selected={fromDate}
+                    />
+
+                    {errors.fromDate
+                        ? <p className={styles.error}>{errors.fromDate}</p>
+                        : undefined}
+                </div>
+
+                <div className={styles.fieldRow}>
+                    <span className={styles.label}>
+                        To *
+                    </span>
+                    <DatePicker
+                        customInput={<DateInput />}
+                        dateFormat='MM/dd/yyyy'
+                        disabled={isSubmitting}
+                        minDate={fromDate || undefined}
+                        onChange={date => {
+                            setToDate(date)
+                            setErrors(previous => ({
+                                ...previous,
+                                toDate: undefined,
+                            }))
+                        }}
+                        placeholderText='To: ...'
+                        preventOpenOnFocus
+                        portalId='react-date-portal'
+                        popperPlacement='bottom-start'
+                        selected={toDate}
                     />
                     {paymentTitle
                         ? (
@@ -333,14 +378,22 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
                             </p>
                         )
                         : undefined}
-                    {errors.weekEnding
-                        ? <p className={styles.error}>{errors.weekEnding}</p>
+                    {errors.toDate
+                        ? <p className={styles.error}>{errors.toDate}</p>
                         : undefined}
                 </div>
 
                 <div className={styles.fieldRow}>
                     <label className={styles.label} htmlFor='payment-hours-worked'>
                         Hours worked *
+                        {expectedHoursLabel
+                            ? (
+                                <span className={styles.helperText}>
+                                    {' '}
+                                    Expected: {expectedHoursLabel}
+                                </span>
+                            )
+                            : undefined}
                     </label>
                     <input
                         id='payment-hours-worked'

--- a/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
+++ b/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
@@ -331,7 +331,7 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
                         dateFormat='MM/dd/yyyy'
                         disabled={isSubmitting}
                         onChange={date => {
-                            setFromDate(date)
+                            setFromDate(date ?? undefined)
                             setErrors(previous => ({
                                 ...previous,
                                 fromDate: undefined,
@@ -359,7 +359,7 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
                         disabled={isSubmitting}
                         minDate={fromDate || undefined}
                         onChange={date => {
-                            setToDate(date)
+                            setToDate(date ?? undefined)
                             setErrors(previous => ({
                                 ...previous,
                                 toDate: undefined,

--- a/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
+++ b/src/apps/work/src/lib/components/PaymentFormModal/PaymentFormModal.tsx
@@ -133,10 +133,10 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
     const isSubmitting = props.isSubmitting === true
 
     const [errors, setErrors] = useState<ValidationErrors>({})
-    const [fromDate, setFromDate] = useState<Date | null>(null)
+    const [fromDate, setFromDate] = useState<Date | undefined>(undefined)
     const [hoursWorked, setHoursWorked] = useState<string>('')
     const [remarks, setRemarks] = useState<string>('')
-    const [toDate, setToDate] = useState<Date | null>(null)
+    const [toDate, setToDate] = useState<Date | undefined>(undefined)
 
     const ratePerHour = useMemo(
         () => getAssignmentRatePerHour(props.member || {}),
@@ -185,10 +185,10 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
 
     const resetState = useCallback((): void => {
         setErrors({})
-        setFromDate(null)
+        setFromDate(undefined)
         setHoursWorked('')
         setRemarks('')
-        setToDate(null)
+        setToDate(undefined)
     }, [props.member])
 
     useEffect(() => {
@@ -390,7 +390,9 @@ const PaymentFormModal: FC<PaymentFormModalProps> = (
                             ? (
                                 <span className={styles.helperText}>
                                     {' '}
-                                    Expected: {expectedHoursLabel}
+                                    Expected:
+                                    {' '}
+                                    {expectedHoursLabel}
                                 </span>
                             )
                             : undefined}

--- a/src/apps/work/src/lib/models/Engagement.model.ts
+++ b/src/apps/work/src/lib/models/Engagement.model.ts
@@ -18,6 +18,8 @@ export type ApplicationStatus = 'REJECTED' | 'SELECTED' | 'SUBMITTED' | 'UNDER_R
 
 export type AssignmentStatus = 'ACTIVE' | 'ASSIGNED' | 'COMPLETED' | 'OFFER_REJECTED' | 'SELECTED' | 'TERMINATED'
 
+export type PaymentCycle = 'WEEKLY' | 'FORTNIGHTLY' | 'MONTHLY'
+
 export interface Assignment {
     agreementRate: string
     durationMonths?: number | string
@@ -27,8 +29,10 @@ export interface Assignment {
     memberHandle: string
     memberId: number | string
     otherRemarks: string
+    paymentCycle?: PaymentCycle | string
     ratePerHour?: string
     startDate: string
+    standardHoursPerDay?: number | string
     standardHoursPerWeek?: number | string
     status: AssignmentStatus | string
     terminationReason?: string

--- a/src/apps/work/src/lib/schemas/engagement-editor.schema.ts
+++ b/src/apps/work/src/lib/schemas/engagement-editor.schema.ts
@@ -4,8 +4,10 @@ interface EngagementEditorSchemaAssignmentDetails {
     agreementRate?: string
     durationMonths?: number | string
     memberHandle?: string
+    paymentCycle?: string
     ratePerHour?: string
     startDate?: string
+    standardHoursPerDay?: number | string
     standardHoursPerWeek?: number | string
 }
 
@@ -118,7 +120,12 @@ function hasCompleteAssignmentDetails(
         && !Number.isNaN(parsedStartDate.getTime())
         && toPositiveInteger(detail.durationMonths) !== undefined
         && isPositiveDecimal(detail.ratePerHour)
-        && isPositiveDecimal(detail.standardHoursPerWeek, 2)
+        && isPositiveDecimal(detail.standardHoursPerDay, 2)
+        && ['WEEKLY', 'FORTNIGHTLY', 'MONTHLY'].includes(
+            String(detail.paymentCycle || 'WEEKLY')
+                .trim()
+                .toUpperCase(),
+        )
 }
 
 export const engagementEditorSchema: yup.ObjectSchema<EngagementEditorSchemaData> = yup.object({

--- a/src/apps/work/src/lib/services/engagements.service.ts
+++ b/src/apps/work/src/lib/services/engagements.service.ts
@@ -55,8 +55,10 @@ interface AssignmentDetails {
     memberHandle?: string
     memberId?: number | string
     otherRemarks?: string
+    paymentCycle?: string
     ratePerHour?: string
     startDate?: string
+    standardHoursPerDay?: number | string
     standardHoursPerWeek?: number | string
 }
 
@@ -309,6 +311,12 @@ function serializeEngagementPayload(data: EngagementUpsertData): Record<string, 
                         .trim()
                 }
 
+                if (assignment.paymentCycle) {
+                    entry.paymentCycle = String(assignment.paymentCycle)
+                        .trim()
+                        .toUpperCase()
+                }
+
                 if (assignment.ratePerHour) {
                     entry.ratePerHour = String(assignment.ratePerHour)
                         .trim()
@@ -319,8 +327,21 @@ function serializeEngagementPayload(data: EngagementUpsertData): Record<string, 
                 }
 
                 if (
+                    assignment.standardHoursPerDay !== undefined
+                    && assignment.standardHoursPerDay !== ''
+                ) {
+                    const standardHoursPerDay = Number(assignment.standardHoursPerDay)
+
+                    if (Number.isFinite(standardHoursPerDay)) {
+                        entry.standardHoursPerDay = String(standardHoursPerDay)
+                        entry.standardHoursPerWeek = String(Number((standardHoursPerDay * 5).toFixed(2)))
+                    }
+                }
+
+                if (
                     assignment.standardHoursPerWeek !== undefined
                     && assignment.standardHoursPerWeek !== ''
+                    && entry.standardHoursPerDay === undefined
                 ) {
                     const standardHoursPerWeek = Number(assignment.standardHoursPerWeek)
 

--- a/src/apps/work/src/lib/utils/engagement.utils.ts
+++ b/src/apps/work/src/lib/utils/engagement.utils.ts
@@ -132,6 +132,22 @@ function toOptionalNumberishValue(value: unknown): number | string | undefined {
     return undefined
 }
 
+function toStandardHoursPerDay(value: unknown): number | string | undefined {
+    const normalized = toOptionalNumberishValue(value)
+
+    if (normalized === undefined) {
+        return undefined
+    }
+
+    const parsedValue = Number(normalized)
+
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        return undefined
+    }
+
+    return Number((parsedValue / 5).toFixed(2))
+}
+
 function toIdentifierValue(...values: unknown[]): number | string {
     for (const value of values) {
         if (typeof value === 'number' && Number.isFinite(value)) {
@@ -310,6 +326,11 @@ function normalizeAssignment(
     const ratePerHour = toOptionalString(
         assignment.ratePerHour ?? assignment.rate_per_hour,
     )
+    const standardHoursPerDay = toOptionalNumberishValue(
+        assignment.standardHoursPerDay ?? assignment.standard_hours_per_day,
+    ) ?? toStandardHoursPerDay(
+        assignment.standardHoursPerWeek ?? assignment.standard_hours_per_week,
+    )
     const standardHoursPerWeek = toOptionalNumberishValue(
         assignment.standardHoursPerWeek ?? assignment.standard_hours_per_week,
     )
@@ -317,7 +338,13 @@ function normalizeAssignment(
         assignment.agreementRate
         ?? assignment.agreement_rate
         ?? assignment.rate
-        ?? calculateAssignmentRatePerWeek(ratePerHour, standardHoursPerWeek),
+        ?? calculateAssignmentRatePerWeek(
+            ratePerHour,
+            standardHoursPerWeek
+                ?? (standardHoursPerDay !== undefined
+                    ? Number(standardHoursPerDay) * 5
+                    : undefined),
+        ),
     )
 
     return {
@@ -356,7 +383,12 @@ function normalizeAssignment(
             ?? assignment.other_remarks
             ?? assignment.remarks,
         ),
+        paymentCycle: normalizeString(
+            assignment.paymentCycle
+            ?? assignment.payment_cycle,
+        ) || 'WEEKLY',
         ratePerHour,
+        standardHoursPerDay,
         standardHoursPerWeek,
         startDate: toIsoString(
             assignment.startDate

--- a/src/apps/work/src/lib/utils/index.ts
+++ b/src/apps/work/src/lib/utils/index.ts
@@ -12,8 +12,11 @@ export * from './metadata.utils'
 export * from './navigation.utils'
 export {
     calculatePaymentAmount,
+    getAssignmentPaymentCycle,
     getAssignmentRatePerHour,
+    getAssignmentStandardHoursPerDay,
     getAssignmentStandardHoursPerWeek,
+    getExpectedHoursLabel,
     getAssignmentStatus,
     getPaymentAmount,
     getPaymentCreatorLabel,

--- a/src/apps/work/src/lib/utils/payment.utils.ts
+++ b/src/apps/work/src/lib/utils/payment.utils.ts
@@ -233,7 +233,11 @@ export function getAssignmentPaymentCycle(member: Partial<Assignment>): string {
 export function getAssignmentStandardHoursPerDay(
     member: Partial<Assignment>,
 ): number | string | undefined {
-    if (member.standardHoursPerDay !== undefined && member.standardHoursPerDay !== null && member.standardHoursPerDay !== '') {
+    if (
+        member.standardHoursPerDay !== undefined
+        && member.standardHoursPerDay !== null
+        && member.standardHoursPerDay !== ''
+    ) {
         return member.standardHoursPerDay
     }
 
@@ -255,7 +259,11 @@ export function getAssignmentStandardHoursPerDay(
 export function getAssignmentStandardHoursPerWeek(
     member: Partial<Assignment>,
 ): number | string | undefined {
-    if (member.standardHoursPerWeek !== undefined && member.standardHoursPerWeek !== null && member.standardHoursPerWeek !== '') {
+    if (
+        member.standardHoursPerWeek !== undefined
+        && member.standardHoursPerWeek !== null
+        && member.standardHoursPerWeek !== ''
+    ) {
         return member.standardHoursPerWeek
     }
 

--- a/src/apps/work/src/lib/utils/payment.utils.ts
+++ b/src/apps/work/src/lib/utils/payment.utils.ts
@@ -5,6 +5,8 @@ import {
 
 import { Assignment, AssignmentPayment } from '../models'
 
+const DEFAULT_PAYMENT_CYCLE = 'WEEKLY'
+
 const currencyFormatter = new Intl.NumberFormat('en-US', {
     currency: 'USD',
     style: 'currency',
@@ -220,6 +222,30 @@ export function getAssignmentStatus(member: Partial<Assignment>): string {
     return String(member.status)
 }
 
+export function getAssignmentPaymentCycle(member: Partial<Assignment>): string {
+    const normalizedCycle = toOptionalDisplayString(member.paymentCycle)
+
+    return normalizedCycle
+        ? normalizedCycle.toUpperCase()
+        : DEFAULT_PAYMENT_CYCLE
+}
+
+export function getAssignmentStandardHoursPerDay(
+    member: Partial<Assignment>,
+): number | string | undefined {
+    if (member.standardHoursPerDay !== undefined && member.standardHoursPerDay !== null && member.standardHoursPerDay !== '') {
+        return member.standardHoursPerDay
+    }
+
+    const standardHoursPerWeek = toNumber(member.standardHoursPerWeek)
+
+    if (standardHoursPerWeek === undefined || standardHoursPerWeek <= 0) {
+        return undefined
+    }
+
+    return Number((standardHoursPerWeek / 5).toFixed(2))
+}
+
 /**
  * Reads the assignment standard hours value from a member object.
  *
@@ -229,7 +255,17 @@ export function getAssignmentStatus(member: Partial<Assignment>): string {
 export function getAssignmentStandardHoursPerWeek(
     member: Partial<Assignment>,
 ): number | string | undefined {
-    return member.standardHoursPerWeek
+    if (member.standardHoursPerWeek !== undefined && member.standardHoursPerWeek !== null && member.standardHoursPerWeek !== '') {
+        return member.standardHoursPerWeek
+    }
+
+    const standardHoursPerDay = toNumber(getAssignmentStandardHoursPerDay(member))
+
+    if (standardHoursPerDay === undefined || standardHoursPerDay <= 0) {
+        return undefined
+    }
+
+    return Number((standardHoursPerDay * 5).toFixed(2))
 }
 
 /**
@@ -260,6 +296,29 @@ export function getAssignmentRatePerHour(
     }
 
     return agreementRate / standardHoursPerWeek
+}
+
+export function getExpectedHoursLabel(member: Partial<Assignment>): string {
+    const standardHoursPerDay = toNumber(getAssignmentStandardHoursPerDay(member))
+
+    if (standardHoursPerDay === undefined || standardHoursPerDay <= 0) {
+        return ''
+    }
+
+    const paymentCycle = getAssignmentPaymentCycle(member)
+
+    if (paymentCycle === 'FORTNIGHTLY') {
+        return `${Number((standardHoursPerDay * 10).toFixed(2))} hours`
+    }
+
+    if (paymentCycle === 'MONTHLY') {
+        const minimum = Number((standardHoursPerDay * 20).toFixed(2))
+        const maximum = Number((standardHoursPerDay * 23).toFixed(2))
+
+        return `${minimum}-${maximum} hours`
+    }
+
+    return `${Number((standardHoursPerDay * 5).toFixed(2))} hours`
 }
 
 /**

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/AssignmentDetailsModal.tsx
@@ -33,8 +33,10 @@ export interface AssignmentDetailsFormValue {
     durationMonths: string
     memberHandle: string
     otherRemarks?: string
+    paymentCycle: string
     ratePerHour: string
     startDate: string
+    standardHoursPerDay: string
     standardHoursPerWeek: string
 }
 
@@ -48,9 +50,10 @@ interface AssignmentDetailsModalProps {
 
 interface ValidationErrors {
     durationMonths?: string
+    paymentCycle?: string
     ratePerHour?: string
     startDate?: string
-    standardHoursPerWeek?: string
+    standardHoursPerDay?: string
 }
 
 export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
@@ -59,12 +62,13 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
     const [durationMonths, setDurationMonths] = useState<string>(props.initialValue?.durationMonths || '')
     const [errors, setErrors] = useState<ValidationErrors>({})
     const [otherRemarks, setOtherRemarks] = useState<string>(props.initialValue?.otherRemarks || '')
+    const [paymentCycle, setPaymentCycle] = useState<string>(props.initialValue?.paymentCycle || 'WEEKLY')
     const [ratePerHour, setRatePerHour] = useState<string>(props.initialValue?.ratePerHour || '')
     const [startDate, setStartDate] = useState<Date | undefined>(
         deserializeTentativeAssignmentDate(props.initialValue?.startDate),
     )
-    const [standardHoursPerWeek, setStandardHoursPerWeek] = useState<string>(
-        props.initialValue?.standardHoursPerWeek || '',
+    const [standardHoursPerDay, setStandardHoursPerDay] = useState<string>(
+        props.initialValue?.standardHoursPerDay || '',
     )
 
     const timezone = useMemo(
@@ -74,8 +78,19 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
         [],
     )
     const agreementRate = useMemo(
-        () => calculateAssignmentRatePerWeek(ratePerHour, standardHoursPerWeek),
-        [ratePerHour, standardHoursPerWeek],
+        () => {
+            const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+                standardHoursPerDay,
+                2,
+            )
+
+            if (parsedStandardHoursPerDay === undefined) {
+                return ''
+            }
+
+            return calculateAssignmentRatePerWeek(ratePerHour, parsedStandardHoursPerDay * 5)
+        },
+        [ratePerHour, standardHoursPerDay],
     )
 
     useEffect(() => {
@@ -84,9 +99,10 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
         }
 
         setDurationMonths(props.initialValue?.durationMonths || '')
+        setPaymentCycle(props.initialValue?.paymentCycle || 'WEEKLY')
         setRatePerHour(props.initialValue?.ratePerHour || '')
         setStartDate(deserializeTentativeAssignmentDate(props.initialValue?.startDate))
-        setStandardHoursPerWeek(props.initialValue?.standardHoursPerWeek || '')
+        setStandardHoursPerDay(props.initialValue?.standardHoursPerDay || '')
         setOtherRemarks(props.initialValue?.otherRemarks || '')
         setErrors({})
     }, [props.initialValue, props.open])
@@ -95,10 +111,13 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
         const nextErrors: ValidationErrors = {}
         const parsedDurationMonths = toPositiveInteger(durationMonths)
         const parsedRatePerHour = toPositiveNumber(ratePerHour)
-        const parsedStandardHoursPerWeek = toPositiveNumberWithMaxDecimalPlaces(
-            standardHoursPerWeek,
+        const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+            standardHoursPerDay,
             2,
         )
+        const normalizedPaymentCycle = String(paymentCycle || 'WEEKLY')
+            .trim()
+            .toUpperCase()
 
         if (!startDate) {
             nextErrors.startDate = 'Engagement start date is required.'
@@ -112,9 +131,13 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
             nextErrors.ratePerHour = 'Rate per hour must be a positive number.'
         }
 
-        if (parsedStandardHoursPerWeek === undefined) {
-            nextErrors.standardHoursPerWeek = 'Standard hours per week must be a '
+        if (parsedStandardHoursPerDay === undefined) {
+            nextErrors.standardHoursPerDay = 'Standard hours per day must be a '
                 + 'positive number with up to 2 decimal places.'
+        }
+
+        if (!['WEEKLY', 'FORTNIGHTLY', 'MONTHLY'].includes(normalizedPaymentCycle)) {
+            nextErrors.paymentCycle = 'Payment cycle must be Weekly, Fortnightly, or Monthly.'
         }
 
         if (Object.keys(nextErrors).length > 0) {
@@ -126,7 +149,7 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
             !startDate
             || parsedDurationMonths === undefined
             || parsedRatePerHour === undefined
-            || parsedStandardHoursPerWeek === undefined
+            || parsedStandardHoursPerDay === undefined
         ) {
             return
         }
@@ -136,17 +159,20 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
             durationMonths: String(parsedDurationMonths),
             memberHandle: props.memberHandle || '',
             otherRemarks: otherRemarks.trim() || undefined,
+            paymentCycle: normalizedPaymentCycle,
             ratePerHour: parsedRatePerHour.toString(),
-            standardHoursPerWeek: String(parsedStandardHoursPerWeek),
+            standardHoursPerDay: String(parsedStandardHoursPerDay),
+            standardHoursPerWeek: String(Number((parsedStandardHoursPerDay * 5).toFixed(2))),
             startDate: serializeTentativeAssignmentDate(startDate),
         })
     }, [
         agreementRate,
         durationMonths,
         otherRemarks,
+        paymentCycle,
         props,
         ratePerHour,
-        standardHoursPerWeek,
+        standardHoursPerDay,
         startDate,
     ])
 
@@ -252,43 +278,52 @@ export const AssignmentDetailsModal: FC<AssignmentDetailsModalProps> = (
 
                 <div className={styles.fieldRow}>
                     <label className={styles.label} htmlFor='assignment-standard-hours'>
-                        Standard hours per week *
+                        Standard hours per day *
                     </label>
                     <input
                         id='assignment-standard-hours'
                         className={styles.input}
                         inputMode='decimal'
                         onChange={event => {
-                            setStandardHoursPerWeek(
+                            setStandardHoursPerDay(
                                 sanitizePositiveNumericInput(event.target.value, 2),
                             )
                             setErrors(previous => ({
                                 ...previous,
-                                standardHoursPerWeek: undefined,
+                                standardHoursPerDay: undefined,
                             }))
                         }}
                         pattern='[0-9.]*'
                         type='text'
-                        value={standardHoursPerWeek}
+                        value={standardHoursPerDay}
                     />
-                    {errors.standardHoursPerWeek
-                        ? <p className={styles.error}>{errors.standardHoursPerWeek}</p>
+                    {errors.standardHoursPerDay
+                        ? <p className={styles.error}>{errors.standardHoursPerDay}</p>
                         : undefined}
                 </div>
 
                 <div className={styles.fieldRow}>
-                    <label className={styles.label} htmlFor='assignment-rate'>
-                        Assignment rate per week *
+                    <label className={styles.label} htmlFor='assignment-payment-cycle'>
+                        Payment cycle *
                     </label>
-                    <input
-                        id='assignment-rate'
+                    <select
+                        id='assignment-payment-cycle'
                         className={styles.input}
-                        readOnly
-                        type='text'
-                        value={agreementRate}
-                    />
-                    {!agreementRate
-                        ? <p className={styles.error}>Assignment rate is calculated after entering hourly details.</p>
+                        onChange={event => {
+                            setPaymentCycle(event.target.value)
+                            setErrors(previous => ({
+                                ...previous,
+                                paymentCycle: undefined,
+                            }))
+                        }}
+                        value={paymentCycle}
+                    >
+                        <option value='WEEKLY'>Weekly</option>
+                        <option value='FORTNIGHTLY'>Fortnightly</option>
+                        <option value='MONTHLY'>Monthly</option>
+                    </select>
+                    {errors.paymentCycle
+                        ? <p className={styles.error}>{errors.paymentCycle}</p>
                         : undefined}
                 </div>
 

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementEditorForm.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementEditorForm.tsx
@@ -115,7 +115,9 @@ type SerializedAssignmentDetailsPayload = {
     durationMonths?: number
     memberHandle: string
     otherRemarks?: string
+    paymentCycle?: string
     ratePerHour: string
+    standardHoursPerDay?: number
     standardHoursPerWeek?: number
     startDate: string
 }
@@ -224,8 +226,16 @@ function serializeAssignmentDetails(
                         ? String(detail.otherRemarks)
                             .trim()
                         : undefined,
+                    paymentCycle: detail.paymentCycle
+                        ? String(detail.paymentCycle)
+                            .trim()
+                            .toUpperCase()
+                        : 'WEEKLY',
                     ratePerHour: String(detail.ratePerHour || '')
                         .trim(),
+                    standardHoursPerDay: detail.standardHoursPerDay
+                        ? Number(detail.standardHoursPerDay)
+                        : undefined,
                     standardHoursPerWeek: detail.standardHoursPerWeek
                         ? Number(detail.standardHoursPerWeek)
                         : undefined,
@@ -248,9 +258,18 @@ function toAssignmentDetailsValue(assignment: EngagementAssignment): AssignmentD
         otherRemarks: assignment.otherRemarks
             ? String(assignment.otherRemarks)
             : undefined,
+        paymentCycle: assignment.paymentCycle
+            ? String(assignment.paymentCycle)
+            : 'WEEKLY',
         ratePerHour: assignment.ratePerHour
             ? String(assignment.ratePerHour)
             : '',
+        standardHoursPerDay:
+            assignment.standardHoursPerDay !== undefined && assignment.standardHoursPerDay !== null
+                ? String(assignment.standardHoursPerDay)
+                : (assignment.standardHoursPerWeek !== undefined && assignment.standardHoursPerWeek !== null
+                    ? String(Number(assignment.standardHoursPerWeek) / 5)
+                    : ''),
         standardHoursPerWeek:
             assignment.standardHoursPerWeek !== undefined && assignment.standardHoursPerWeek !== null
                 ? String(assignment.standardHoursPerWeek)

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementEditorForm.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementEditorForm.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/jsx-no-bind */
+/* eslint-disable complexity */
 
 import {
     FC,

--- a/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementPrivateSection.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementEditorPage/components/EngagementPrivateSection.tsx
@@ -18,9 +18,9 @@ import {
 } from '../../../../lib/components/form'
 import {
     formatAssignmentCurrency,
-    getAssignmentStandardHoursPerWeek,
+    getAssignmentPaymentCycle,
+    getAssignmentStandardHoursPerDay,
 } from '../../../../lib/utils'
-import { formatCurrency } from '../../../../lib/utils/payment.utils'
 
 import {
     AssignmentDetailsFormValue,
@@ -116,7 +116,9 @@ function createEmptyAssignmentDetails(): AssignmentDetailsFormValue {
         durationMonths: '',
         memberHandle: '',
         otherRemarks: undefined,
+        paymentCycle: 'WEEKLY',
         ratePerHour: '',
+        standardHoursPerDay: '',
         standardHoursPerWeek: '',
         startDate: '',
     }
@@ -287,15 +289,15 @@ export const EngagementPrivateSection: FC<EngagementPrivateSectionProps> = (
                                                                         ,
                                                                     </span>
                                                                     <span>
-                                                                        <span className={styles.detailLabel}>Hours/Wk:</span>
+                                                                        <span className={styles.detailLabel}>Hours/Day:</span>
                                                                         {' '}
-                                                                        {getAssignmentStandardHoursPerWeek(assignmentDetail) || '-'}
+                                                                        {getAssignmentStandardHoursPerDay(assignmentDetail) || '-'}
                                                                         ,
                                                                     </span>
                                                                     <span>
-                                                                        <span className={styles.detailLabel}>Rate/Wk:</span>
+                                                                        <span className={styles.detailLabel}>Payment Cycle:</span>
                                                                         {' '}
-                                                                        {formatCurrency(assignmentDetail.agreementRate)}
+                                                                        {getAssignmentPaymentCycle(assignmentDetail)}
                                                                     </span>
                                                                     {!isLockedAssignment
                                                                         ? (

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
@@ -51,6 +51,8 @@ import {
 import {
     calculateAssignmentRatePerWeek,
     deserializeTentativeAssignmentDate,
+    getAssignmentPaymentCycle,
+    getAssignmentStandardHoursPerDay,
     getCountableEngagementAssignments,
     normalizeAssignmentStatus,
     sanitizePositiveNumericInput,
@@ -131,6 +133,32 @@ function toOptionalNumber(value: unknown): number | undefined {
     }
 
     return parsedValue
+}
+
+function formatPaymentCycle(value: unknown): string {
+    const normalizedCycle = String(value || 'WEEKLY')
+        .trim()
+        .toUpperCase()
+
+    if (normalizedCycle === 'FORTNIGHTLY') {
+        return 'Fortnightly'
+    }
+
+    if (normalizedCycle === 'MONTHLY') {
+        return 'Monthly'
+    }
+
+    return 'Weekly'
+}
+
+function toWeeklyHours(standardHoursPerDay: unknown): number | undefined {
+    const parsedValue = Number(standardHoursPerDay)
+
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        return undefined
+    }
+
+    return Number((parsedValue * 5).toFixed(2))
 }
 
 function isAssignedStatus(status: string): boolean {
@@ -226,7 +254,9 @@ function buildAssignmentDetailsPayloadEntry(
     appendPayloadStringField(payload, 'agreementRate', assignment.agreementRate)
     appendPayloadNumberField(payload, 'durationMonths', assignment.durationMonths)
     appendPayloadStringField(payload, 'otherRemarks', assignment.otherRemarks)
+    appendPayloadStringField(payload, 'paymentCycle', assignment.paymentCycle)
     appendPayloadStringField(payload, 'ratePerHour', assignment.ratePerHour)
+    appendPayloadNumberField(payload, 'standardHoursPerDay', assignment.standardHoursPerDay)
     appendPayloadNumberField(payload, 'standardHoursPerWeek', assignment.standardHoursPerWeek)
     appendPayloadStringField(payload, 'startDate', assignment.startDate)
 
@@ -237,8 +267,10 @@ interface EditAssignmentPayload {
     agreementRate: string
     durationMonths?: number
     otherRemarks?: string
+    paymentCycle: string
     ratePerHour: string
     startDate: string
+    standardHoursPerDay: number
     standardHoursPerWeek: number
 }
 
@@ -287,9 +319,10 @@ interface EditAssignmentModalProps {
 
 interface EditAssignmentErrors {
     durationMonths?: string
+    paymentCycle?: string
     ratePerHour?: string
     startDate?: string
-    standardHoursPerWeek?: string
+    standardHoursPerDay?: string
 }
 
 export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
@@ -302,19 +335,39 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
     )
     const [errors, setErrors] = useState<EditAssignmentErrors>({})
     const [otherRemarks, setOtherRemarks] = useState<string>(props.assignment?.otherRemarks || '')
+    const [paymentCycle, setPaymentCycle] = useState<string>(getAssignmentPaymentCycle(props.assignment || {}))
     const [ratePerHour, setRatePerHour] = useState<string>(props.assignment?.ratePerHour || '')
     const [startDate, setStartDate] = useState<Date | undefined>(
         deserializeTentativeAssignmentDate(props.assignment?.startDate),
     )
-    const [standardHoursPerWeek, setStandardHoursPerWeek] = useState<string>(
-        props.assignment?.standardHoursPerWeek !== undefined && props.assignment?.standardHoursPerWeek !== null
-            ? String(props.assignment.standardHoursPerWeek)
+    const [standardHoursPerDay, setStandardHoursPerDay] = useState<string>(
+        getAssignmentStandardHoursPerDay(props.assignment || {}) !== undefined
+            ? String(getAssignmentStandardHoursPerDay(props.assignment || {}))
             : '',
     )
 
+    const weeklyHours = useMemo(
+        () => {
+            if (!standardHoursPerDay) {
+                return ''
+            }
+
+            const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+                standardHoursPerDay,
+                2,
+            )
+
+            if (parsedStandardHoursPerDay === undefined) {
+                return ''
+            }
+
+            return String(Number((parsedStandardHoursPerDay * 5).toFixed(2)))
+        },
+        [standardHoursPerDay],
+    )
     const agreementRate = useMemo(
-        () => calculateAssignmentRatePerWeek(ratePerHour, standardHoursPerWeek),
-        [ratePerHour, standardHoursPerWeek],
+        () => calculateAssignmentRatePerWeek(ratePerHour, weeklyHours),
+        [ratePerHour, weeklyHours],
     )
     const isSubmitting = props.isSubmitting === true
 
@@ -326,11 +379,12 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
         )
         setErrors({})
         setOtherRemarks(props.assignment?.otherRemarks || '')
+        setPaymentCycle(getAssignmentPaymentCycle(props.assignment || {}))
         setRatePerHour(props.assignment?.ratePerHour || '')
         setStartDate(deserializeTentativeAssignmentDate(props.assignment?.startDate))
-        setStandardHoursPerWeek(
-            props.assignment?.standardHoursPerWeek !== undefined && props.assignment?.standardHoursPerWeek !== null
-                ? String(props.assignment.standardHoursPerWeek)
+        setStandardHoursPerDay(
+            getAssignmentStandardHoursPerDay(props.assignment || {}) !== undefined
+                ? String(getAssignmentStandardHoursPerDay(props.assignment || {}))
                 : '',
         )
     }, [props.assignment])
@@ -355,10 +409,13 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
             ? toPositiveInteger(durationMonths)
             : undefined
         const parsedRatePerHour = toPositiveNumber(ratePerHour)
-        const parsedStandardHoursPerWeek = toPositiveNumberWithMaxDecimalPlaces(
-            standardHoursPerWeek,
+        const parsedStandardHoursPerDay = toPositiveNumberWithMaxDecimalPlaces(
+            standardHoursPerDay,
             2,
         )
+        const normalizedPaymentCycle = String(paymentCycle || 'WEEKLY')
+            .trim()
+            .toUpperCase()
 
         if (!startDate) {
             nextErrors.startDate = 'Billing start date is required.'
@@ -372,9 +429,13 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
             nextErrors.ratePerHour = 'Rate per hour must be a positive number.'
         }
 
-        if (parsedStandardHoursPerWeek === undefined) {
-            nextErrors.standardHoursPerWeek = 'Standard hours per week must be a '
+        if (parsedStandardHoursPerDay === undefined) {
+            nextErrors.standardHoursPerDay = 'Standard hours per day must be a '
                 + 'positive number with up to 2 decimal places.'
+        }
+
+        if (!['WEEKLY', 'FORTNIGHTLY', 'MONTHLY'].includes(normalizedPaymentCycle)) {
+            nextErrors.paymentCycle = 'Payment cycle must be Weekly, Fortnightly, or Monthly.'
         }
 
         if (Object.keys(nextErrors).length > 0) {
@@ -385,8 +446,14 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
         if (
             !startDate
             || parsedRatePerHour === undefined
-            || parsedStandardHoursPerWeek === undefined
+            || parsedStandardHoursPerDay === undefined
         ) {
+            return
+        }
+
+        const parsedStandardHoursPerWeek = toWeeklyHours(parsedStandardHoursPerDay)
+
+        if (parsedStandardHoursPerWeek === undefined) {
             return
         }
 
@@ -394,7 +461,9 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
             agreementRate,
             durationMonths: parsedDurationMonths,
             otherRemarks: otherRemarks.trim() || undefined,
+            paymentCycle: normalizedPaymentCycle,
             ratePerHour: parsedRatePerHour.toString(),
+            standardHoursPerDay: parsedStandardHoursPerDay,
             standardHoursPerWeek: parsedStandardHoursPerWeek,
             startDate: serializeTentativeAssignmentDate(startDate),
         })
@@ -404,10 +473,11 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
         agreementRate,
         durationMonths,
         otherRemarks,
+        paymentCycle,
         props,
         ratePerHour,
         resetState,
-        standardHoursPerWeek,
+        standardHoursPerDay,
         startDate,
     ])
 
@@ -508,41 +578,53 @@ export const EditAssignmentModal: FC<EditAssignmentModalProps> = (
 
                     <div className={styles.modalFieldRow}>
                         <label className={styles.modalLabel} htmlFor='edit-assignment-hours'>
-                            Standard hours per week *
+                            Standard hours per day *
                         </label>
                         <input
                             id='edit-assignment-hours'
                             className={styles.modalInput}
                             inputMode='decimal'
                             onChange={event => {
-                                setStandardHoursPerWeek(
+                                setStandardHoursPerDay(
                                     sanitizePositiveNumericInput(event.target.value, 2),
                                 )
                                 setErrors(previous => ({
                                     ...previous,
-                                    standardHoursPerWeek: undefined,
+                                    standardHoursPerDay: undefined,
                                 }))
                             }}
                             pattern='[0-9.]*'
                             type='text'
-                            value={standardHoursPerWeek}
+                            value={standardHoursPerDay}
                         />
-                        {errors.standardHoursPerWeek
-                            ? <p className={styles.modalError}>{errors.standardHoursPerWeek}</p>
+                        {errors.standardHoursPerDay
+                            ? <p className={styles.modalError}>{errors.standardHoursPerDay}</p>
                             : undefined}
                     </div>
 
                     <div className={styles.modalFieldRow}>
-                        <label className={styles.modalLabel} htmlFor='edit-assignment-rate-week'>
-                            Rate per week
+                        <label className={styles.modalLabel} htmlFor='edit-assignment-payment-cycle'>
+                            Payment cycle *
                         </label>
-                        <input
-                            id='edit-assignment-rate-week'
-                            className={`${styles.modalInput} ${styles.modalInputReadOnly}`}
-                            readOnly
-                            type='text'
-                            value={agreementRate}
-                        />
+                        <select
+                            id='edit-assignment-payment-cycle'
+                            className={styles.modalInput}
+                            onChange={event => {
+                                setPaymentCycle(event.target.value)
+                                setErrors(previous => ({
+                                    ...previous,
+                                    paymentCycle: undefined,
+                                }))
+                            }}
+                            value={paymentCycle}
+                        >
+                            <option value='WEEKLY'>Weekly</option>
+                            <option value='FORTNIGHTLY'>Fortnightly</option>
+                            <option value='MONTHLY'>Monthly</option>
+                        </select>
+                        {errors.paymentCycle
+                            ? <p className={styles.modalError}>{errors.paymentCycle}</p>
+                            : undefined}
                     </div>
                 </div>
 
@@ -918,16 +1000,16 @@ export const EngagementPaymentPage: FC = () => {
                                             </div>
                                             <div>
                                                 <span className={styles.label}>
-                                                    Standard Hours Per Week
+                                                    Standard Hours Per Day
                                                     <span aria-hidden='true' className={styles.required}>*</span>
                                                 </span>
                                                 <span className={styles.value}>
-                                                    {assignment.standardHoursPerWeek || '-'}
+                                                    {getAssignmentStandardHoursPerDay(assignment) || '-'}
                                                 </span>
                                             </div>
                                             <div>
-                                                <span className={styles.label}>Rate Per Week</span>
-                                                <span className={styles.value}>{formatCurrency(assignment.agreementRate)}</span>
+                                                <span className={styles.label}>Payment Cycle</span>
+                                                <span className={styles.value}>{formatPaymentCycle(assignment.paymentCycle)}</span>
                                             </div>
                                         </div>
 

--- a/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
+++ b/src/apps/work/src/pages/engagements/EngagementPaymentPage/EngagementPaymentPage.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 /* eslint-disable react/jsx-no-bind */
+/* eslint-disable complexity */
 
 import {
     FC,


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-4669 


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request introduces significant changes to how work assignments and payments are managed in the wallet and work admin applications. The main improvements include switching from "standard hours per week" to "standard hours per day" throughout the UI and data models, adding support for selecting a payment cycle (weekly, fortnightly, or monthly), and updating form validations and calculations accordingly. There are also enhancements to the payment form, including improved date selection and work period labeling.

**Assignment Details and Payment Cycle Enhancements:**

* Changed all references and form fields from "standard hours per week" to "standard hours per day" in both the UI and data models, with weekly hours now derived as `standardHoursPerDay * 5`.
* Added a selectable "payment cycle" field (`WEEKLY`, `FORTNIGHTLY`, or `MONTHLY`) to assignment forms and details, with validation and defaulting to `WEEKLY` if not specified. 

**Form and Validation Updates:**

* Updated the Accept Application Modal to use and validate "standard hours per day" and "payment cycle," including error handling and state management. 
* Adjusted calculations for agreement rate to use daily hours multiplied by 5 to obtain weekly values. [[1]](diffhunk://#diff-4e540aae436f8259d5d6cb9d12a72d7dab0a3b1957bcf64f41a8131bbe161cb7L75-R101) [[2]](diffhunk://#diff-4e540aae436f8259d5d6cb9d12a72d7dab0a3b1957bcf64f41a8131bbe161cb7R160-R163)
