### PR TITLE
PM-5121: Stop reviewer count stepper loop

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
@@ -29,6 +29,7 @@ import {
     MAX_MANUAL_REVIEWER_COUNT,
 } from '../../../../../lib/constants/challenge-editor.constants'
 import {
+    deleteResource,
     fetchDefaultReviewers,
     fetchProfile,
     fetchScorecards,
@@ -212,6 +213,7 @@ const mockedUseFetchChallengeTracks = useFetchChallengeTracks as jest.Mock
 const mockedUseFetchChallengeTypes = useFetchChallengeTypes as jest.Mock
 const mockedUseFetchResourceRoles = useFetchResourceRoles as jest.Mock
 const mockedUseFetchResources = useFetchResources as jest.Mock
+const mockedDeleteResource = deleteResource as jest.Mock
 const mockedFetchDefaultReviewers = fetchDefaultReviewers as jest.Mock
 const mockedFetchProfile = fetchProfile as jest.Mock
 const mockedFetchScorecards = fetchScorecards as jest.Mock
@@ -369,6 +371,7 @@ describe('HumanReviewTab', () => {
                 .mockResolvedValue(undefined),
             resources: [],
         })
+        mockedDeleteResource.mockResolvedValue(undefined)
         mockedFetchDefaultReviewers.mockImplementation(() => createPendingPromise())
         mockedFetchProfile.mockResolvedValue(undefined)
         mockedFetchScorecards.mockImplementation(() => createPendingPromise())
@@ -731,6 +734,47 @@ describe('HumanReviewTab', () => {
             .not.toBeNull()
         expect(screen.queryByTestId(`reviewers.0.additionalMemberIds.${MAX_MANUAL_REVIEWER_COUNT - 1}`))
             .toBeNull()
+    })
+
+    it('removes blank assignment slots without deleting resources when reviewer count is decreased', async () => {
+        render(
+            <TestHarness
+                defaultValues={{
+                    reviewers: [
+                        {
+                            additionalMemberIds: [''],
+                            isMemberReview: true,
+                            memberId: '',
+                            memberReviewerCount: 2,
+                            phaseId: 'phase-1',
+                            roleId: 'role-1',
+                            scorecardId: 'scorecard-1',
+                            shouldOpenOpportunity: false,
+                        },
+                    ],
+                }}
+            />,
+        )
+
+        expect(screen.getByTestId('reviewers.0.additionalMemberIds.0'))
+            .not.toBeNull()
+
+        fireEvent.change(
+            within(screen.getByTestId('reviewers.0.memberReviewerCount'))
+                .getByRole('spinbutton', { name: 'Reviewer Count' }),
+            {
+                target: {
+                    value: '1',
+                },
+            },
+        )
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('reviewers.0.additionalMemberIds.0'))
+                .toBeNull()
+        })
+        expect(mockedDeleteResource)
+            .not.toHaveBeenCalled()
     })
 
     it('hides appeal phases for manual reviewer cards across challenge types', () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
@@ -1335,15 +1335,26 @@ export const HumanReviewTab: FC = () => {
             }
 
             const nextAdditionalMemberIds = additionalMemberIds.slice(0, maxAdditionalMembers)
+            const removedAdditionalMemberIds = additionalMemberIds.slice(maxAdditionalMembers)
             const keptMemberIds = toUniqueValues([
                 normalizeText(reviewer.memberId),
                 ...nextAdditionalMemberIds,
             ])
             const removedMemberIds = toUniqueValues(
-                additionalMemberIds
-                    .slice(maxAdditionalMembers)
+                removedAdditionalMemberIds
                     .filter(memberId => !keptMemberIds.includes(memberId)),
             )
+            const hasRemovedAdditionalMemberValue = removedAdditionalMemberIds.some(Boolean)
+
+            removedAdditionalMemberIds.forEach((_, removedIndex) => {
+                formContext.unregister(
+                    `reviewers.${fieldIndex}.additionalMemberIds.${maxAdditionalMembers + removedIndex}` as any,
+                )
+            })
+
+            if (!hasRemovedAdditionalMemberValue && !nextAdditionalMemberIds.some(Boolean)) {
+                return
+            }
 
             formContext.setValue(
                 `reviewers.${fieldIndex}.additionalMemberIds` as any,


### PR DESCRIPTION
What was broken

The prior PM-5121 fix capped large reviewer counts, but QA still reproduced the freeze by closing the public review opportunity and clicking the Reviewer Count down stepper.

Root cause (if identifiable)

Closed-opportunity member selectors can leave blank additionalMemberIds slots registered in react-hook-form. When the reviewer count dropped, the trimming effect treated those blank hidden slots as data to write back during validation, allowing the reviewer watcher cleanup path to re-enter repeatedly.

What was changed

Unregistered additional member fields that are no longer visible when reviewer count shrinks, and only write/delete additional members when an actual assigned member value is being removed or preserved.

Any added/updated tests

Added HumanReviewTab coverage for decreasing reviewer count with a blank extra assignment slot and asserting no reviewer resource deletion is attempted.

Validation:
- yarn lint passed.
- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx passed with existing React act warnings.
- yarn run build passed with existing warnings.
- yarn test:no-watch was run and still fails in unrelated existing suites, including wallet-admin alias resolution, engagement/payment assignment utility mocks, and existing engagement schema/assignment-card expectations.
