### PR TITLE
PM-5048: Support project invitation email routes

### DIFF
--- a/src/apps/work/src/pages/invitations/ProjectInvitationsPage/ProjectInvitationsPage.spec.tsx
+++ b/src/apps/work/src/pages/invitations/ProjectInvitationsPage/ProjectInvitationsPage.spec.tsx
@@ -213,6 +213,10 @@ function renderPage(options: RenderPageOptions = {}): jest.Mock {
                         path='/projects/:projectId/invitations/:action?'
                     />
                     <Route
+                        element={<ProjectInvitationsPage />}
+                        path='/projects/:projectId/invitation/:action?'
+                    />
+                    <Route
                         element={<div>Challenges Page</div>}
                         path='/projects/:projectId/challenges'
                     />
@@ -380,6 +384,29 @@ describe('ProjectInvitationsPage', () => {
         await waitFor(() => {
             expect(mockedShowErrorToast)
                 .toHaveBeenCalledWith('Update failed')
+        })
+    })
+
+    it('refuses the current user invite from the legacy email invitation route', async () => {
+        mockedCheckIsUserInvitedToProject.mockReturnValue(pendingInvitation)
+
+        renderPage({
+            route: '/projects/200/invitation/refused?source=email',
+        })
+
+        await waitFor(() => {
+            expect(mockedUpdateProjectMemberInvite)
+                .toHaveBeenCalledWith(
+                    '200',
+                    '77',
+                    'refused',
+                    'email',
+                )
+        })
+
+        await waitFor(() => {
+            expect(screen.queryByText('Invitation Declined'))
+                .not.toBeNull()
         })
     })
 })

--- a/src/apps/work/src/work-app.routes.tsx
+++ b/src/apps/work/src/work-app.routes.tsx
@@ -404,6 +404,12 @@ export const workRoutes: ReadonlyArray<PlatformRoute> = [
             {
                 authRequired: true,
                 element: <ProjectInvitationsPage />,
+                route: '/projects/:projectId/invitation/:action?',
+                title: 'Project Invitations',
+            },
+            {
+                authRequired: true,
+                element: <ProjectInvitationsPage />,
                 id: projectInvitationsRouteId,
                 route: '/projects/:projectId/invitations/:action?',
                 title: 'Project Invitations',


### PR DESCRIPTION
What was broken
Project invitation email links can open /projects/:projectId/invitation/accepted or /projects/:projectId/invitation/refused, but the work app only routed the plural invitations path and older accept/decline links with invite IDs. Those email links landed on an empty partially loaded page and never updated the invite.

Root cause (if identifiable)
The work app route table did not include the legacy singular invitation URL shape emitted by the email flow.

What was changed
Added the singular /projects/:projectId/invitation/:action? route to the work app and routed it to the existing ProjectInvitationsPage flow so it can resolve the current user's pending invite and update its status.

Any added/updated tests
Added a ProjectInvitationsPage spec covering the refused email route with source=email and verifying the current user's pending invite is updated to refused.

Validation performed:
- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/invitations/ProjectInvitationsPage/ProjectInvitationsPage.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing project warnings.
- yarn test:no-watch was run; it failed in unrelated existing suites outside this change area, including wallet-admin module resolution and engagement/payment specs.
