### PR TITLE
PM-5257: Align mobile rating card data

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
@@ -95,15 +95,23 @@
         }
 
         @include ltesm {
-            grid-template-columns: 52px 104px auto;
+            grid-template-columns: 1fr;
             column-gap: $sp-3;
+            row-gap: $sp-1;
+            justify-content: start;
             justify-items: stretch;
             width: 300px;
 
+            .percentileWrap {
+                .name {
+                    margin-left: 0;
+                }
+            }
+
             .link {
-                grid-column: -2 / -1;
-                justify-self: end;
-                margin-top: $sp-1;
+                grid-column: 1;
+                justify-self: start;
+                margin-top: 0;
             }
         }
     }


### PR DESCRIPTION
What was broken
The mobile profile rating card laid out the rating, percentile, audience label, and help link across the same multi-column grid used at wider sizes, so the data appeared misaligned instead of reading as a single stack.

Root cause
The small-screen breakpoint kept the three-column card grid and right-aligned the help link. The affected dark rating card is part of the profile-update branch, so this branch is stacked on that work while targeting dev.

What was changed
Updated the mobile MemberRatingCard styles to use one grid column, align the percentile audience label with the rating data, and place the help action at the same left edge.

Any added/updated tests
No tests were added because this is a scoped SCSS layout fix. Validation run:

- source ~/.nvm/nvm.sh && nvm use && yarn lint
- source ~/.nvm/nvm.sh && nvm use && yarn run build
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx

The full source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch command was also run and failed in unrelated work/wallet test suites that are outside this CSS change.
