### PR TITLE
PM-5113: Use marathon aggregate review scores

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
@@ -24,7 +24,7 @@ import {
     ReviewResult,
     SubmissionInfo,
 } from '../../models'
-import { hasIsLatestFlag } from '../../utils'
+import { hasIsLatestFlag, isMarathonMatchChallenge } from '../../utils'
 import { TableAppeals } from '../TableAppeals'
 import { TableAppealsForSubmitter } from '../TableAppealsForSubmitter'
 import { TableAppealsResponse } from '../TableAppealsResponse'
@@ -86,7 +86,15 @@ const parseScoreValue = (value: unknown): number | undefined => {
     return undefined
 }
 
-const resolveSubmissionReviewScore = (submission: SubmissionInfo): number | undefined => {
+const resolveSubmissionReviewScore = (
+    submission: SubmissionInfo,
+    preferAggregateScore: boolean,
+): number | undefined => {
+    const aggregateScore = parseScoreValue(submission.aggregateScore)
+    if (preferAggregateScore && aggregateScore !== undefined) {
+        return aggregateScore
+    }
+
     const reviewResultScores = Array.isArray(submission.reviews)
         ? submission.reviews
             .map(review => parseScoreValue(review?.score))
@@ -98,7 +106,6 @@ const resolveSubmissionReviewScore = (submission: SubmissionInfo): number | unde
         return total / reviewResultScores.length
     }
 
-    const aggregateScore = parseScoreValue(submission.aggregateScore)
     if (aggregateScore !== undefined) {
         return aggregateScore
     }
@@ -122,10 +129,13 @@ type SubmissionScoreEntry = {
     submission: SubmissionInfo
 }
 
-const sortSubmissionsByReviewScoreDesc = (rows: SubmissionInfo[]): SubmissionInfo[] => {
+const sortSubmissionsByReviewScoreDesc = (
+    rows: SubmissionInfo[],
+    preferAggregateScore: boolean,
+): SubmissionInfo[] => {
     const entries: SubmissionScoreEntry[] = rows.map((submission, index) => ({
         index,
-        score: resolveSubmissionReviewScore(submission),
+        score: resolveSubmissionReviewScore(submission, preferAggregateScore),
         submission,
     }))
 
@@ -226,6 +236,10 @@ export const TabContentReview: FC<Props> = (props: Props) => {
     const challengeSubmissions = useMemo<SubmissionInfo[]>(
         () => challengeInfo?.submissions ?? [],
         [challengeInfo?.submissions],
+    )
+    const useAggregateReviewScore = useMemo<boolean>(
+        () => isMarathonMatchChallenge(challengeInfo),
+        [challengeInfo],
     )
     const myOwnedMemberIds = useMemo<Set<string>>(
         () => {
@@ -736,15 +750,15 @@ export const TabContentReview: FC<Props> = (props: Props) => {
     )
     const reviewerRowsForReviewTab = useMemo(
         () => (shouldSortReviewTabByScore
-            ? sortSubmissionsByReviewScoreDesc(filteredReviews)
+            ? sortSubmissionsByReviewScoreDesc(filteredReviews, useAggregateReviewScore)
             : filteredReviews),
-        [filteredReviews, shouldSortReviewTabByScore],
+        [filteredReviews, shouldSortReviewTabByScore, useAggregateReviewScore],
     )
     const submitterRowsForReviewTab = useMemo(
         () => (shouldSortReviewTabByScore
-            ? sortSubmissionsByReviewScoreDesc(filteredSubmitterReviews)
+            ? sortSubmissionsByReviewScoreDesc(filteredSubmitterReviews, useAggregateReviewScore)
             : filteredSubmitterReviews),
-        [filteredSubmitterReviews, shouldSortReviewTabByScore],
+        [filteredSubmitterReviews, shouldSortReviewTabByScore, useAggregateReviewScore],
     )
     const hideHandleColumn = props.isActiveChallenge
         && actionChallengeRole === REVIEWER

--- a/src/apps/review/src/lib/components/TableReview/TableReview.tsx
+++ b/src/apps/review/src/lib/components/TableReview/TableReview.tsx
@@ -42,6 +42,7 @@ import {
 import {
     aggregateSubmissionReviews,
     challengeHasSubmissionLimit,
+    isMarathonMatchChallenge,
     isReviewPhase,
     isReviewPhaseCurrentlyOpen,
     refreshChallengeReviewData,
@@ -191,6 +192,10 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
 
     const restrictToLatest = useMemo<boolean>(
         () => challengeHasSubmissionLimit(challengeInfo),
+        [challengeInfo],
+    )
+    const useAggregateReviewScore = useMemo<boolean>(
+        () => isMarathonMatchChallenge(challengeInfo),
         [challengeInfo],
     )
 
@@ -470,8 +475,9 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
             canDisplayScores: () => true,
             canViewScorecard: true,
             isAppealsTab: false,
+            useAggregateScore: useAggregateReviewScore,
         }),
-        [],
+        [useAggregateReviewScore],
     )
 
     const { canViewAllSubmissions }: UseRolePermissionsResult = useRolePermissions()
@@ -967,6 +973,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
 
                     const result = resolveSubmissionReviewResult(row, {
                         minimumPassingScoreByScorecardId,
+                        preferAggregateScore: useAggregateReviewScore,
                     })
                     if (result === 'PASS') {
                         return (
@@ -1050,6 +1057,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
         openReopenDialog,
         challengeInfo,
         pendingReopen,
+        useAggregateReviewScore,
     ])
 
     const columnsMobile = useMemo<MobileTableColumn<SubmissionReviewerRow>[][]>(

--- a/src/apps/review/src/lib/components/TableReviewForSubmitter/TableReviewForSubmitter.tsx
+++ b/src/apps/review/src/lib/components/TableReviewForSubmitter/TableReviewForSubmitter.tsx
@@ -44,6 +44,7 @@ import {
     getSubmissionHistoryKey,
     isAppealsPhase,
     isAppealsResponsePhase,
+    isMarathonMatchChallenge,
 } from '../../utils'
 import type { AggregatedSubmissionReviews } from '../../utils'
 import {
@@ -171,6 +172,10 @@ export const TableReviewForSubmitter: FC<TableReviewForSubmitterProps> = (props:
 
     const restrictToLatest = useMemo<boolean>(
         () => challengeHasSubmissionLimit(challengeInfo),
+        [challengeInfo],
+    )
+    const useAggregateReviewScore = useMemo<boolean>(
+        () => isMarathonMatchChallenge(challengeInfo),
         [challengeInfo],
     )
 
@@ -426,6 +431,7 @@ export const TableReviewForSubmitter: FC<TableReviewForSubmitterProps> = (props:
                     canDisplayScores,
                     canViewScorecard: isChallengeCompleted || isOwnedSubmission,
                     isAppealsTab: false,
+                    useAggregateScore: useAggregateReviewScore,
                 }
 
                 return renderReviewScoreCell(submission, scoreConfig)
@@ -444,6 +450,7 @@ export const TableReviewForSubmitter: FC<TableReviewForSubmitterProps> = (props:
 
                 const result = resolveSubmissionReviewResult(submission, {
                     minimumPassingScoreByScorecardId,
+                    preferAggregateScore: useAggregateReviewScore,
                 })
                 if (result === 'PASS') {
                     return (
@@ -489,6 +496,7 @@ export const TableReviewForSubmitter: FC<TableReviewForSubmitterProps> = (props:
                     canDisplayScores,
                     canViewScorecard: isChallengeCompleted || isOwnedSubmission,
                     isAppealsTab: false,
+                    useAggregateScore: useAggregateReviewScore,
                 }
 
                 return renderScoreCell(submission, submission.reviewerIndex, scoreConfig)
@@ -585,6 +593,7 @@ export const TableReviewForSubmitter: FC<TableReviewForSubmitterProps> = (props:
         restrictToLatest,
         shouldShowHistoryActions,
         shouldRestrictSubmitterToOwnSubmission,
+        useAggregateReviewScore,
     ])
 
     const columnsMobile = useMemo<MobileTableColumn<SubmissionReviewerRow>[][]>(

--- a/src/apps/review/src/lib/components/common/TableColumnRenderers.spec.tsx
+++ b/src/apps/review/src/lib/components/common/TableColumnRenderers.spec.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen } from '@testing-library/react'
+
+import type { SubmissionReviewerRow } from './types'
+import {
+    renderReviewScoreCell,
+    renderScoreCell,
+} from './TableColumnRenderers'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        REVIEW: {
+            PROFILE_PAGE_URL: 'https://profiles.test',
+        },
+    },
+}), { virtual: true })
+
+jest.mock('~/libs/core', () => ({
+    getRatingColor: () => '#2a2a2a',
+}), { virtual: true })
+
+jest.mock('~/libs/shared', () => ({
+    copyTextToClipboard: jest.fn(),
+}), { virtual: true })
+
+jest.mock('~/libs/ui', () => {
+    const React = jest.requireActual('react')
+
+    return {
+        IconOutline: {
+            DocumentDuplicateIcon: () => React.createElement('span'),
+        },
+        Tooltip: (props: { children: React.ReactNode }) => (
+            React.createElement(React.Fragment, undefined, props.children)
+        ),
+    }
+}, { virtual: true })
+
+const buildMarathonSubmission = (): SubmissionReviewerRow => {
+    const submission = {
+        aggregateScore: 88,
+        id: 'submission-1',
+        memberId: 'member-1',
+    }
+
+    return {
+        ...submission,
+        aggregated: {
+            averageFinalScore: 0,
+            averageFinalScoreDisplay: '0.00',
+            id: submission.id,
+            reviews: [
+                {
+                    finalScore: 0,
+                    reviewId: 'review-1',
+                    status: 'COMPLETED',
+                },
+            ],
+            submission,
+        },
+        isFirstReviewerRow: true,
+        isLastReviewerRow: true,
+        reviewerIndex: 0,
+    }
+}
+
+describe('TableColumnRenderers marathon score display', () => {
+    it('renders the aggregate score instead of the scorecard average for Review Score', () => {
+        render(renderReviewScoreCell(buildMarathonSubmission(), {
+            canDisplayScores: () => true,
+            canViewScorecard: true,
+            isAppealsTab: false,
+            useAggregateScore: true,
+        }))
+
+        expect(screen.getByText('88.00'))
+            .toBeTruthy()
+        expect(screen.queryByText('0.00'))
+            .toBeNull()
+    })
+
+    it('renders aggregate Score as plain text without a scorecard link', () => {
+        const rendered: ReturnType<typeof render> = render(renderScoreCell(
+            buildMarathonSubmission(),
+            0,
+            {
+                canDisplayScores: () => true,
+                canViewScorecard: true,
+                isAppealsTab: false,
+                useAggregateScore: true,
+            },
+        ))
+
+        expect(screen.getByText('88.00'))
+            .toBeTruthy()
+        expect(rendered.container.querySelector('a'))
+            .toBeNull()
+    })
+})

--- a/src/apps/review/src/lib/components/common/TableColumnRenderers.tsx
+++ b/src/apps/review/src/lib/components/common/TableColumnRenderers.tsx
@@ -223,11 +223,24 @@ export function renderReviewScoreCell(
     const {
         canDisplayScores,
         canViewScorecard,
+        useAggregateScore,
         viewOwnScorecardTooltip = VIEW_OWN_SCORECARD_TOOLTIP,
     }: ScoreVisibilityConfig = configWithDefaults
 
     if (!canDisplayScores(submission)) {
         return (
+            <span className={styles.notReviewed}>
+                --
+            </span>
+        )
+    }
+
+    if (useAggregateScore) {
+        const aggregateScoreDisplay = formatScoreDisplay(submission.aggregateScore)
+
+        return aggregateScoreDisplay ? (
+            <span>{aggregateScoreDisplay}</span>
+        ) : (
             <span className={styles.notReviewed}>
                 --
             </span>
@@ -529,10 +542,35 @@ export function renderScoreCell(
     const {
         canDisplayScores,
         canViewScorecard,
+        useAggregateScore,
         viewOwnScorecardTooltip = VIEW_OWN_SCORECARD_TOOLTIP,
         getReviewUrl,
         canRespondToAppeals,
     }: ScoreVisibilityConfig = configWithDefaults
+
+    if (!canDisplayScores(submission)) {
+        return (
+            <span className={styles.notReviewed}>
+                --
+            </span>
+        )
+    }
+
+    if (useAggregateScore) {
+        const isFirstSubmissionRow = !('isFirstReviewerRow' in submission)
+            || submission.isFirstReviewerRow !== false
+        const aggregateScoreDisplay = isFirstSubmissionRow
+            ? formatScoreDisplay(submission.aggregateScore)
+            : undefined
+
+        return aggregateScoreDisplay ? (
+            <span>{aggregateScoreDisplay}</span>
+        ) : (
+            <span className={styles.notReviewed}>
+                --
+            </span>
+        )
+    }
 
     const reviewDetail = submission.aggregated?.reviews?.[reviewIndex]
 
@@ -548,14 +586,6 @@ export function renderScoreCell(
     const reviewId = reviewInfo?.id ?? reviewDetail.reviewId
 
     if (!reviewId) {
-        return (
-            <span className={styles.notReviewed}>
-                --
-            </span>
-        )
-    }
-
-    if (!canDisplayScores(submission)) {
         return (
             <span className={styles.notReviewed}>
                 --

--- a/src/apps/review/src/lib/components/common/reviewResult.spec.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.spec.ts
@@ -164,4 +164,26 @@ describe('resolveSubmissionReviewResult', () => {
         expect(result)
             .toBe('PASS')
     })
+
+    it('prefers the summation aggregate score when requested', () => {
+        const submission = {
+            ...buildSubmission([
+                {
+                    finalScore: 0,
+                    resourceId: 'res-1',
+                    status: 'COMPLETED',
+                },
+            ], 0),
+            aggregateScore: 88,
+            isPassingReview: true,
+        }
+
+        const result = resolveSubmissionReviewResult(submission, {
+            defaultMinimumPassingScore: DEFAULT_PASSING_SCORE,
+            preferAggregateScore: true,
+        })
+
+        expect(result)
+            .toBe('PASS')
+    })
 })

--- a/src/apps/review/src/lib/components/common/reviewResult.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.ts
@@ -301,14 +301,46 @@ const extractMinimumPassingScoreFromMetadata = (metadata: unknown): number | und
 }
 /* eslint-enable complexity, no-continue */
 
-const resolveReviewScore = (submission: SubmissionRow): number | undefined => {
+/**
+ * Resolves the review summation aggregate score from a submission row.
+ *
+ * @param submission - Submission row that may include a Review API summation aggregate score.
+ * @returns Finite aggregate score, or undefined when no score is available.
+ */
+const resolveAggregateScore = (submission: SubmissionRow): number | undefined => {
+    const aggregateScore = submission.aggregateScore
+    if (typeof aggregateScore === 'number' && Number.isFinite(aggregateScore)) {
+        return aggregateScore
+    }
+
+    return undefined
+}
+
+/**
+ * Resolves the score used for pass/fail decisions.
+ *
+ * @param submission - Submission row containing review and summation scores.
+ * @param preferAggregateScore - True when summation scores should take priority over scorecard scores.
+ * @returns Finite score for outcome evaluation, or undefined when no score is available.
+ */
+const resolveReviewScore = (
+    submission: SubmissionRow,
+    preferAggregateScore: boolean,
+): number | undefined => {
+    if (preferAggregateScore) {
+        const aggregateScore = resolveAggregateScore(submission)
+        if (aggregateScore !== undefined) {
+            return aggregateScore
+        }
+    }
+
     const aggregatedAverage = submission.aggregated?.averageFinalScore
     if (typeof aggregatedAverage === 'number' && Number.isFinite(aggregatedAverage)) {
         return aggregatedAverage
     }
 
-    const aggregateScore = submission.aggregateScore
-    if (typeof aggregateScore === 'number' && Number.isFinite(aggregateScore)) {
+    const aggregateScore = resolveAggregateScore(submission)
+    if (aggregateScore !== undefined) {
         return aggregateScore
     }
 
@@ -431,6 +463,7 @@ const resolveForcedOutcome = (
 }
 
 export interface ResolveSubmissionReviewResultOptions {
+    preferAggregateScore?: boolean
     minimumPassingScoreByScorecardId?: Map<string, number | undefined>
     defaultMinimumPassingScore?: number
 }
@@ -440,6 +473,7 @@ export function resolveSubmissionReviewResult(
     options: ResolveSubmissionReviewResultOptions = {},
 ): ReviewOutcome | undefined {
     const {
+        preferAggregateScore = false,
         minimumPassingScoreByScorecardId,
         defaultMinimumPassingScore,
     }: ResolveSubmissionReviewResultOptions = options
@@ -461,7 +495,7 @@ export function resolveSubmissionReviewResult(
         defaultMinimumPassingScore,
     )
 
-    const reviewScore = resolveReviewScore(submission)
+    const reviewScore = resolveReviewScore(submission, preferAggregateScore)
 
     const scoreOutcome = resolveScoreOutcome(reviewScore, minimumPassingScore)
 

--- a/src/apps/review/src/lib/components/common/types.ts
+++ b/src/apps/review/src/lib/components/common/types.ts
@@ -84,6 +84,8 @@ export interface ScoreVisibilityConfig {
     canDisplayScores: (submission: SubmissionRow) => boolean
     /** Whether the viewer can navigate to the detailed scorecard for the submission. */
     canViewScorecard: boolean
+    /** True when the table should render the submission aggregate score instead of scorecard links. */
+    useAggregateScore?: boolean
     /** Tooltip message shown when scorecard access is restricted. */
     viewOwnScorecardTooltip?: string
     /** True when the parent table is rendered within the appeals tab. */

--- a/src/apps/review/src/lib/utils/challenge.spec.ts
+++ b/src/apps/review/src/lib/utils/challenge.spec.ts
@@ -6,6 +6,7 @@ import {
     findPhaseByTabLabel,
     hasPendingApprovalReview,
     isFirst2FinishChallenge,
+    isMarathonMatchChallenge,
     type PhaseLike,
     resolveFirst2FinishIterativeSubmissionIds,
     shouldAllowWinnersTabForPastChallenge,
@@ -50,6 +51,29 @@ const createBackendPhase = (
 })
 
 describe('challenge phase tab helpers', () => {
+    it('recognizes Marathon Match challenges from type metadata', () => {
+        expect(isMarathonMatchChallenge({
+            type: {
+                abbreviation: 'MM',
+                id: 'type-1',
+                name: 'Marathon Match',
+            },
+            typeId: 'type-1',
+        }))
+            .toBe(true)
+    })
+
+    it('recognizes Marathon Match challenges from the canonical type id', () => {
+        expect(isMarathonMatchChallenge({
+            type: {
+                id: 'type-1',
+                name: 'Code',
+            },
+            typeId: '929bc408-9cf2-4b3e-ba71-adfbf693046c',
+        }))
+            .toBe(true)
+    })
+
     it('preserves the incoming phase order', () => {
         const phases: PhaseLike[] = [
             createPhase('1', 'Registration', '2025-01-01T00:00:00Z'),

--- a/src/apps/review/src/lib/utils/challenge.ts
+++ b/src/apps/review/src/lib/utils/challenge.ts
@@ -276,6 +276,10 @@ function normalizeChallengeKey(value?: string): string {
         .replace(/[^a-z0-9]/g, '')
 }
 
+const MARATHON_MATCH_TYPE_IDS = new Set([
+    '929bc408-9cf2-4b3e-ba71-adfbf693046c',
+])
+
 /**
  * Check whether a challenge should follow First2Finish-specific UI rules.
  *
@@ -289,6 +293,27 @@ export function isFirst2FinishChallenge(
     const trackName = normalizeChallengeKey(challengeInfo?.track?.name)
 
     return typeName === 'first2finish' || trackName === 'first2finish'
+}
+
+/**
+ * Check whether a challenge should follow Marathon Match-specific score display rules.
+ *
+ * @param challengeInfo - Challenge metadata containing type name, abbreviation, and type ID.
+ * @returns True when the type metadata identifies the challenge as Marathon Match.
+ */
+export function isMarathonMatchChallenge(
+    challengeInfo?: Pick<ChallengeInfo, 'type' | 'typeId'>,
+): boolean {
+    const typeName = normalizeChallengeKey(challengeInfo?.type?.name)
+    const typeAbbreviation = normalizeChallengeKey(challengeInfo?.type?.abbreviation)
+    const typeId = (challengeInfo?.typeId ?? '')
+        .trim()
+        .toLowerCase()
+
+    return typeName === 'marathonmatch'
+        || typeAbbreviation === 'mm'
+        || typeAbbreviation === 'marathonmatch'
+        || MARATHON_MATCH_TYPE_IDS.has(typeId)
 }
 
 function normalizeEntityId(value: unknown): string | undefined {


### PR DESCRIPTION
What was broken
Marathon Match review rows displayed scorecard-derived review scores, so submitters could see 0.00 and a Fail result after winners were announced even when review summations had the final aggregate score.

Root cause
The review app's shared review table helpers preferred per-review scorecard averages over submission aggregate scores, and the score cell always linked through the scorecard path. Marathon Match system reviews do not have a scorecard to open.

What was changed
Added Marathon Match challenge detection in the review app and routed review tables to prefer review summation aggregate scores for Marathon Match submissions. The Review Score and Score cells now display the aggregate score as plain text for Marathon Match rows, and pass/fail resolution can use the aggregate score before scorecard averages.

Any added/updated tests
Added tests for Marathon Match challenge detection, aggregate-score pass/fail resolution, and aggregate score rendering without a scorecard link.

Validation:
- yarn lint passed.
- yarn test:no-watch --runTestsByPath src/apps/review/src/lib/components/common/reviewResult.spec.ts src/apps/review/src/lib/components/common/TableColumnRenderers.spec.tsx src/apps/review/src/lib/utils/challenge.spec.ts passed.
- yarn run build passed with existing CSS order and lint warnings.
- yarn test:no-watch was run; the new tests passed, but the full suite failed in unrelated existing wallet-admin and work app tests.
