### PR TITLE
PM-5230: Show latest profile rating

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { useMemberStats, UserProfile, UserStats } from '~/libs/core'
 
+import { getLatestProfileRating } from './MemberRatingCard.utils'
 import { MemberRatingInfoModal } from './MemberRatingInfoModal'
 import styles from './MemberRatingCard.module.scss'
 
@@ -13,6 +14,7 @@ interface MemberRatingCardProps {
 
 const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProps) => {
     const memberStats: UserStats | undefined = useMemberStats(props.profile.handle)
+    const rating: number | undefined = useMemo(() => getLatestProfileRating(memberStats), [memberStats])
 
     const [isInfoModalOpen, setIsInfoModalOpen]: [boolean, Dispatch<SetStateAction<boolean>>] = useState(false)
 
@@ -45,11 +47,11 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
         setIsInfoModalOpen(true)
     }
 
-    return memberStats?.maxRating?.rating ? (
+    return rating !== undefined ? (
         <div className={styles.container}>
             <div className={styles.innerWrap}>
                 <div className={classNames(styles.valueWrap, !maxPercentile ? styles.noPercentile : '')}>
-                    <p className={styles.value}>{memberStats?.maxRating?.rating}</p>
+                    <p className={styles.value}>{rating}</p>
                     <p className={styles.name}>Rating</p>
                 </div>
                 {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -1,0 +1,82 @@
+import type { UserStats } from '~/libs/core'
+
+import { getLatestProfileRating } from './MemberRatingCard.utils'
+
+describe('getLatestProfileRating', () => {
+    it('uses the newest rated track instead of the historical max rating', () => {
+        expect(getLatestProfileRating({
+            DATA_SCIENCE: {
+                'AI Engineering': {
+                    mostRecentEventDate: 1000,
+                    rank: {
+                        rating: 840,
+                    },
+                },
+            },
+            DEVELOP: {
+                subTracks: [{
+                    mostRecentEventDate: 2000,
+                    name: 'Challenge',
+                    rank: {
+                        rating: 748,
+                    },
+                }],
+            },
+            maxRating: {
+                rating: 840,
+                ratingColor: '#9D9FA0',
+                subTrack: 'AI Engineering',
+                track: 'DATA_SCIENCE',
+            },
+        } as unknown as UserStats))
+            .toBe(748)
+    })
+
+    it('uses configured data science rating paths when they are newest', () => {
+        expect(getLatestProfileRating({
+            DATA_SCIENCE: {
+                AI: {
+                    mostRecentEventDate: 2000,
+                    rank: {
+                        rating: 840,
+                    },
+                },
+            },
+            DEVELOP: {
+                subTracks: [{
+                    mostRecentEventDate: 1000,
+                    name: 'Challenge',
+                    rank: {
+                        rating: 748,
+                    },
+                }],
+            },
+            maxRating: {
+                rating: 840,
+                ratingColor: '#9D9FA0',
+                subTrack: 'AI Engineering',
+                track: 'DATA_SCIENCE',
+            },
+        } as unknown as UserStats))
+            .toBe(840)
+    })
+
+    it('falls back to maxRating when no rated track entries are available', () => {
+        expect(getLatestProfileRating({
+            DEVELOP: {
+                subTracks: [{
+                    mostRecentEventDate: 2000,
+                    name: 'First2Finish',
+                    rank: {},
+                }],
+            },
+            maxRating: {
+                rating: 1100,
+                ratingColor: '#9D9FA0',
+                subTrack: 'Challenge',
+                track: 'DEVELOP',
+            },
+        } as unknown as UserStats))
+            .toBe(1100)
+    })
+})

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -1,0 +1,112 @@
+import { UserStats } from '~/libs/core'
+
+interface RatingCandidate {
+    rating: number
+    ratingDate: number
+}
+
+type StatsRecord = Record<string, unknown>
+
+/**
+ * Returns a finite number from unknown API data when the value can be used for rating comparisons.
+ *
+ * @param {unknown} value - A raw API value that may or may not be numeric.
+ * @returns {number | undefined} The numeric value when it is finite, otherwise undefined.
+ */
+const getFiniteNumber = (value: unknown): number | undefined => (
+    typeof value === 'number' && Number.isFinite(value) ? value : undefined
+)
+
+/**
+ * Checks whether an unknown API value can be read as an object record.
+ *
+ * @param {unknown} value - A raw API value.
+ * @returns {boolean} True when the value is a non-array object record.
+ */
+const isStatsRecord = (value: unknown): value is StatsRecord => (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+)
+
+/**
+ * Builds a rating candidate from a stats object that includes rank.rating.
+ *
+ * The member stats API stores the current rating at `rank.rating` and the
+ * event timestamp at `mostRecentEventDate`. Entries without a finite rating
+ * are ignored because unrated subtracks should not drive the profile rating.
+ *
+ * @param {unknown} stats - Raw subtrack or rating-path stats from the member stats API.
+ * @returns {RatingCandidate | undefined} Rating and event date when the stats are rated.
+ */
+const getRatingCandidate = (stats: unknown): RatingCandidate | undefined => {
+    if (!isStatsRecord(stats) || !isStatsRecord(stats.rank)) {
+        return undefined
+    }
+
+    const rating: number | undefined = getFiniteNumber(stats.rank.rating)
+
+    if (rating === undefined) {
+        return undefined
+    }
+
+    return {
+        rating,
+        ratingDate: getFiniteNumber(stats.mostRecentEventDate) ?? 0,
+    }
+}
+
+/**
+ * Extracts rated candidates from a design or development subtrack list.
+ *
+ * @param {unknown} subTracks - Raw `subTracks` array from member stats.
+ * @returns {RatingCandidate[]} Rated subtracks available for profile rating selection.
+ */
+const getSubTrackRatingCandidates = (subTracks: unknown): RatingCandidate[] => (
+    Array.isArray(subTracks)
+        ? subTracks
+            .map(getRatingCandidate)
+            .filter((candidate: RatingCandidate | undefined): candidate is RatingCandidate => candidate !== undefined)
+        : []
+)
+
+/**
+ * Extracts rated candidates from native and configured DATA_SCIENCE rating paths.
+ *
+ * @param {unknown} dataScienceStats - Raw DATA_SCIENCE stats from member stats.
+ * @returns {RatingCandidate[]} Rated data science paths available for profile rating selection.
+ */
+const getDataScienceRatingCandidates = (dataScienceStats: unknown): RatingCandidate[] => (
+    isStatsRecord(dataScienceStats)
+        ? Object.values(dataScienceStats)
+            .map(getRatingCandidate)
+            .filter((candidate: RatingCandidate | undefined): candidate is RatingCandidate => candidate !== undefined)
+        : []
+)
+
+/**
+ * Returns the rating that should be shown on the compact profile rating card.
+ *
+ * The card should show the latest current rating from the user's rated tracks,
+ * not the historical maximum rating. `maxRating` is used only as a fallback
+ * when the stats payload does not include any rated track entries.
+ *
+ * @param {UserStats | undefined} memberStats - Raw member stats for the profile user.
+ * @returns {number | undefined} Latest current rating, or the max rating fallback when no track rating exists.
+ */
+export const getLatestProfileRating = (memberStats?: UserStats): number | undefined => {
+    const candidates: RatingCandidate[] = [
+        ...getSubTrackRatingCandidates(memberStats?.DEVELOP?.subTracks),
+        ...getSubTrackRatingCandidates(memberStats?.DESIGN?.subTracks),
+        ...getDataScienceRatingCandidates(memberStats?.DATA_SCIENCE),
+    ]
+
+    const latestCandidate: RatingCandidate | undefined = candidates.reduce((
+        latest: RatingCandidate | undefined,
+        candidate: RatingCandidate,
+    ) => (
+        latest === undefined || candidate.ratingDate > latest.ratingDate ? candidate : latest
+    ), undefined)
+
+    return latestCandidate?.rating ?? memberStats?.maxRating?.rating
+}

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -30,6 +30,7 @@ import {
     AiReviewDecision,
     AiReviewDecisionBreakdownWorkflow,
     AiReviewDecisionEscalation,
+    BackendResource,
     BackendSubmission,
     ChallengeDetailContextModel,
 } from '../../models'
@@ -159,6 +160,8 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
         = challengeDetailContext.isLoadingAiReviewConfig
     const isLoadingAiReviewDecisions: ChallengeDetailContextModel['isLoadingAiReviewDecisions']
         = challengeDetailContext.isLoadingAiReviewDecisions
+    const resourceMemberIdMapping: ChallengeDetailContextModel['resourceMemberIdMapping']
+        = challengeDetailContext.resourceMemberIdMapping
 
     const windowSize: WindowSize = useWindowSize()
     const isTablet = useMemo(
@@ -279,9 +282,16 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
     const loading = isLoading || isLoadingAiReviewConfig || isLoadingAiReviewDecisions
 
     const rolePermissions: UseRolePermissionsResult = useRolePermissions()
-    const { isAdmin, hasSubmitterRole }: UseRolePermissionsResult = rolePermissions
+    const { isAdmin, hasSubmitterRole, hasCopilotRole, isProjectManager }: UseRolePermissionsResult = rolePermissions
     const { mutate }: FullConfiguration = useSWRConfig()
     const [, setRerunningRunId] = useState<string | undefined>(undefined)
+
+    /**
+     * Only Copilot, Project Manager, and Admin can see WHO performed the action.
+     * Reviewers can see the note TEXT but NOT the author "(by handle)".
+     * Submitters cannot see notes at all.
+     */
+    const canSeeAuthor = isAdmin || hasCopilotRole || isProjectManager
 
     const handleRerun = useCallback(async (runId?: string): Promise<void> => {
         if (!runId || runId === '-1') return
@@ -351,14 +361,9 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
 
     const hasDecisionNotes = decisionNotes.length > 0
 
-    /**
-     * Notes panel shown when:
-     * - submission is UNLOCKED (HUMAN_OVERRIDE, not locked) — shows unlock/escalation notes
-     * - submission is still LOCKED — appended inside the locked banner
-     */
     const notesPanel = (
         <>
-            {/* Unlocked submission: show notes banner */}
+            {/* Unlocked submission: show blue notes banner */}
             {currentDecision?.status === 'HUMAN_OVERRIDE'
                 && !currentDecision?.submissionLocked
                 && hasDecisionNotes && (
@@ -374,7 +379,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
                 </div>
             )}
 
-            {/* Locked submission with escalation notes: append inside locked banner area */}
+            {/* Locked submission with escalation/approval notes: show yellow notes banner */}
             {currentDecision?.submissionLocked && hasDecisionNotes && (
                 <div className={styles.escalationNotesBanner}>
                     <IconOutline.InformationCircleIcon className='icon-xl' />
@@ -393,7 +398,6 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
     if (isTablet) {
         return (
             <div className={styles.wrap}>
-                {/* Locked banner */}
                 {currentDecision?.submissionLocked && lockMessage && (
                     <div className={styles.lockedBanner}>
                         <div className={styles.lockedTitle}>
@@ -404,7 +408,6 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
                     </div>
                 )}
 
-                {/* Notes panel: escalation / approval / unlock notes for Copilot/Manager/Admin */}
                 {notesPanel}
 
                 {!reviewerRows.length && loading && (
@@ -508,7 +511,6 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
 
     return (
         <div className={styles.wrap} onClick={stopPropagation}>
-            {/* Locked banner */}
             {currentDecision?.submissionLocked && lockMessage && (
                 <div className={styles.lockedBanner}>
                     <IconOutline.LockClosedIcon className='icon-xl' />
@@ -521,7 +523,6 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
                 </div>
             )}
 
-            {/* Notes panel: escalation / approval / unlock notes for Copilot/Manager/Admin */}
             {notesPanel}
 
             <table className={styles.reviewsTable}>

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -114,29 +114,45 @@ function getDecisionBySubmission(
 }
 
 /**
- * Builds a list of human-readable note strings from escalations.
- * Used to display notes for Escalating, Approving/Rejecting, and Unlocking actions.
+ * Resolves a memberId to a display handle using the resourceMemberIdMapping.
+ * Falls back to the raw id string if no match is found.
+ */
+function resolveHandle(
+    memberId: string | null | undefined,
+    resourceMemberIdMapping: Record<string, BackendResource>,
+): string {
+    if (!memberId) return ''
+    return resourceMemberIdMapping[memberId]?.memberHandle ?? memberId
+}
+
+/**
+ * Builds a list of human-readable note strings from escalations and unlock reason.
+ *
+ * @param escalations            - List of escalation objects from the AI review decision
+ * @param reason                 - The unlock reason string from the decision
+ * @param showAuthor             - When true, appends "(by <handle>)" to each note.
+ *                                 Pass false for reviewer role so author identity is hidden.
+ *                                 Defaults to true.
+ * @param resourceMemberIdMapping - Map of memberId → BackendResource used to resolve handles.
  */
 function buildDecisionNotes(
     escalations?: AiReviewDecisionEscalation[],
-    resourceMemberIdMapping?: Record<string, any>,
+    reason?: string | null,
+    showAuthor = true,
+    resourceMemberIdMapping: Record<string, BackendResource> = {},
 ): string[] {
     const parts: string[] = []
 
-    const getMemberHandle = (memberId?: string | null): string => {
-        if (!memberId || !resourceMemberIdMapping) return ''
-        const resource = resourceMemberIdMapping[memberId]
-        return resource?.memberHandle || ''
-    }
-
     escalations?.forEach(esc => {
         if (esc.escalationNotes) {
-            const by = esc.createdBy ? ` (by ${getMemberHandle(esc.createdBy)})` : ''
+            const handle = resolveHandle(esc.createdBy, resourceMemberIdMapping)
+            const by = showAuthor && handle ? ` (by ${handle})` : ''
             parts.push(`Escalation Note${by}: ${esc.escalationNotes}`)
         }
 
         if (esc.approverNotes) {
-            const by = esc.updatedBy ? ` (by ${getMemberHandle(esc.updatedBy)})` : ''
+            const handle = resolveHandle(esc.updatedBy, resourceMemberIdMapping)
+            const by = showAuthor && handle ? ` (by ${handle})` : ''
             const prefix = esc.status === 'APPROVED'
                 ? 'Approval Note'
                 : esc.status === 'REJECTED'
@@ -145,6 +161,10 @@ function buildDecisionNotes(
             parts.push(`${prefix}${by}: ${esc.approverNotes}`)
         }
     })
+
+    if (reason) {
+        parts.push(`Unlock Reason: ${reason}`)
+    }
 
     return parts
 }
@@ -346,18 +366,23 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
         return 'Submission Locked - This submission won\'t be reviewed during the Review Phase.'
     }, [currentDecision?.submissionLocked, hasSubmitterRole])
 
-    const resourceMemberIdMapping = challengeDetailContext.resourceMemberIdMapping
-
     /**
-     * Builds the list of notes from escalations (escalationNotes, approverNotes).
-     * These are shown to Copilot/Manager/Admin only (not to submitters) so they
-     * can see why a submission was escalated or approved/rejected.
+     * Builds the notes list shown in the banner.
+     *
+     * - Submitters              → NO notes shown at all (empty array)
+     * - Reviewers               → note text only, NO "(by handle)"  (canSeeAuthor = false)
+     * - Copilot / PM / Admin    → note text WITH "(by handle)"       (canSeeAuthor = true)
      */
     const decisionNotes = useMemo((): string[] => {
         if (!currentDecision || hasSubmitterRole) return []
 
-        return buildDecisionNotes(currentDecision.escalations, resourceMemberIdMapping)
-    }, [currentDecision, hasSubmitterRole, resourceMemberIdMapping])
+        return buildDecisionNotes(
+            currentDecision.escalations,
+            currentDecision.reason,
+            canSeeAuthor,
+            resourceMemberIdMapping,
+        )
+    }, [canSeeAuthor, currentDecision, hasSubmitterRole, resourceMemberIdMapping])
 
     const hasDecisionNotes = decisionNotes.length > 0
 

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -126,20 +126,23 @@ function resolveHandle(
 }
 
 /**
- * Builds a list of human-readable note strings from escalations and unlock reason.
+ * Builds a list of human-readable note strings from escalations and lock/unlock reason.
  *
  * @param escalations            - List of escalation objects from the AI review decision
- * @param reason                 - The unlock reason string from the decision
+ * @param reason                 - The reason string from the decision
  * @param showAuthor             - When true, appends "(by <handle>)" to each note.
  *                                 Pass false for reviewer role so author identity is hidden.
  *                                 Defaults to true.
  * @param resourceMemberIdMapping - Map of memberId → BackendResource used to resolve handles.
+ * @param submissionLocked       - When true, labels the reason as "Locked Reason";
+ *                                 otherwise labels it as "Unlock Reason".
  */
 function buildDecisionNotes(
     escalations?: AiReviewDecisionEscalation[],
     reason?: string | null,
     showAuthor: boolean = true,
     resourceMemberIdMapping: Record<string, BackendResource> = {},
+    submissionLocked: boolean = false,
 ): string[] {
     const parts: string[] = []
 
@@ -163,7 +166,8 @@ function buildDecisionNotes(
     })
 
     if (reason) {
-        parts.push(`Unlock Reason: ${reason}`)
+        const reasonLabel: string = submissionLocked ? 'Locked Reason' : 'Unlock Reason'
+        parts.push(`${reasonLabel}: ${reason}`)
     }
 
     return parts
@@ -381,6 +385,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
             currentDecision.reason,
             canSeeAuthor,
             resourceMemberIdMapping,
+            currentDecision.submissionLocked,
         )
     }, [canSeeAuthor, currentDecision, hasSubmitterRole, resourceMemberIdMapping])
 

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -138,7 +138,7 @@ function resolveHandle(
 function buildDecisionNotes(
     escalations?: AiReviewDecisionEscalation[],
     reason?: string | null,
-    showAuthor = true,
+    showAuthor: boolean = true,
     resourceMemberIdMapping: Record<string, BackendResource> = {},
 ): string[] {
     const parts: string[] = []

--- a/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
+++ b/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
@@ -9,6 +9,7 @@ import {
     AiReviewDecision,
     AiReviewDecisionEscalation,
     AiReviewDecisionStatus,
+    BackendResource,
     BackendSubmission,
     ChallengeDetailContextModel,
 } from '../../models'
@@ -90,13 +91,53 @@ function buildNotesTooltip(
     return parts.length ? parts.join('\n') : undefined
 }
 
+interface ScoreBadgeProps {
+    score: number
+    normalizedStatus: ReturnType<typeof normalizeDecisionStatus>
+    aiReviewConfig: ChallengeDetailContextModel['aiReviewConfig']
+}
+
+const ScoreBadge: FC<ScoreBadgeProps> = props => (
+    <span className={classNames(
+        styles.score,
+        props.normalizedStatus === 'passed' && styles.scorePassed,
+        (props.normalizedStatus === 'failed' || props.normalizedStatus === 'failed-score') && styles.scoreFailed,
+    )}
+    >
+        <Tooltip
+            content={<AiScoreFormulaTooltip aiReviewConfig={props.aiReviewConfig} />}
+            triggerOn='hover'
+        >
+            <span className={styles.infoIcon}>
+                <IconOutline.InformationCircleIcon className='icon-lg' />
+            </span>
+        </Tooltip>
+        {formatScore(props.score)}
+    </span>
+)
+
 const CollapsibleAiReviewsRow: FC<CollapsibleAiReviewsRowProps> = props => {
     const challengeDetailContext: ChallengeDetailContextModel = useContext(ChallengeDetailContext)
     const aiReviewConfig: ChallengeDetailContextModel['aiReviewConfig'] = challengeDetailContext.aiReviewConfig
     const aiReviewDecisionsBySubmissionId: ChallengeDetailContextModel['aiReviewDecisionsBySubmissionId']
         = challengeDetailContext.aiReviewDecisionsBySubmissionId
+    const resourceMemberIdMapping: ChallengeDetailContextModel['resourceMemberIdMapping']
+        = challengeDetailContext.resourceMemberIdMapping
 
-    const { hasSubmitterRole }: UseRolePermissionsResult = useRolePermissions()
+    const rolePermissions: UseRolePermissionsResult = useRolePermissions()
+    const {
+        hasSubmitterRole,
+        isAdmin,
+        hasCopilotRole,
+        isProjectManager,
+    }: UseRolePermissionsResult = rolePermissions
+
+    /**
+     * Only Copilot, Project Manager, and Admin can see WHO performed the action.
+     * Reviewers can see the note TEXT but NOT the author "(by handle)".
+     * Submitters cannot see notes at all.
+     */
+    const canSeeAuthor = isAdmin || hasCopilotRole || isProjectManager
 
     const aiReviewersCount = useMemo(() => {
         const reviewersCount = props.aiReviewers.length || aiReviewConfig?.workflows?.length || 0
@@ -108,6 +149,7 @@ const CollapsibleAiReviewsRow: FC<CollapsibleAiReviewsRowProps> = props => {
         [aiReviewDecisionsBySubmissionId, props.submission.id],
     )
 
+    // Extracted into its own memo to reduce the complexity count of the component arrow function
     const normalizedStatus = useMemo(
         () => normalizeDecisionStatus(currentDecision?.status),
         [currentDecision?.status],
@@ -179,32 +221,20 @@ const CollapsibleAiReviewsRow: FC<CollapsibleAiReviewsRowProps> = props => {
                 </span>
                 <div className={styles.statusContainer}>
                     {hasScore && (
-                        <span className={classNames(
-                            styles.score,
-                            normalizedStatus === 'passed' && styles.scorePassed,
-                            (
-                                normalizedStatus === 'failed' || normalizedStatus === 'failed-score'
-                            ) && styles.scoreFailed,
-                        )}
-                        >
-                            <Tooltip
-                                content={<AiScoreFormulaTooltip aiReviewConfig={aiReviewConfig} />}
-                                triggerOn='hover'
-                            >
-                                <span className={styles.infoIcon}>
-                                    <IconOutline.InformationCircleIcon className='icon-lg' />
-                                </span>
-                            </Tooltip>
-                            {formatScore(currentDecision!.totalScore)}
-                        </span>
+                        <ScoreBadge
+                            score={currentDecision!.totalScore!}
+                            normalizedStatus={normalizedStatus}
+                            aiReviewConfig={aiReviewConfig}
+                        />
                     )}
                     {currentDecision && (
                         <div className={styles.runStatus}>
                             <AiWorkflowRunStatus status={normalizedStatus} showScore={false} />
                             {/*
-                             * Notes icon: shown only to Copilot/Manager/Admin (not submitters)
-                             * when there are escalation notes, approval/rejection notes,
-                             * or an unlock reason to display.
+                             * Notes icon: visible to Reviewers, Copilot, PM, Admin.
+                             * Hidden from Submitters entirely.
+                             * Reviewers see note text only (no author handle).
+                             * Copilot / PM / Admin see note text with "(by handle)".
                              */}
                             {notesTooltip && (
                                 <Tooltip

--- a/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
+++ b/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
@@ -54,31 +54,48 @@ export function normalizeDecisionStatus(
 }
 
 /**
- * Builds a multi-line tooltip string from escalation notes and approver notes.
+ * Resolves a memberId to a display handle using the resourceMemberIdMapping.
+ * Falls back to the raw id string if no match is found.
+ */
+function resolveHandle(
+    memberId: string | null | undefined,
+    resourceMemberIdMapping: Record<string, BackendResource>,
+): string {
+    if (!memberId) return ''
+    return resourceMemberIdMapping[memberId]?.memberHandle ?? memberId
+}
+
+/**
+ * Builds a multi-line tooltip string from escalation notes, approver notes,
+ * and the unlock reason.
+ *
+ * @param escalations            - List of escalation objects from the AI review decision
+ * @param reason                 - The unlock reason string from the decision
+ * @param showAuthor             - When true, appends "(by <handle>)" to each note.
+ *                                 Pass false for reviewer role so author identity is hidden.
+ *                                 Defaults to true.
+ * @param resourceMemberIdMapping - Map of memberId → BackendResource used to resolve handles.
+ *
  * Returns undefined if there are no notes at all.
- * Used to show Copilot/Manager/Admin why a submission was escalated or
- * approved/rejected.
  */
 function buildNotesTooltip(
     escalations?: AiReviewDecisionEscalation[],
-    resourceMemberIdMapping?: Record<string, any>,
+    reason?: string | null,
+    showAuthor = true,
+    resourceMemberIdMapping: Record<string, BackendResource> = {},
 ): string | undefined {
     const parts: string[] = []
 
-    const getMemberHandle = (memberId?: string | null): string => {
-        if (!memberId || !resourceMemberIdMapping) return ''
-        const resource = resourceMemberIdMapping[memberId]
-        return resource?.memberHandle || ''
-    }
-
     escalations?.forEach(esc => {
         if (esc.escalationNotes) {
-            const by = esc.createdBy ? ` (by ${getMemberHandle(esc.createdBy)})` : ''
+            const handle = resolveHandle(esc.createdBy, resourceMemberIdMapping)
+            const by = showAuthor && handle ? ` (by ${handle})` : ''
             parts.push(`Escalation Note${by}: ${esc.escalationNotes}`)
         }
 
         if (esc.approverNotes) {
-            const by = esc.updatedBy ? ` (by ${getMemberHandle(esc.updatedBy)})` : ''
+            const handle = resolveHandle(esc.updatedBy, resourceMemberIdMapping)
+            const by = showAuthor && handle ? ` (by ${handle})` : ''
             const prefix = esc.status === 'APPROVED'
                 ? 'Approval Note'
                 : esc.status === 'REJECTED'
@@ -87,6 +104,10 @@ function buildNotesTooltip(
             parts.push(`${prefix}${by}: ${esc.approverNotes}`)
         }
     })
+
+    if (reason) {
+        parts.push(`Unlock Reason: ${reason}`)
+    }
 
     return parts.length ? parts.join('\n') : undefined
 }
@@ -155,18 +176,23 @@ const CollapsibleAiReviewsRow: FC<CollapsibleAiReviewsRowProps> = props => {
         [currentDecision?.status],
     )
 
-    const resourceMemberIdMapping = challengeDetailContext.resourceMemberIdMapping
-
     /**
      * Builds the tooltip text for the notes icon shown next to the status label.
-     * Only shown to Copilot/Manager/Admin (not submitters).
-     * Covers: escalation notes and approval/rejection notes.
+     *
+     * - Submitters              → undefined (icon not shown at all)
+     * - Reviewers               → note text only, NO "(by handle)"  (canSeeAuthor = false)
+     * - Copilot / PM / Admin    → note text WITH "(by handle)"       (canSeeAuthor = true)
      */
     const notesTooltip = useMemo((): string | undefined => {
         if (hasSubmitterRole || !currentDecision) return undefined
 
-        return buildNotesTooltip(currentDecision.escalations, resourceMemberIdMapping)
-    }, [currentDecision, hasSubmitterRole, resourceMemberIdMapping])
+        return buildNotesTooltip(
+            currentDecision.escalations,
+            currentDecision.reason,
+            canSeeAuthor,
+            resourceMemberIdMapping,
+        )
+    }, [canSeeAuthor, currentDecision, hasSubmitterRole, resourceMemberIdMapping])
 
     const [isOpen, setIsOpen] = useState(props.defaultOpen ?? false)
     const [portalContainer, setPortalContainer] = useState<HTMLTableCellElement | undefined>(undefined)

--- a/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
+++ b/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
@@ -81,7 +81,7 @@ function resolveHandle(
 function buildNotesTooltip(
     escalations?: AiReviewDecisionEscalation[],
     reason?: string | null,
-    showAuthor = true,
+    showAuthor: boolean = true,
     resourceMemberIdMapping: Record<string, BackendResource> = {},
 ): string | undefined {
     const parts: string[] = []

--- a/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
+++ b/src/apps/review/src/lib/components/CollapsibleAiReviewsRow/CollapsibleAiReviewsRow.tsx
@@ -67,14 +67,16 @@ function resolveHandle(
 
 /**
  * Builds a multi-line tooltip string from escalation notes, approver notes,
- * and the unlock reason.
+ * and the lock/unlock reason.
  *
  * @param escalations            - List of escalation objects from the AI review decision
- * @param reason                 - The unlock reason string from the decision
+ * @param reason                 - The reason string from the decision
  * @param showAuthor             - When true, appends "(by <handle>)" to each note.
  *                                 Pass false for reviewer role so author identity is hidden.
  *                                 Defaults to true.
  * @param resourceMemberIdMapping - Map of memberId → BackendResource used to resolve handles.
+ * @param submissionLocked       - When true, labels the reason as "Locked Reason";
+ *                                 otherwise labels it as "Unlock Reason".
  *
  * Returns undefined if there are no notes at all.
  */
@@ -83,6 +85,7 @@ function buildNotesTooltip(
     reason?: string | null,
     showAuthor: boolean = true,
     resourceMemberIdMapping: Record<string, BackendResource> = {},
+    submissionLocked: boolean = false,
 ): string | undefined {
     const parts: string[] = []
 
@@ -106,7 +109,8 @@ function buildNotesTooltip(
     })
 
     if (reason) {
-        parts.push(`Unlock Reason: ${reason}`)
+        const reasonLabel: string = submissionLocked ? 'Locked Reason' : 'Unlock Reason'
+        parts.push(`${reasonLabel}: ${reason}`)
     }
 
     return parts.length ? parts.join('\n') : undefined
@@ -191,6 +195,7 @@ const CollapsibleAiReviewsRow: FC<CollapsibleAiReviewsRowProps> = props => {
             currentDecision.reason,
             canSeeAuthor,
             resourceMemberIdMapping,
+            currentDecision.submissionLocked,
         )
     }, [canSeeAuthor, currentDecision, hasSubmitterRole, resourceMemberIdMapping])
 


### PR DESCRIPTION
What was broken
The compact profile card rendered memberStats.maxRating.rating, which is the historical max rating. For users whose newest rated track had moved below an older max, the card did not match the latest rating shown in the track stats.

Root cause (if identifiable)
The card read the stats API maxRating summary directly instead of deriving the display value from rated track entries.

What was changed
Added a helper that selects the rated track/subtrack with the newest mostRecentEventDate across Development, Design, and Data Science stats, falling back to maxRating only when no rated track entry exists. The card now renders that latest profile rating.

Any added/updated tests
Added unit tests for latest-track selection, configured Data Science rating paths, and maxRating fallback.
