### PR TITLE
PM-5253: Fix rating card typography

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
@@ -48,6 +48,7 @@
 
             .name {
                 color: rgba($tc-white, 0.84);
+                font-family: $font-roboto;
                 font-size: 12px;
                 line-height: 14px;
             }
@@ -56,7 +57,7 @@
                 background: rgba($tc-white, 0.06);
                 border-radius: 2px;
                 font-family: $font-roboto;
-                font-size: 13px;
+                font-size: 14px;
                 font-weight: $font-weight-bold;
                 line-height: 16px;
                 padding: 2px $sp-2;
@@ -79,7 +80,7 @@
             justify-self: end;
             margin-top: $sp-1;
             color: $tc-white;
-            font-size: 11px;
+            font-size: 12px;
             line-height: 14px;
             font-weight: $font-weight-medium;
             font-family: $font-roboto;


### PR DESCRIPTION
What was broken
The compact profile rating card rendered the Rating/Data Scientists labels with the inherited browser font, the Top percentage pill at 13px, and the What is this? link at 11px instead of the Figma typography.

Root cause (if identifiable)
The card SCSS did not explicitly set Roboto on the small rating labels and used outdated font sizes for the percentile pill and help link.

What was changed
Updated the MemberRatingCard module styles so rating labels use Roboto, the Top percentage pill is 14px, and the What is this? link is 12px.

Any added/updated tests
No tests were added because this is a scoped CSS typography adjustment.

Validation run:
- yarn lint passed.
- yarn test:no-watch MemberRatingCard passed.
- yarn run build passed with existing CSS order and lint-style warnings.
- yarn test:no-watch was run and currently fails in unrelated work and wallet-admin tests outside the profile rating-card styling area.
