### PR TITLE
PM-5112: show latest relative marathon scores

### DIFF
--- a/src/apps/work/src/lib/utils/challenge.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.spec.ts
@@ -63,6 +63,35 @@ describe('challenge utils', () => {
                 .toBe(12)
         })
 
+        it('returns the latest provisional summation before stale raw scores', () => {
+            expect(getSubmissionProvisionalScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: 93.82,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                        updatedAt: '2026-05-20T03:41:00.000Z',
+                    },
+                    {
+                        aggregateScore: 73.2513061836071,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                        updatedAt: '2026-05-20T04:04:00.000Z',
+                    },
+                ],
+                submissions: [
+                    {
+                        provisionalScore: 93.82,
+                    },
+                ],
+            }))
+                .toBe(73.2513061836071)
+        })
+
         it('returns undefined when provisional scoring is unavailable', () => {
             expect(getSubmissionProvisionalScore({
                 review: [
@@ -125,6 +154,35 @@ describe('challenge utils', () => {
                 ],
             }))
                 .toBe(20)
+        })
+
+        it('returns the latest system summation before stale raw scores', () => {
+            expect(getSubmissionSystemScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: 60,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                        },
+                        updatedAt: '2026-05-20T03:41:00.000Z',
+                    },
+                    {
+                        aggregateScore: 88.5,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                        },
+                        updatedAt: '2026-05-20T04:04:00.000Z',
+                    },
+                ],
+                submissions: [
+                    {
+                        finalScore: 60,
+                    },
+                ],
+            }))
+                .toBe(88.5)
         })
 
         it('returns undefined when system scoring is unavailable', () => {

--- a/src/apps/work/src/lib/utils/challenge.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.ts
@@ -118,6 +118,28 @@ function getAverageScore(scores: Array<number | undefined>): number | undefined 
     return totalScore / validScores.length
 }
 
+/**
+ * Resolves the best timestamp available for ordering scored review summations.
+ * @param entry Review summation returned by Review API.
+ * @returns Epoch milliseconds or 0 when no parseable timestamp exists.
+ * Used by marathon score display to pick the latest relative-scoring update.
+ */
+function getReviewSummationScoreTimestamp(entry: ReviewSummation): number {
+    const timestamp = entry.updatedAt || entry.createdAt || ''
+    const parsedTimestamp = Date.parse(timestamp)
+
+    return Number.isFinite(parsedTimestamp)
+        ? parsedTimestamp
+        : 0
+}
+
+/**
+ * Returns the latest valid score from matching Review API summations.
+ * @param reviewSummation Review summations attached to a submission.
+ * @param matcher Predicate that selects the requested Marathon Match score phase.
+ * @returns Latest valid aggregate score, or `undefined` when no matching score exists.
+ * Used by marathon score display so relative-score rewrites replace stale raw scores.
+ */
 function getScoreFromSummation(
     reviewSummation: ReviewSummation[] | undefined,
     matcher: (entry: ReviewSummation) => boolean,
@@ -126,9 +148,20 @@ function getScoreFromSummation(
         return undefined
     }
 
-    const matchedSummation = reviewSummation.find(matcher)
+    const matchedSummation = reviewSummation
+        .map((entry, index) => ({
+            entry,
+            index,
+            score: toValidScore(entry.aggregateScore),
+            timestamp: getReviewSummationScoreTimestamp(entry),
+        }))
+        .filter(item => item.score !== undefined && matcher(item.entry))
+        .sort((first, second) => (
+            second.timestamp - first.timestamp
+            || second.index - first.index
+        ))[0]
 
-    return toValidScore(matchedSummation?.aggregateScore)
+    return matchedSummation?.score
 }
 
 /**
@@ -439,11 +472,19 @@ export function getProvisionalScore(submission: ScoredSubmissionLike): number {
  * Returns only the provisional marathon score for a submission.
  * @param submission Submission-like object containing legacy phase scores or Review API summations.
  * @returns Provisional score, or `undefined` when provisional scoring has not produced a valid score.
- * Used by marathon submission score display to avoid falling back to unrelated review scores.
+ * Used by marathon submission score display to prefer latest relative summations over stale raw scores.
  */
 export function getSubmissionProvisionalScore(
     submission: ScoredSubmissionLike,
 ): number | undefined {
+    const provisionalSummationScore = getScoreFromSummation(
+        submission.reviewSummation,
+        item => getReviewSummationTestProcess(item) === 'provisional',
+    )
+    if (provisionalSummationScore !== undefined) {
+        return provisionalSummationScore
+    }
+
     const legacyProvisionalScore = toValidScore(
         submission.submissions?.[0]?.provisionalScore,
     )
@@ -451,10 +492,7 @@ export function getSubmissionProvisionalScore(
         return legacyProvisionalScore
     }
 
-    return getScoreFromSummation(
-        submission.reviewSummation,
-        item => getReviewSummationTestProcess(item) === 'provisional',
-    )
+    return undefined
 }
 
 export function getSubmissionInitialScore(submission: ScoredSubmissionLike): number {
@@ -488,11 +526,19 @@ export function getFinalScore(submission: ScoredSubmissionLike): number {
  * Returns only the system marathon score for a submission.
  * @param submission Submission-like object containing legacy phase scores or Review API summations.
  * @returns System score, or `undefined` when system scoring has not produced a valid score.
- * Used by marathon submission score display to show pending/unavailable system scores as empty.
+ * Used by marathon submission score display to prefer latest relative summations over stale raw scores.
  */
 export function getSubmissionSystemScore(
     submission: ScoredSubmissionLike,
 ): number | undefined {
+    const systemSummationScore = getScoreFromSummation(
+        submission.reviewSummation,
+        item => getReviewSummationTestProcess(item) === 'system',
+    )
+    if (systemSummationScore !== undefined) {
+        return systemSummationScore
+    }
+
     const legacyFinalScore = toValidScore(
         submission.submissions?.[0]?.finalScore,
     )
@@ -500,10 +546,7 @@ export function getSubmissionSystemScore(
         return legacyFinalScore
     }
 
-    return getScoreFromSummation(
-        submission.reviewSummation,
-        item => getReviewSummationTestProcess(item) === 'system',
-    )
+    return undefined
 }
 
 export function getSubmissionFinalScore(submission: ScoredSubmissionLike): number {


### PR DESCRIPTION
What was broken
The Work app submissions table could show an older raw Marathon Match score while community-app showed the updated relative provisional score.

Root cause
The Work app score helper returned the first matching Review API summation, and legacy nested scores were preferred before summations, so later relative-score rewrites could be ignored.

What was changed
Marathon provisional and system score helpers now pick the latest valid matching review summation by timestamp and use legacy nested scores only as a fallback.

Any added/updated tests
Added regression coverage for provisional and system scores where a later relative summation must override a stale raw score.

Validation run:
- yarn test:no-watch src/apps/work/src/lib/utils/challenge.utils.spec.ts
- yarn test:no-watch src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
- yarn lint
- yarn run build

The full yarn test:no-watch command was also run. It still fails in unrelated pre-existing specs under wallet-admin and ChallengeEditorForm module resolution; the PM-5112 targeted tests pass.
