### PR TITLE
PM-5121: Clear hidden reviewer slots

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
@@ -245,6 +245,7 @@ function createDeferredPromise<T>(): DeferredPromise<T> {
 interface TestHarnessProps {
     defaultValues?: Partial<ChallengeEditorFormData>
     initialScorecardErrorMessage?: string
+    showAdditionalMemberIdsValue?: boolean
     showMemberValue?: boolean
     showScorecardValue?: boolean
 }
@@ -318,6 +319,15 @@ const TestHarness = (props: TestHarnessProps): JSX.Element => {
     return (
         <FormProvider {...formMethods}>
             <HumanReviewTab />
+            {props.showAdditionalMemberIdsValue
+                ? (
+                    <div data-testid='additional-member-ids-value'>
+                        {formMethods.watch('reviewers.0.additionalMemberIds') === undefined
+                            ? 'undefined'
+                            : JSON.stringify(formMethods.watch('reviewers.0.additionalMemberIds'))}
+                    </div>
+                )
+                : undefined}
             {props.showMemberValue
                 ? (
                     <div data-testid='member-id-value'>
@@ -736,7 +746,7 @@ describe('HumanReviewTab', () => {
             .toBeNull()
     })
 
-    it('removes blank assignment slots without deleting resources when reviewer count is decreased', async () => {
+    it('removes blank assignment slots without deleting resources after closing public opportunity', async () => {
         render(
             <TestHarness
                 defaultValues={{
@@ -749,12 +759,15 @@ describe('HumanReviewTab', () => {
                             phaseId: 'phase-1',
                             roleId: 'role-1',
                             scorecardId: 'scorecard-1',
-                            shouldOpenOpportunity: false,
+                            shouldOpenOpportunity: true,
                         },
                     ],
                 }}
+                showAdditionalMemberIdsValue
             />,
         )
+
+        fireEvent.click(screen.getByLabelText('Open public review opportunity'))
 
         expect(screen.getByTestId('reviewers.0.additionalMemberIds.0'))
             .not.toBeNull()
@@ -773,6 +786,8 @@ describe('HumanReviewTab', () => {
             expect(screen.queryByTestId('reviewers.0.additionalMemberIds.0'))
                 .toBeNull()
         })
+        expect(screen.getByTestId('additional-member-ids-value').textContent)
+            .toBe('undefined')
         expect(mockedDeleteResource)
             .not.toHaveBeenCalled()
     })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
@@ -1352,10 +1352,6 @@ export const HumanReviewTab: FC = () => {
                 )
             })
 
-            if (!hasRemovedAdditionalMemberValue && !nextAdditionalMemberIds.some(Boolean)) {
-                return
-            }
-
             formContext.setValue(
                 `reviewers.${fieldIndex}.additionalMemberIds` as any,
                 nextAdditionalMemberIds.length
@@ -1368,7 +1364,12 @@ export const HumanReviewTab: FC = () => {
             )
 
             const roleId = resolveRoleIdForReviewer(reviewer)
-            if (!normalizedChallengeId || !roleId || !removedMemberIds.length) {
+            if (
+                !hasRemovedAdditionalMemberValue
+                || !normalizedChallengeId
+                || !roleId
+                || !removedMemberIds.length
+            ) {
                 return
             }
 


### PR DESCRIPTION
What was broken

After closing the public review opportunity, clicking the Reviewer Count down stepper could leave a hidden blank additional member slot in form state and the Work app could become unresponsive.

Root cause (if identifiable)

The prior follow-up unregistered hidden blank additional member fields but returned before clearing the parent additionalMemberIds value. React Hook Form could keep the stale blank array value watched by the reviewer cleanup effect, allowing that cleanup path to run repeatedly.

What was changed

The reviewer-count shrink cleanup now always writes the trimmed additionalMemberIds value back to the form so hidden blank slots are removed from state. Resource deletion remains gated to cases where an actual assigned member id was removed.

Any added/updated tests

Updated the HumanReviewTab regression to follow QA's public-opportunity toggle path, decrease the reviewer count, assert the hidden blank slot is cleared from form state, and confirm no reviewer resource deletion is attempted for blank slots.

Validation:
- yarn lint passed.
- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx passed with existing React act warnings.
- yarn run build passed with existing warnings.
- yarn test:no-watch was run and still fails in unrelated existing suites, including wallet-admin alias resolution, engagement/payment assignment utility mocks, assignment-card expectations, ChallengePrizesField, and engagement schema expectations.
