### PR TITLE
Fix cancelled status Ui

### DIFF
--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -50,7 +50,7 @@ interface AiReviewerRow {
     reviewDate?: string
     run?: Pick<AiWorkflowRun, 'id'|'score'|'status'|'workflow'>
     score?: number
-    status?: 'failed' | 'failed-score' | 'passed' | 'pending'
+    status?: 'failed' | 'failed-score' | 'passed' | 'pending' | 'cancelled'
     title: string
     weight?: number
     workflowId?: string
@@ -64,9 +64,13 @@ function normalizeStatus(
     runStatus?: string | null,
     score?: number | null,
     minScore?: number,
-): 'failed' | 'failed-score' | 'passed' | 'pending' {
+): 'failed' | 'failed-score' | 'passed' | 'pending' | 'cancelled' {
     if (!runStatus) {
         return 'pending'
+    }
+
+    if (runStatus === AiWorkflowRunStatusEnum.CANCELLED) {
+        return 'cancelled'
     }
 
     if (aiRunInProgress({ status: runStatus as AiWorkflowRunStatusEnum })) {

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiWorkflowRunStatus.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiWorkflowRunStatus.tsx
@@ -8,21 +8,24 @@ import StatusLabel from './StatusLabel'
 
 interface AiWorkflowRunStatusProps {
     run?: Pick<AiWorkflowRun, 'status'|'score'|'workflow'|'id'>
-    status?: 'passed' | 'pending' | 'failed-score' | 'failed' | 'human-override'
+    status?: 'passed' | 'pending' | 'failed-score' | 'failed' | 'cancelled' | 'human-override'
     score?: number
     hideLabel?: boolean
     showScore?: boolean
     action?: ReactNode
 }
 
-const aiRunStatus = (run: Pick<AiWorkflowRun, 'status'|'score'|'workflow'>): string => {
+const aiRunStatus = (
+    run: Pick<AiWorkflowRun, 'status'|'score'|'workflow'>,
+): 'pending' | 'failed' | 'cancelled' | 'passed' | 'failed-score' => {
     const isInProgress = aiRunInProgress(run)
     const isFailed = aiRunFailed(run)
+    const isCancelled = run.status === 'CANCELLED'
     const isPassing = (
         run.status === 'SUCCESS'
         && run.score >= (run.workflow.scorecard?.minimumPassingScore ?? 0)
     )
-    return isInProgress ? 'pending' : isFailed ? 'failed' : (
+    return isInProgress ? 'pending' : isCancelled ? 'cancelled' : isFailed ? 'failed' : (
         isPassing ? 'passed' : 'failed-score'
     )
 }
@@ -81,6 +84,16 @@ export const AiWorkflowRunStatus: FC<AiWorkflowRunStatusProps> = props => {
                     hideLabel={props.hideLabel}
                     status={displayStatus}
                     label='Failure'
+                    score={score}
+                    action={props.action}
+                />
+            )}
+            {displayStatus === 'cancelled' && (
+                <StatusLabel
+                    icon={<IconOutline.XCircleIcon className='icon-xl' />}
+                    hideLabel={props.hideLabel}
+                    status='failed'
+                    label='Cancelled'
                     score={score}
                     action={props.action}
                 />


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request updates the AI review status handling to support a new "cancelled" state. The main changes ensure that cancelled workflow runs are properly represented throughout the UI and logic.

**Status handling improvements:**

* Added `'cancelled'` as a possible value for the `status` field in the `AiReviewerRow` interface, allowing the UI to recognize and handle cancelled runs.
* Updated the `normalizeStatus` function to return `'cancelled'` when the run status matches `AiWorkflowRunStatusEnum.CANCELLED`.
* Modified the `aiRunStatus` function to return `'cancelled'` if the run's status is `'CANCELLED'`, ensuring consistent status normalization.

**UI updates:**

* Updated the `AiWorkflowRunStatus` component to render a "Cancelled" status label with an appropriate icon when the status is `'cancelled'`.
* Extended the accepted `status` prop values for `AiWorkflowRunStatus` to include `'cancelled'`.