### PR TITLE
PM-5243: Add reviewer with next valid default phase

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
@@ -772,6 +772,90 @@ describe('HumanReviewTab', () => {
         })
     })
 
+    it('adds the next selectable default reviewer phase for one-round design challenges', async () => {
+        mockedFetchDefaultReviewers.mockResolvedValue([
+            {
+                isMemberReview: true,
+                memberReviewerCount: 1,
+                phaseId: 'checkpoint-review',
+                scorecardId: 'checkpoint-review-scorecard',
+                shouldOpenOpportunity: true,
+            },
+            {
+                isMemberReview: true,
+                memberReviewerCount: 1,
+                phaseId: 'screening',
+                scorecardId: 'screening-scorecard',
+                shouldOpenOpportunity: true,
+            },
+            {
+                isMemberReview: true,
+                memberReviewerCount: 1,
+                phaseId: 'review',
+                scorecardId: 'review-scorecard',
+                shouldOpenOpportunity: false,
+            },
+        ])
+        mockedFetchScorecards.mockResolvedValue([
+            {
+                id: 'screening-scorecard',
+                name: 'Screening scorecard',
+                phaseId: 'screening',
+            },
+            {
+                id: 'review-scorecard',
+                name: 'Review scorecard',
+                phaseId: 'review',
+            },
+        ])
+
+        render(
+            <TestHarness
+                defaultValues={{
+                    phases: [
+                        {
+                            id: 'screening',
+                            name: 'Screening',
+                            phaseId: 'screening',
+                        },
+                        {
+                            id: 'review',
+                            name: 'Review',
+                            phaseId: 'review',
+                        },
+                    ],
+                    reviewers: [
+                        {
+                            additionalMemberIds: [],
+                            isMemberReview: true,
+                            memberReviewerCount: 1,
+                            phaseId: 'screening',
+                            roleId: 'role-1',
+                            scorecardId: 'screening-scorecard',
+                            shouldOpenOpportunity: true,
+                        },
+                    ],
+                }}
+            />,
+        )
+
+        await waitFor(() => {
+            expect((screen.getByRole('button', { name: 'Add reviewer' }) as HTMLButtonElement).disabled)
+                .toBe(false)
+        })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add reviewer' }))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('reviewers.1.phaseId')
+                .getAttribute('data-value'))
+                .toBe('review')
+        })
+        expect(screen.getByTestId('reviewers.1.scorecardId')
+            .getAttribute('data-value'))
+            .toBe('review-scorecard')
+    })
+
     it('caps assignment fields when closed-opportunity reviewer count is too large', async () => {
         render(<TestHarness />)
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
@@ -614,6 +614,53 @@ function mapDefaultReviewerToReviewer(
     }
 }
 
+/**
+ * Selects the default reviewer metadata used when adding the next manual
+ * reviewer card.
+ *
+ * @param params.defaultReviewers default reviewer rows for the selected challenge type and track.
+ * @param params.phases current challenge phases used to resolve legacy defaults without a phase id.
+ * @param params.phaseNameById current challenge phase names keyed by phase id.
+ * @param params.reviewers existing manual reviewer rows already shown in the human review tab.
+ * @param params.allowAppealPhases whether appeal phases are valid manual reviewer phases.
+ * @returns the first member-review default for a selectable phase, or `undefined` to use fallback defaults.
+ * @remarks Used by `HumanReviewTab` so environment-specific default-reviewer rows for unrelated phases are skipped.
+ * @throws Does not throw.
+ */
+function getNextDefaultReviewer(params: {
+    allowAppealPhases: boolean
+    defaultReviewers: DefaultReviewer[]
+    phaseNameById: Map<string, string>
+    phases: ChallengeEditorFormData['phases']
+    reviewers: Reviewer[]
+}): DefaultReviewer | undefined {
+    const memberDefaultReviewers = params.defaultReviewers.filter(reviewer => isMemberReviewer(reviewer))
+    const assignedPhaseIds = new Set(
+        params.reviewers
+            .map(reviewer => normalizeText(reviewer.phaseId))
+            .filter(Boolean),
+    )
+    const getSelectableDefaultPhaseId = (defaultReviewer: DefaultReviewer): string => {
+        const defaultPhaseId = normalizeText(getReviewerPhaseId(defaultReviewer, params.phases))
+        const defaultPhaseName = params.phaseNameById.get(defaultPhaseId)
+
+        return defaultPhaseId
+            && defaultPhaseName
+            && isSelectableReviewerPhaseName(defaultPhaseName, params.allowAppealPhases)
+            ? defaultPhaseId
+            : ''
+    }
+
+    const unassignedDefaultReviewer = memberDefaultReviewers.find(defaultReviewer => {
+        const defaultPhaseId = getSelectableDefaultPhaseId(defaultReviewer)
+
+        return defaultPhaseId && !assignedPhaseIds.has(defaultPhaseId)
+    })
+
+    return unassignedDefaultReviewer
+        || memberDefaultReviewers.find(defaultReviewer => !!getSelectableDefaultPhaseId(defaultReviewer))
+}
+
 function getSelectValue(selected: unknown): string {
     if (!selected || typeof selected !== 'object') {
         return ''
@@ -1660,7 +1707,13 @@ export const HumanReviewTab: FC = () => {
     )
 
     const addReviewer = useCallback((): void => {
-        const defaultReviewer = defaultReviewers.find(reviewer => isMemberReviewer(reviewer))
+        const defaultReviewer = getNextDefaultReviewer({
+            allowAppealPhases,
+            defaultReviewers,
+            phaseNameById,
+            phases,
+            reviewers: reviewerRows,
+        })
         const reviewerFromDefaults = mapDefaultReviewerToReviewer(
             defaultReviewer,
             phases,
@@ -1677,10 +1730,13 @@ export const HumanReviewTab: FC = () => {
             shouldValidate: true,
         })
     }, [
+        allowAppealPhases,
         defaultReviewers,
         allReviewerRows,
         formContext,
+        phaseNameById,
         phases,
+        reviewerRows,
         resolveRoleIdForPhase,
     ])
 


### PR DESCRIPTION
What was broken
Add Reviewer could use the first default reviewer row even when that row belonged to a phase that was not present in the current one-round Design challenge.

Root cause
Dev default reviewer metadata includes checkpoint phase defaults ahead of the single-round review defaults. The UI did not filter defaults against the active challenge phases or existing human reviewer rows before appending a new reviewer card.

What was changed
The human review tab now selects the next member-reviewer default whose phase is selectable for the current challenge, preferring unassigned phases and falling back only to selectable defaults.

Any added/updated tests
Added a HumanReviewTab regression test that reproduces the one-round Design ordering and verifies Add Reviewer selects the Review phase and scorecard instead of an unrelated checkpoint default.

Validation run:
- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx: passed.
- yarn lint: passed.
- yarn run build: passed with existing CSS order and unrelated lint-warning output from the build tool.
- yarn test:no-watch --silent: failed in unrelated existing suites, including payment/engagement utility mock exports, wallet-admin module alias resolution, and ChallengePrizesField continuous typing expectation.
