### PR TITLE
PM-5105: Add rated challenge toggle

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -158,6 +158,9 @@ import {
     NDAField,
 } from './NDAField'
 import {
+    RateChallengeField,
+} from './RateChallengeField'
+import {
     ReviewCostField,
 } from './ReviewCostField'
 import {
@@ -289,6 +292,7 @@ const CHALLENGE_TYPE_MARATHON_MATCH_NAME = 'MARATHONMATCH'
 const CHALLENGE_TYPE_MARATHON_MATCH_SHORT_ABBREVIATION = 'MM'
 const CHALLENGE_TYPE_TASK_NAME = 'TASK'
 const CHALLENGE_TYPE_TASK_SHORT_ABBREVIATION = 'TSK'
+const CHALLENGE_TRACK_DEVELOPMENT_NAME = 'DEVELOPMENT'
 const CHECKPOINT_REQUIRED_PHASES = [
     'Checkpoint Submission',
     'Checkpoint Screening',
@@ -1642,20 +1646,36 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
             values.trackId,
         ],
     )
+    const fallbackChallengeTrackName = useMemo(
+        (): string | undefined => {
+            const challengeTrack = props.challenge?.track
+
+            if (!challengeTrack) {
+                return props.challenge?.legacy?.track
+            }
+
+            if (typeof challengeTrack === 'string') {
+                return challengeTrack
+            }
+
+            return challengeTrack.track || challengeTrack.name || challengeTrack.abbreviation
+        },
+        [
+            props.challenge?.legacy?.track,
+            props.challenge?.track,
+        ],
+    )
+    const resolvedChallengeTrackName = selectedChallengeTrack?.track
+        || selectedChallengeTrack?.name
+        || selectedChallengeTrack?.abbreviation
+        || fallbackChallengeTrackName
     const isDesignTrackSelected = useMemo(
         (): boolean => {
-            const normalizedTrack = (
-                selectedChallengeTrack?.track
-                || selectedChallengeTrack?.name
-                || selectedChallengeTrack?.abbreviation
-                || ''
-            )
-                .trim()
-                .toUpperCase()
+            const normalizedTrack = normalizeChallengeTypeToken(resolvedChallengeTrackName)
 
-            return normalizedTrack === CHALLENGE_TRACKS.DESIGN
+            return normalizedTrack === normalizeChallengeTypeToken(CHALLENGE_TRACKS.DESIGN)
         },
-        [selectedChallengeTrack],
+        [resolvedChallengeTrackName],
     )
     const isChallengeTypeSelected = useMemo(
         (): boolean => {
@@ -1716,6 +1736,28 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
             name: resolvedChallengeTypeName,
         }),
         [
+            resolvedChallengeTypeAbbreviation,
+            resolvedChallengeTypeName,
+        ],
+    )
+    const isDevelopmentChallengeSelected = useMemo(
+        (): boolean => {
+            const normalizedTrackName = normalizeChallengeTypeToken(resolvedChallengeTrackName)
+            const normalizedChallengeTypeName = normalizeChallengeTypeToken(resolvedChallengeTypeName)
+            const normalizedChallengeTypeAbbreviation
+                = normalizeChallengeTypeToken(resolvedChallengeTypeAbbreviation)
+
+            return (
+                normalizedTrackName === CHALLENGE_TRACK_DEVELOPMENT_NAME
+                || normalizedTrackName === normalizeChallengeTypeToken(CHALLENGE_TRACKS.DEVELOP)
+            )
+                && (
+                    normalizedChallengeTypeName === CHALLENGE_TYPE_CHALLENGE_NAME
+                    || normalizedChallengeTypeAbbreviation === CHALLENGE_TYPE_CHALLENGE_ABBREVIATION
+                )
+        },
+        [
+            resolvedChallengeTrackName,
             resolvedChallengeTypeAbbreviation,
             resolvedChallengeTypeName,
         ],
@@ -1812,6 +1854,7 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     const isFunChallengeSelected = values.funChallenge === true
     const showFunChallengeField = isMarathonMatchChallengeSelected
     const showMarathonMatchScorerSection = isMarathonMatchChallengeSelected && isChallengeCreated
+    const showRateChallengeField = isMarathonMatchChallengeSelected || isDevelopmentChallengeSelected
     const showPrizesAndBillingSection = !isFunChallengeSelected
     const showEditableTimelineSection = !isTaskChallenge
     const usesManualReviewers = useMemo(
@@ -3685,6 +3728,9 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                                             label='Wipro Allowed'
                                             name='wiproAllowed'
                                         />
+                                        {showRateChallengeField
+                                            ? <RateChallengeField />
+                                            : undefined}
                                     </div>
                                 </section>
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/RateChallengeField.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/RateChallengeField.spec.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { FC } from 'react'
+import {
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react'
+import '@testing-library/jest-dom'
+import userEvent from '@testing-library/user-event'
+import {
+    FormProvider,
+    useForm,
+    useWatch,
+} from 'react-hook-form'
+
+import { ChallengeEditorFormData } from '../../../../../lib/models'
+
+import { RateChallengeField } from './RateChallengeField'
+
+jest.mock('../../../../../lib/components/form', () => ({
+    FormCheckboxField: function MockFormCheckboxField(props: {
+        label: string
+        name: string
+        onChange?: (checked: boolean) => void
+    }) {
+        const React: typeof import('react') = jest.requireActual('react')
+        const reactHookForm: typeof import('react-hook-form') = jest.requireActual('react-hook-form')
+        const formContext = reactHookForm.useFormContext()
+        const controller = reactHookForm.useController({
+            control: formContext.control,
+            name: props.name,
+        })
+
+        return React.createElement(
+            'label',
+            {},
+            React.createElement('input', {
+                checked: controller.field.value === true,
+                onChange: (event: { target: { checked: boolean } }) => {
+                    controller.field.onChange(event.target.checked)
+                    props.onChange?.(event.target.checked)
+                },
+                type: 'checkbox',
+            }),
+            props.label,
+        )
+    },
+}))
+
+interface TestHarnessProps {
+    defaultMetadata?: Array<{
+        name: string
+        value: unknown
+    }>
+}
+
+const MetadataWatcher: FC = () => {
+    const metadata = useWatch<ChallengeEditorFormData>({
+        name: 'metadata',
+    })
+
+    return <output data-testid='metadata-value'>{JSON.stringify(metadata || [])}</output>
+}
+
+const TestHarness: FC<TestHarnessProps> = (props: TestHarnessProps) => {
+    const formMethods = useForm<ChallengeEditorFormData>({
+        defaultValues: {
+            description: 'Public challenge specification',
+            metadata: props.defaultMetadata,
+            name: 'Development challenge',
+            skills: [],
+            tags: [],
+            trackId: 'development-track',
+            typeId: 'development-type',
+        },
+    })
+
+    return (
+        <FormProvider {...formMethods}>
+            <RateChallengeField />
+            <MetadataWatcher />
+        </FormProvider>
+    )
+}
+
+describe('RateChallengeField', () => {
+    it('defaults to rated when metadata is missing and stores false when unchecked', async () => {
+        const user = userEvent.setup()
+
+        render(<TestHarness />)
+
+        const checkbox = screen.getByRole('checkbox', { name: 'Rate this challenge' })
+        await waitFor(() => {
+            expect(checkbox)
+                .toBeChecked()
+        })
+
+        await user.click(checkbox)
+
+        expect(checkbox)
+            .not.toBeChecked()
+        expect(screen.getByTestId('metadata-value').textContent)
+            .toBe(JSON.stringify([{
+                name: 'isRated',
+                value: 'false',
+            }]))
+    })
+
+    it('restores the default rated metadata when checked again', async () => {
+        const user = userEvent.setup()
+
+        render(
+            <TestHarness
+                defaultMetadata={[{
+                    name: 'isRated',
+                    value: 'false',
+                }]}
+            />,
+        )
+
+        const checkbox = screen.getByRole('checkbox', { name: 'Rate this challenge' })
+        await waitFor(() => {
+            expect(checkbox)
+                .not.toBeChecked()
+        })
+
+        await user.click(checkbox)
+
+        expect(checkbox)
+            .toBeChecked()
+        expect(screen.getByTestId('metadata-value').textContent)
+            .toBe(JSON.stringify([]))
+    })
+})

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/RateChallengeField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/RateChallengeField.tsx
@@ -1,0 +1,114 @@
+import {
+    FC,
+    useCallback,
+    useEffect,
+} from 'react'
+import {
+    useFormContext,
+    useWatch,
+} from 'react-hook-form'
+
+import { FormCheckboxField } from '../../../../../lib/components/form'
+import {
+    getMetadataValue,
+    removeMetadataValue,
+    setMetadataValue,
+} from '../../../../../lib/utils/metadata.utils'
+import {
+    ChallengeEditorFormData,
+    ChallengeMetadata,
+} from '../../../../../lib/models'
+
+const IS_RATED_FIELD = 'isRated'
+const IS_RATED_TOGGLE_FIELD = 'isRatedToggle'
+
+interface RateChallengeFormData extends ChallengeEditorFormData {
+    isRatedToggle?: boolean
+}
+
+/**
+ * Resolves whether a challenge should be treated as rated from metadata.
+ *
+ * @param metadata challenge metadata entries currently held by the editor form.
+ * @returns `false` only when the `isRated` metadata entry is explicitly `false`;
+ * otherwise challenges stay rated by default.
+ * @throws Does not throw.
+ */
+function isRatedMetadataEnabled(metadata: ChallengeMetadata[] | undefined): boolean {
+    return getMetadataValue(metadata, IS_RATED_FIELD)
+        ?.trim()
+        .toLowerCase() !== 'false'
+}
+
+/**
+ * Renders the challenge rating opt-out control backed by challenge metadata.
+ *
+ * Missing `isRated` metadata defaults to rated, so the saved challenge only
+ * needs an explicit `isRated=false` entry when the user opts out.
+ *
+ * @returns The rated challenge checkbox used by the challenge editor.
+ * @throws Does not throw.
+ */
+export const RateChallengeField: FC = () => {
+    const formContext = useFormContext<RateChallengeFormData>()
+    const metadata = useWatch({
+        control: formContext.control,
+        name: 'metadata',
+    })
+    const isRatedToggle = useWatch({
+        control: formContext.control,
+        name: IS_RATED_TOGGLE_FIELD,
+    })
+
+    const isRated = isRatedMetadataEnabled(metadata)
+
+    useEffect(() => {
+        if (isRatedToggle !== undefined) {
+            return
+        }
+
+        formContext.setValue(
+            IS_RATED_TOGGLE_FIELD,
+            isRated,
+            {
+                shouldDirty: false,
+                shouldValidate: false,
+            },
+        )
+    }, [formContext, isRated, isRatedToggle])
+
+    const handleRatedChange = useCallback((checked: boolean): void => {
+        if (checked === isRated) {
+            return
+        }
+
+        formContext.setValue(
+            'metadata',
+            checked
+                ? removeMetadataValue(metadata, IS_RATED_FIELD)
+                : setMetadataValue(
+                    metadata,
+                    IS_RATED_FIELD,
+                    'false',
+                ),
+            {
+                shouldDirty: true,
+                shouldValidate: true,
+            },
+        )
+    }, [
+        formContext,
+        isRated,
+        metadata,
+    ])
+
+    return (
+        <FormCheckboxField
+            label='Rate this challenge'
+            name={IS_RATED_TOGGLE_FIELD}
+            onChange={handleRatedChange}
+        />
+    )
+}
+
+export default RateChallengeField

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/index.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/RateChallengeField/index.ts
@@ -1,0 +1,1 @@
+export * from './RateChallengeField'


### PR DESCRIPTION
What was broken
Marathon matches and development challenges were always treated as rated from the work app because the challenge editor did not expose an opt-out control.

Root cause (if identifiable)
Member API already honors challenge metadata named isRated with value false, but platform-ui never let users set or clear that metadata during challenge setup.

What was changed
Added a Rate this challenge checkbox in Advanced Options for marathon match and development challenge forms. The checkbox defaults to checked, writes metadata isRated=false when unchecked, and removes that metadata when checked again so rated remains the default.

Any added/updated tests
Added RateChallengeField tests covering the default checked state, writing isRated=false when unchecked, and removing the metadata when rechecked.
