### PR TITLE
PM-5282: Preserve schedule phase ids on update

### DIFF
--- a/src/apps/work/src/lib/services/challenges.service.spec.ts
+++ b/src/apps/work/src/lib/services/challenges.service.spec.ts
@@ -177,6 +177,7 @@ describe('patchChallenge', () => {
         await patchChallenge('challenge-1', {
             phases: [{
                 duration: 1440,
+                id: 'challenge-phase-1',
                 phaseId: 'submission-phase',
                 scheduledEndDate: '2026-04-15T15:05:00.000Z',
                 scheduledStartDate: '2026-04-09T15:05:00.000Z',
@@ -189,6 +190,7 @@ describe('patchChallenge', () => {
                 expect.objectContaining({
                     phases: [{
                         duration: 86400,
+                        id: 'challenge-phase-1',
                         phaseId: 'submission-phase',
                         scheduledEndDate: '2026-04-15T15:05:00.000Z',
                         scheduledStartDate: '2026-04-09T15:05:00.000Z',

--- a/src/apps/work/src/lib/services/challenges.service.ts
+++ b/src/apps/work/src/lib/services/challenges.service.ts
@@ -219,6 +219,7 @@ function serializeChallengePhases(phases: unknown): ChallengePhase[] | undefined
 
             return {
                 duration: serializePhaseDurationToSeconds(typedPhase.duration),
+                id: typedPhase.id,
                 phaseId: typedPhase.phaseId,
                 predecessor: typedPhase.predecessor,
                 scheduledEndDate: asIsoDateString(typedPhase.scheduledEndDate),

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
@@ -251,6 +251,7 @@ describe('challenge-editor utils schedule mapping', () => {
             name: 'Scheduled challenge',
             phases: [{
                 duration: 1440,
+                id: 'challenge-phase-1',
                 phaseId: 'submission-phase',
                 scheduledEndDate: '2026-04-15T15:05:00.000Z',
                 scheduledStartDate: '2026-04-09T15:05:00.000Z',
@@ -266,6 +267,7 @@ describe('challenge-editor utils schedule mapping', () => {
         expect(result.phases)
             .toEqual([{
                 duration: 1440,
+                id: 'challenge-phase-1',
                 phaseId: 'submission-phase',
                 scheduledEndDate: '2026-04-15T15:05:00.000Z',
                 scheduledStartDate: '2026-04-09T15:05:00.000Z',

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.ts
@@ -895,6 +895,7 @@ function serializePhasesForApi(phases: unknown): ChallengePhase[] | undefined {
 
             return {
                 duration: normalizePhaseDurationMinutes(typedPhase.duration),
+                id: typedPhase.id,
                 phaseId: typedPhase.phaseId,
                 predecessor: typedPhase.predecessor,
                 scheduledEndDate: toIsoDateString(typedPhase.scheduledEndDate),


### PR DESCRIPTION
What was broken
Design two-round schedule edits recalculated in the editor, but saving the challenge could send phase updates without the persisted challenge phase ids. The saved challenge then returned with the default two-round timeline instead of the edited schedule.

Root cause
The work app converted schedule phases through two serializers before PATCHing the challenge. Both serializers kept the phase definition id but dropped the persisted challenge phase id that the backend can use to update the exact existing phase rows.

What was changed
Preserved challenge phase ids when converting form phases to the challenge payload and when serializing phases for the challenge PATCH request.

Any added/updated tests
Updated schedule serialization tests to verify phase ids are retained while existing duration and scheduled date behavior is preserved.
