### PR TITLE
PM-5227: tighten profile preferred-role display

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -17,6 +17,7 @@ import { getPreferredRolesText, numberToFixed } from '../../../lib'
 
 import {
     calculateTopPercentileFromDistribution,
+    getPreferredRolesDisplay,
     getRatingAudienceLabel,
     getRatingDistributionQuery,
     parsePreferredRolesText,
@@ -78,6 +79,10 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
         () => parsePreferredRolesText(preferredRolesText),
         [preferredRolesText],
     )
+    const preferredRolesDisplay = useMemo(
+        () => getPreferredRolesDisplay(preferredRoles, arePreferredRolesExpanded),
+        [arePreferredRolesExpanded, preferredRoles],
+    )
 
     function handleInfoModalClose(): void {
         setIsInfoModalOpen(false)
@@ -105,34 +110,27 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
     }
 
     function renderPreferredRoles(): JSX.Element {
-        const MAX_VISIBLE_PREFERRED_ROLES = 4
-
         if (preferredRoles.length === 0 && !canEditPreferredRoles) {
             return <></>
         }
-
-        const visiblePreferredRoles = arePreferredRolesExpanded
-            ? preferredRoles
-            : preferredRoles.slice(0, MAX_VISIBLE_PREFERRED_ROLES)
-        const hasMorePreferredRoles = preferredRoles.length > MAX_VISIBLE_PREFERRED_ROLES
 
         return (
             <div className={styles.preferredRolesWrap}>
                 {preferredRoles.length > 0 && (
                     <div className={styles.preferredRolesList}>
-                        {visiblePreferredRoles.map((role: string) => (
+                        {preferredRolesDisplay.visibleRoles.map((role: string) => (
                             <span className={styles.preferredRole} key={role}>
                                 {role}
                             </span>
                         ))}
 
-                        {hasMorePreferredRoles && (
+                        {preferredRolesDisplay.toggleLabel && (
                             <button
                                 className={styles.preferredRolesToggle}
                                 onClick={handlePreferredRolesToggle}
                                 type='button'
                             >
-                                {arePreferredRolesExpanded ? 'See less' : 'See more'}
+                                {preferredRolesDisplay.toggleLabel}
                             </button>
                         )}
                     </div>

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -2,6 +2,7 @@ import type { UserStats, UserStatsDistributionResponse } from '~/libs/core'
 
 import {
     calculateTopPercentileFromDistribution,
+    getPreferredRolesDisplay,
     getRatingAudienceLabel,
     getRatingDistributionQuery,
     parsePreferredRolesText,
@@ -132,5 +133,44 @@ describe('parsePreferredRolesText', () => {
     it('keeps slash-separated role labels intact', () => {
         expect(parsePreferredRolesText('Cybersecurity Analyst / Security Engineer'))
             .toEqual(['Cybersecurity Analyst / Security Engineer'])
+    })
+})
+
+describe('getPreferredRolesDisplay', () => {
+    const preferredRoles = [
+        'Designer',
+        'Front-End Developer',
+        'Back-End Developer',
+        'Data Scientist',
+    ]
+
+    it('shows two roles and the hidden role count when collapsed', () => {
+        expect(getPreferredRolesDisplay(preferredRoles, false))
+            .toEqual({
+                hiddenCount: 2,
+                toggleLabel: '+ 2 more',
+                visibleRoles: [
+                    'Designer',
+                    'Front-End Developer',
+                ],
+            })
+    })
+
+    it('shows all roles and a collapse label when expanded', () => {
+        expect(getPreferredRolesDisplay(preferredRoles, true))
+            .toEqual({
+                hiddenCount: 0,
+                toggleLabel: 'See less',
+                visibleRoles: preferredRoles,
+            })
+    })
+
+    it('omits the toggle when all roles fit in the compact list', () => {
+        expect(getPreferredRolesDisplay(['Designer', 'Front-End Developer'], false))
+            .toEqual({
+                hiddenCount: 0,
+                toggleLabel: undefined,
+                visibleRoles: ['Designer', 'Front-End Developer'],
+            })
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -11,6 +11,14 @@ interface RatingDistributionRange {
     value: number
 }
 
+export interface PreferredRolesDisplay {
+    hiddenCount: number
+    toggleLabel: string | undefined
+    visibleRoles: string[]
+}
+
+const maxCollapsedPreferredRoles = 2
+
 const aiEngineeringTrackNames: Set<string> = new Set([
     'AI',
     'AI_ENGINEER',
@@ -70,6 +78,30 @@ export const parsePreferredRolesText = (preferredRolesText?: string): string[] =
             .replace(/^[-*]\s+/, ''))
         .filter(Boolean)
 )
+
+/**
+ * Builds the compact preferred-role display state for the profile rating card.
+ *
+ * @param {string[]} preferredRoles - Parsed preferred role labels in display order.
+ * @param {boolean} areExpanded - Whether the compact list has been expanded by the user.
+ * @returns {PreferredRolesDisplay} Visible roles plus the toggle label and collapsed hidden count.
+ */
+export const getPreferredRolesDisplay = (
+    preferredRoles: string[],
+    areExpanded: boolean,
+): PreferredRolesDisplay => {
+    const hiddenCount = Math.max(preferredRoles.length - maxCollapsedPreferredRoles, 0)
+
+    return {
+        hiddenCount: areExpanded ? 0 : hiddenCount,
+        toggleLabel: hiddenCount > 0
+            ? (areExpanded ? 'See less' : `+ ${hiddenCount} more`)
+            : undefined,
+        visibleRoles: areExpanded
+            ? preferredRoles
+            : preferredRoles.slice(0, maxCollapsedPreferredRoles),
+    }
+}
 
 /**
  * Parses the stats distribution API response into sorted rating ranges.


### PR DESCRIPTION
What was broken
The QA follow-up for the redesigned member profile showed the role line under the rating card should collapse after two role labels and show a "+ N more" affordance. The prior ai-ratings implementation added preferred roles, but displayed up to four roles and used generic "See more" copy.

Root cause
The earlier role renderer used a hard-coded four-role collapsed limit and did not format the hidden role count from the design.

What was changed
Added a documented display-state helper for preferred roles and wired MemberRatingCard to render two collapsed roles with "+ N more", while retaining the existing expanded "See less" behavior and prior trait parsing.

Any added/updated tests
Added MemberRatingCard utility tests for the two-role collapsed state, expanded state, and no-toggle state.

Validation run:
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts passed.
- yarn lint passed.
- yarn run build passed with existing Webpack/CSS-order and lint-style warnings from unrelated files.
- yarn test:no-watch was run, but the full suite still fails in unrelated work, wallet, and engagement suites outside this change.
