### PR TITLE
PM-4836: Place review action on reviewer row

### DIFF
--- a/src/apps/review/src/lib/components/TableReview/TableReview.tsx
+++ b/src/apps/review/src/lib/components/TableReview/TableReview.tsx
@@ -77,7 +77,12 @@ import type {
     SubmissionReviewerRow,
     SubmissionRow,
 } from '../common/types'
-import { buildSubmissionReviewerRows, resolveSubmissionReviewResult } from '../common/reviewResult'
+import {
+    buildSubmissionReviewerRows,
+    getSubmissionReviewerRowReview,
+    isSubmissionReviewerActionRow,
+    resolveSubmissionReviewResult,
+} from '../common/reviewResult'
 import { shouldIncludeInReviewPhase } from '../../utils/reviewPhaseGuards'
 import { CollapsibleAiReviewsRow } from '../CollapsibleAiReviewsRow'
 
@@ -538,11 +543,10 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
     const renderActionsCell = useCallback<(submission: SubmissionReviewerRow) => JSX.Element>((
         submission: SubmissionReviewerRow,
     ) => {
-        const reviews = submission.aggregated?.reviews ?? []
-        const myReviewDetail = reviews.find(review => {
-            const resourceId = review.reviewInfo?.resourceId ?? review.resourceId
-            return resourceId ? myReviewerResourceIds.has(resourceId) : false
-        })
+        const rowReviewDetail = getSubmissionReviewerRowReview(submission)
+        const myReviewDetail = isSubmissionReviewerActionRow(submission, myReviewerResourceIds)
+            ? rowReviewDetail
+            : undefined
         const actionEntries: Array<{ element: JSX.Element; wrapperKey: string }> = []
 
         const appendAction = (element: JSX.Element | undefined, fallbackKey: string): void => {
@@ -826,10 +830,13 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
         }
 
         appendAction(buildPrimaryAction(), 'primary')
-        appendAction(buildEscalateAction(), 'escalate')
-        appendAction(buildVerifyAction(), 'verify')
-        appendAction(buildUnlockAction(), 'unlock')
-        appendAction(buildHistoryAction(), 'history')
+        if (submission.isFirstReviewerRow) {
+            appendAction(buildEscalateAction(), 'escalate')
+            appendAction(buildVerifyAction(), 'verify')
+            appendAction(buildUnlockAction(), 'unlock')
+            appendAction(buildHistoryAction(), 'history')
+        }
+
         appendAction(buildReopenAction(), 'reopen')
 
         if (!actionEntries.length) {
@@ -1002,13 +1009,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
                 className: styles.textBlue,
                 columnId: 'actions',
                 label: 'Actions',
-                renderer: (row: SubmissionReviewerRow) => (
-                    row.isFirstReviewerRow ? renderActionsCell(row) : (
-                        <span className={styles.notReviewed}>
-                            --
-                        </span>
-                    )
-                ),
+                renderer: (row: SubmissionReviewerRow) => renderActionsCell(row),
                 type: 'element',
             })
         }

--- a/src/apps/review/src/lib/components/common/reviewResult.spec.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.spec.ts
@@ -1,7 +1,16 @@
 import type { ReviewInfo } from '../../models/ReviewInfo.model'
 
-import type { AggregatedReviewDetail, SubmissionRow } from './types'
-import { resolveSubmissionReviewResult } from './reviewResult'
+import type {
+    AggregatedReviewDetail,
+    AggregatedSubmissionReviews,
+    SubmissionRow,
+} from './types'
+import {
+    buildSubmissionReviewerRows,
+    getSubmissionReviewerRowReview,
+    isSubmissionReviewerActionRow,
+    resolveSubmissionReviewResult,
+} from './reviewResult'
 
 const DEFAULT_PASSING_SCORE = 80
 
@@ -38,6 +47,34 @@ const buildReviewInfo = (
         .toISOString(),
     ...overrides,
 })
+
+const createSubmissionRow = (): SubmissionRow => {
+    const aggregated: AggregatedSubmissionReviews = {
+        id: 'submission-1',
+        reviews: [
+            {
+                resourceId: 'other-reviewer-resource',
+                reviewerHandle: 'taasintake300',
+                reviewId: 'other-review',
+            },
+            {
+                resourceId: 'copilot-reviewer-resource',
+                reviewerHandle: 'TCConnCopilot',
+                reviewId: 'copilot-review',
+            },
+        ],
+        submission: {
+            id: 'submission-1',
+            memberId: 'submitter-1',
+        },
+    }
+
+    return {
+        aggregated,
+        id: 'submission-1',
+        memberId: 'submitter-1',
+    }
+}
 
 describe('resolveSubmissionReviewResult', () => {
     it('returns undefined when any reviewer is still pending in a multi-review setup', () => {
@@ -185,5 +222,23 @@ describe('resolveSubmissionReviewResult', () => {
 
         expect(result)
             .toBe('PASS')
+    })
+})
+
+describe('reviewResult row helpers', () => {
+    it('marks only the matching reviewer row as action-eligible when the current reviewer is not first', () => {
+        const rows = buildSubmissionReviewerRows([createSubmissionRow()])
+        const currentReviewerResourceIds = new Set(['copilot-reviewer-resource'])
+
+        expect(rows)
+            .toHaveLength(2)
+        expect(getSubmissionReviewerRowReview(rows[0])?.reviewId)
+            .toBe('other-review')
+        expect(getSubmissionReviewerRowReview(rows[1])?.reviewId)
+            .toBe('copilot-review')
+        expect(isSubmissionReviewerActionRow(rows[0], currentReviewerResourceIds))
+            .toBe(false)
+        expect(isSubmissionReviewerActionRow(rows[1], currentReviewerResourceIds))
+            .toBe(true)
     })
 })

--- a/src/apps/review/src/lib/components/common/reviewResult.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.ts
@@ -536,3 +536,34 @@ export function buildSubmissionReviewerRows(
 
     return rows
 }
+
+/**
+ * Resolves the aggregated review detail represented by a flattened reviewer row.
+ *
+ * @param submission - Flattened reviewer row from the submissions table.
+ * @returns The aggregated review detail at the row's reviewer index, or undefined when unavailable.
+ * @throws This helper does not throw.
+ */
+export function getSubmissionReviewerRowReview(
+    submission: SubmissionReviewerRow,
+): AggregatedReviewDetail | undefined {
+    return submission.aggregated?.reviews?.[submission.reviewerIndex]
+}
+
+/**
+ * Determines whether reviewer-owned actions should render on a flattened reviewer row.
+ *
+ * @param submission - Flattened reviewer row from the submissions table.
+ * @param reviewerResourceIds - Resource IDs assigned to the current reviewer.
+ * @returns True when the row's review belongs to one of the current reviewer's resources.
+ * @throws This helper does not throw.
+ */
+export function isSubmissionReviewerActionRow(
+    submission: SubmissionReviewerRow,
+    reviewerResourceIds: Set<string>,
+): boolean {
+    const reviewDetail = getSubmissionReviewerRowReview(submission)
+    const resourceId = reviewDetail?.reviewInfo?.resourceId ?? reviewDetail?.resourceId
+
+    return resourceId ? reviewerResourceIds.has(resourceId) : false
+}


### PR DESCRIPTION
## What was broken
The review table rendered the current reviewer action only on the first reviewer row for a submission. When a copilot reviewer was the second reviewer, Complete Review appeared beside the other reviewer.

## Root cause
The actions cell looked up the current user's review across the whole submission while the table only rendered actions for the first flattened reviewer row.

## What was changed
Reviewer-owned actions now resolve against the flattened row's reviewer index, so Complete Review, Review Complete, and Reopen Review render on the row for the matching reviewer resource. Submission-level actions still render only on the first row to avoid duplicates.

## Any added/updated tests
Added regression coverage for a two-reviewer row set where the current reviewer is not first, ensuring only that reviewer row is action-eligible.

Validation run:
- yarn lint passed.
- yarn test:no-watch src/apps/review/src/lib/components/common/reviewResult.spec.ts passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch was run and failed in unrelated wallet/work/engagement suites, including missing modules under wallet-admin and missing assignment utility exports in work engagement tests.
