### PR TITLE
PM-5027: Search user billing accounts in project edit

### DIFF
--- a/src/apps/work/src/lib/components/form/FormBillingAccountAutocomplete/FormBillingAccountAutocomplete.spec.tsx
+++ b/src/apps/work/src/lib/components/form/FormBillingAccountAutocomplete/FormBillingAccountAutocomplete.spec.tsx
@@ -277,8 +277,8 @@ describe('FormBillingAccountAutocomplete', () => {
         })
     })
 
-    it('filters preloaded project billing accounts locally when searching in edit mode', async () => {
-        fetchProjectBillingAccountsMock.mockResolvedValue([
+    it('uses user-scoped billing account search when editing with user context', async () => {
+        searchBillingAccountsMock.mockResolvedValueOnce([
             {
                 active: true,
                 endDate: '2023-11-20T00:00:00.000Z',
@@ -294,6 +294,15 @@ describe('FormBillingAccountAutocomplete', () => {
                 startDate: '2023-10-04T00:00:00.000Z',
             },
         ])
+        searchBillingAccountsMock.mockResolvedValueOnce([
+            {
+                active: true,
+                endDate: '2026-10-16T23:59:00.000Z',
+                id: '80001063',
+                name: 'BA For Marios',
+                startDate: '2023-10-31T00:00:00.000Z',
+            },
+        ])
 
         render(
             <TestHarness
@@ -303,9 +312,16 @@ describe('FormBillingAccountAutocomplete', () => {
         )
 
         await waitFor(() => {
-            expect(fetchProjectBillingAccountsMock)
-                .toHaveBeenCalledWith('100578')
+            expect(searchBillingAccountsMock)
+                .toHaveBeenCalledWith({
+                    page: 1,
+                    perPage: 20,
+                    userId: '12345',
+                })
         })
+        expect(fetchProjectBillingAccountsMock)
+            .not
+            .toHaveBeenCalled()
         await waitFor(() => {
             expect(latestAsyncSelectProps?.defaultOptions)
                 .toEqual(expect.arrayContaining([
@@ -320,17 +336,21 @@ describe('FormBillingAccountAutocomplete', () => {
         let options: unknown
 
         await act(async () => {
-            options = await loadOptions('Budget')
+            options = await loadOptions('BA F')
         })
 
         expect(searchBillingAccountsMock)
-            .not
-            .toHaveBeenCalled()
+            .toHaveBeenLastCalledWith({
+                name: 'BA F',
+                page: 1,
+                perPage: 20,
+                userId: '12345',
+            })
         expect(options)
             .toEqual([
                 expect.objectContaining({
-                    label: expect.stringContaining('Budget Validation - 3'),
-                    value: '80001042',
+                    label: expect.stringContaining('BA For Marios'),
+                    value: '80001063',
                 }),
             ])
     })

--- a/src/apps/work/src/lib/components/form/FormBillingAccountAutocomplete/FormBillingAccountAutocomplete.tsx
+++ b/src/apps/work/src/lib/components/form/FormBillingAccountAutocomplete/FormBillingAccountAutocomplete.tsx
@@ -198,16 +198,13 @@ function createDebouncedLoader(
 /**
  * Async billing-account selector backed by server-side name search.
  *
- * When `projectId` is provided, the selector preloads the project's billing
- * accounts so edit flows match legacy behavior. Edit-mode search stays within
- * that preloaded project-scoped list so the typed results remain consistent
- * with the available options. When only `userId` is provided, the selector
- * preloads billing accounts granted to that user so create flows start with
- * their accessible options. Server-side search remains scoped to `userId` when
- * provided. When `selectedBillingAccount` is provided, the field seeds the
- * selected option label from project-scoped data before attempting a direct
- * billing-account lookup. The field stores only the selected billing-account
- * id in form state.
+ * When `userId` is provided, the selector preloads and searches billing
+ * accounts granted to that user so create and edit flows use the same
+ * Billing Accounts API source. When only `projectId` is provided, the selector
+ * falls back to the legacy project-scoped list and filters it locally. When
+ * `selectedBillingAccount` is provided, the field seeds the selected option
+ * label from project-scoped data before attempting a direct billing-account
+ * lookup. The field stores only the selected billing-account id in form state.
  */
 export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompleteProps> = (
     props: FormBillingAccountAutocompleteProps,
@@ -245,6 +242,11 @@ export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompletePr
         [],
     )
 
+    const normalizedUserId = useMemo(
+        () => normalizeOptionalStringValue(props.userId),
+        [props.userId],
+    )
+
     const loadBillingAccountOptions = useCallback(
         async (inputValue: string): Promise<BillingAccountOption[]> => {
             const normalizedInputValue = inputValue.trim()
@@ -255,7 +257,7 @@ export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompletePr
                 return []
             }
 
-            if (props.projectId) {
+            if (props.projectId && !normalizedUserId) {
                 return filterOptionsByInputValue(optionCacheRef.current, normalizedInputValue)
             }
 
@@ -264,7 +266,7 @@ export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompletePr
                     name: normalizedInputValue,
                     page: 1,
                     perPage: 20,
-                    userId: normalizeOptionalStringValue(props.userId),
+                    userId: normalizedUserId,
                 })
                 const options = billingAccounts.map(account => toOption(account))
 
@@ -281,17 +283,12 @@ export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompletePr
                 return []
             }
         },
-        [mergeCachedOptions, props.projectId, props.userId],
+        [mergeCachedOptions, normalizedUserId, props.projectId],
     )
 
     const debouncedLoadBillingAccountOptions = useMemo(
         () => createDebouncedLoader(loadBillingAccountOptions),
         [loadBillingAccountOptions],
-    )
-
-    const normalizedUserId = useMemo(
-        () => normalizeOptionalStringValue(props.userId),
-        [props.userId],
     )
 
     const shouldPreloadInitialOptions = useMemo(
@@ -358,13 +355,13 @@ export const FormBillingAccountAutocomplete: FC<FormBillingAccountAutocompletePr
         setInitialBillingAccountOptions([])
         setSearchErrorMessage(undefined)
 
-        const initialBillingAccountsPromise = props.projectId
-            ? fetchProjectBillingAccounts(props.projectId)
-            : searchBillingAccounts({
+        const initialBillingAccountsPromise = normalizedUserId
+            ? searchBillingAccounts({
                 page: 1,
                 perPage: 20,
                 userId: normalizedUserId,
             })
+            : fetchProjectBillingAccounts(props.projectId as string)
 
         initialBillingAccountsPromise
             .then(billingAccounts => {


### PR DESCRIPTION
What was broken
Project edit passed a project id into the billing-account selector, which made typed searches filter only the project-scoped billing-account list. Billing accounts created in system admin and granted to the user could be selected during project creation, but disappeared from edit search after the project billing account was cleared.

Root cause
Create and edit were using different billing-account sources. Create searched the Billing Accounts API by user id, while edit searched only the legacy project-scoped list when a project id was present.

What was changed
Updated the billing-account autocomplete so a user-scoped selector preloads and searches the Billing Accounts API, including edit flows. The project-scoped list remains as a fallback when no user id is available.

Any added/updated tests
Updated the autocomplete spec to verify edit mode with both project id and user id searches the user-scoped Billing Accounts API and returns matching billing accounts.
