### PR TITLE
PM-5261: Keep rating position details together

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -64,12 +64,12 @@
     border: 1px solid $black-10;
     border-radius: 6px;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 126px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr);
     min-height: 96px;
     overflow: hidden;
 
     @include ltesm {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 
@@ -93,12 +93,25 @@
 }
 
 .positionMetric {
+    align-items: center;
     border-left: 1px solid $black-10;
+    flex-direction: row;
+    gap: $sp-6;
+    justify-content: flex-start;
 
     @include ltesm {
-        border-left: 1px solid $black-10;
+        border-left: 0;
         border-top: 1px solid $black-10;
+        gap: $sp-4;
+        grid-column: 1 / -1;
     }
+}
+
+.positionDetails {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
 }
 
 .summaryLabel {
@@ -135,18 +148,10 @@
 
 .tierPyramid {
     align-items: center;
-    border-left: 1px solid $black-10;
     display: flex;
-    flex-direction: column;
+    flex: 0 0 76px;
     justify-content: center;
     min-width: 0;
-    padding: $sp-2 0;
-
-    @include ltesm {
-        border-left: 0;
-        border-top: 1px solid $black-10;
-        padding: $sp-4 0;
-    }
 }
 
 .tierPyramidSvg {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import type { PropsWithChildren } from 'react'
+import { render, screen, within } from '@testing-library/react'
+
+import type { UserProfile } from '~/libs/core'
+
+import MemberRatingInfoModal from './MemberRatingInfoModal'
+
+jest.mock('~/libs/core', () => ({
+    getRatingColor: jest.fn(() => '#616BD5'),
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/ui', () => ({
+    BaseModal: (props: PropsWithChildren<{
+        open?: boolean
+        title?: JSX.Element
+    }>): JSX.Element => (
+        props.open ? (
+            <section>
+                {props.title}
+                {props.children}
+            </section>
+        ) : <></>
+    ),
+}), {
+    virtual: true,
+})
+
+jest.mock('../../../../lib', () => ({
+    numberToFixed: (value: number | string, digits: number = 2): string => Number(value)
+        .toFixed(digits),
+}))
+
+describe('MemberRatingInfoModal', () => {
+    it('keeps the pyramid graphic in the position summary cell', () => {
+        render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={15}
+                profile={{
+                    firstName: 'Emily',
+                    handle: 'emily',
+                    photoURL: 'https://example.com/photo.png',
+                } as UserProfile}
+                rating={1646}
+                ratingDistribution={{
+                    createdAt: '2026-06-04T00:00:00.000Z',
+                    createdBy: 'test',
+                    distribution: {
+                        ratingRange0To899: 10,
+                        ratingRange900To1199: 20,
+                        ratingRange1200To1499: 30,
+                        ratingRange1500To2199: 40,
+                    },
+                    subTrack: 'AI',
+                    track: 'DATA_SCIENCE',
+                    updatedAt: '2026-06-04T00:00:00.000Z',
+                    updatedBy: 'test',
+                }}
+            />,
+        )
+
+        const positionSummary = screen.getByTestId('rating-position-summary')
+
+        expect(within(positionSummary)
+            .getByText('Position'))
+            .toBeInTheDocument()
+        expect(within(positionSummary)
+            .getByText(/TOP\s+15%/))
+            .toBeInTheDocument()
+        expect(positionSummary.querySelector('svg'))
+            .toBeInTheDocument()
+    })
+})

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -327,41 +327,46 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                         <span className={styles.summaryMeta}>{getRatingTierName(props.rating)}</span>
                     </div>
 
-                    <div className={styles.tierPyramid} aria-hidden='true'>
-                        <svg
-                            className={styles.tierPyramidSvg}
-                            viewBox='0 0 100 91'
-                            focusable='false'
-                        >
-                            {pyramidTierShapes.map((shape: PyramidTierShape) => {
-                                const tier = ratingTiers.find((ratingTier: RatingTier) => (
-                                    ratingTier.id === shape.tierId
-                                )) ?? ratingTiers[0]
+                    <div
+                        className={classNames(styles.summaryMetric, styles.positionMetric)}
+                        data-testid='rating-position-summary'
+                    >
+                        <div className={styles.tierPyramid} aria-hidden='true'>
+                            <svg
+                                className={styles.tierPyramidSvg}
+                                viewBox='0 0 100 91'
+                                focusable='false'
+                            >
+                                {pyramidTierShapes.map((shape: PyramidTierShape) => {
+                                    const tier = ratingTiers.find((ratingTier: RatingTier) => (
+                                        ratingTier.id === shape.tierId
+                                    )) ?? ratingTiers[0]
 
-                                return (
-                                    <polygon
-                                        key={shape.tierId}
-                                        points={shape.points}
-                                        fill={tier.id === selectedTier.id ? tier.color : '#D4D4D4'}
-                                    />
-                                )
-                            })}
-                        </svg>
-                    </div>
+                                    return (
+                                        <polygon
+                                            key={shape.tierId}
+                                            points={shape.points}
+                                            fill={tier.id === selectedTier.id ? tier.color : '#D4D4D4'}
+                                        />
+                                    )
+                                })}
+                            </svg>
+                        </div>
 
-                    <div className={classNames(styles.summaryMetric, styles.positionMetric)}>
-                        <span className={styles.summaryLabel}>Position</span>
-                        <span className={styles.positionValue} style={{ color: getRatingColor(props.rating) }}>
-                            TOP
-                            {' '}
-                            {percentileLabel}
-                            {percentileLabel === '--' ? '' : '%'}
-                        </span>
-                        <span className={styles.summaryMeta}>
-                            of
-                            {' '}
-                            {props.audienceLabel.toLowerCase()}
-                        </span>
+                        <div className={styles.positionDetails}>
+                            <span className={styles.summaryLabel}>Position</span>
+                            <span className={styles.positionValue} style={{ color: getRatingColor(props.rating) }}>
+                                TOP
+                                {' '}
+                                {percentileLabel}
+                                {percentileLabel === '--' ? '' : '%'}
+                            </span>
+                            <span className={styles.summaryMeta}>
+                                of
+                                {' '}
+                                {props.audienceLabel.toLowerCase()}
+                            </span>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
What was broken
The rating info popup rendered the pyramid graphic as its own summary cell between overall rating and position, which separated the triangle from the position data.

Root cause
The summary grid defined three columns and rendered the pyramid as a standalone grid item with its own divider, instead of grouping it with the position metric.

What was changed
Moved the pyramid markup inside the position summary cell and updated the summary grid styles so the position cell contains both the pyramid and position text, including responsive behavior.

Any added/updated tests
Added a MemberRatingInfoModal rendering test that verifies the position summary cell contains both the position data and the pyramid graphic.

Validation note
The focused PM-5261 test, lint, and production build pass. The full project Jest command currently fails in unrelated wallet, work, and engagements suites that are outside this profiles modal change.
