### PR TITLE
PM-5258: Format award badge tooltips

### DIFF
--- a/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx
+++ b/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import type { PropsWithChildren, ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { useMemberBadges, type UserBadge, type UserBadgesResponse, type UserProfile } from '~/libs/core'
+
+import CommunityAwards from './CommunityAwards'
+
+jest.mock('~/libs/core', () => ({
+    useMemberBadges: jest.fn(),
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/ui', () => ({
+    Tooltip: (props: PropsWithChildren<{ content?: ReactNode }>): JSX.Element => (
+        <div
+            data-testid='award-tooltip'
+            data-tooltip-content={String(props.content)}
+        >
+            {props.children}
+        </div>
+    ),
+}), {
+    virtual: true,
+})
+
+jest.mock('../../components', () => ({
+    MemberBadgeModal: (): JSX.Element => <div data-testid='badge-modal' />,
+}))
+
+const mockUseMemberBadges = useMemberBadges as jest.MockedFunction<typeof useMemberBadges>
+
+function createBadge(badgeName: string): UserBadge {
+    return {
+        awarded_at: new Date('2026-06-04T00:00:00.000Z'),
+        awarded_by: 'admin',
+        org_badge: {
+            active: true,
+            badge_description: 'Awarded for AI profile work.',
+            badge_image_url: 'https://example.com/ai-rookie.svg',
+            badge_name: badgeName,
+            badge_status: 'active',
+            id: 'badge-1',
+            organization_id: 'topcoder',
+            orgranization: {
+                id: 'topcoder',
+                name: 'Topcoder',
+            },
+            tags_id_tags: [],
+        },
+        org_badge_id: 'badge-1',
+        user_handle: 'tester',
+        user_id: '123',
+    }
+}
+
+describe('CommunityAwards', () => {
+    beforeEach(() => {
+        mockUseMemberBadges.mockReset()
+    })
+
+    it('renders awards with formatted tooltips instead of native title tooltips', () => {
+        const memberBadges: UserBadgesResponse = {
+            count: 1,
+            rows: [createBadge('AI Rookie')],
+        }
+
+        mockUseMemberBadges.mockReturnValue(memberBadges)
+
+        render(<CommunityAwards profile={{ userId: 123 } as UserProfile} />)
+
+        const awardButton = screen.getByRole('button', {
+            name: 'View AI Rookie award details',
+        })
+
+        expect(awardButton)
+            .not
+            .toHaveAttribute('title')
+        expect(screen.getByTestId('award-tooltip'))
+            .toHaveAttribute('data-tooltip-content', 'AI Rookie')
+        expect(mockUseMemberBadges)
+            .toHaveBeenCalledWith(123, { limit: 500 })
+    })
+})

--- a/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.tsx
+++ b/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.tsx
@@ -2,6 +2,7 @@ import { Dispatch, FC, SetStateAction, useCallback, useEffect, useState } from '
 import { bind } from 'lodash'
 
 import { useMemberBadges, UserBadge, UserBadgesResponse, UserProfile } from '~/libs/core'
+import { Tooltip } from '~/libs/ui'
 
 import { MemberBadgeModal } from '../../components'
 
@@ -59,20 +60,24 @@ const CommunityAwards: FC<CommunityAwardsProps> = (props: CommunityAwardsProps) 
             <div className={styles.badges}>
                 {
                     visibleBadges.map(badge => (
-                        <button
-                            aria-label={`View ${badge.org_badge.badge_name} award details`}
+                        <Tooltip
+                            content={badge.org_badge.badge_name}
                             key={badge.org_badge_id}
-                            className={styles.badgeButton}
-                            onClick={bind(onBadgeClick, this, badge)}
-                            title={badge.org_badge.badge_name}
-                            type='button'
+                            place='top'
                         >
-                            <img
-                                src={badge.org_badge.badge_image_url}
-                                alt={`Topcoder community badge - ${badge.org_badge.badge_name}`}
-                                className={styles.badgeImage}
-                            />
-                        </button>
+                            <button
+                                aria-label={`View ${badge.org_badge.badge_name} award details`}
+                                className={styles.badgeButton}
+                                onClick={bind(onBadgeClick, this, badge)}
+                                type='button'
+                            >
+                                <img
+                                    src={badge.org_badge.badge_image_url}
+                                    alt={`Topcoder community badge - ${badge.org_badge.badge_name}`}
+                                    className={styles.badgeImage}
+                                />
+                            </button>
+                        </Tooltip>
                     ))
                 }
             </div>


### PR DESCRIPTION
What was broken
Award icons on the compact profile Awards section used native browser title tooltips, so hover text rendered with inconsistent default styling.

Root cause (if identifiable)
CommunityAwards assigned badge names through the title attribute instead of the shared Tooltip component used elsewhere.

What was changed
Wrapped each award button with the shared Tooltip component and removed the native title attribute so the badge name appears in the formatted tooltip.

Any added/updated tests
Added a CommunityAwards regression test asserting award buttons no longer render title attributes and pass the badge name to the tooltip wrapper.

Validation:
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx passed.
- yarn lint passed.
- yarn build passed with existing project warnings.
- yarn test:no-watch was run and failed in unrelated work, engagements, and wallet-admin suites that are outside this ticket's profile tooltip changes.
