### PR TITLE
PM-5256: Fix challenge points typography

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
@@ -22,8 +22,8 @@
     background: linear-gradient(90deg, #008A72, #005B86);
     color: $tc-white;
     font-family: $font-roboto;
-    font-size: 18px;
-    line-height: 24px;
+    font-size: 16px;
+    line-height: 22px;
 
     @include ltesm {
         flex-wrap: wrap;
@@ -33,14 +33,14 @@
 }
 
 .challengePointsLabel {
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-normal;
 }
 
 .challengePointsValue {
     font-family: $font-barlow-condensed;
-    font-size: 32px;
+    font-size: 26px;
     font-weight: $font-weight-medium;
-    line-height: 34px;
+    line-height: 28px;
 }
 
 .challengePointsMeta {


### PR DESCRIPTION
What was broken
The Challenge Points profile bar rendered the label at 18px in bold and the points total at 32px, which did not match the required typography.

Root cause (if identifiable)
The earlier Challenge Points implementation inherited oversized bar text and explicitly set the label to bold and the numeric value to 32px.

What was changed
Updated the Challenge Points bar stylesheet so the label renders at 16px with normal weight and the points total renders at 26px.

Any added/updated tests
No tests were added because this is a CSS-only typography adjustment. Existing profile specs were run for the surrounding profile area.

Validation
- yarn test:no-watch --runInBand src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx src/apps/profiles/src/components/tc-achievements/StatsSummaryBlock/StatsSummaryBlock.spec.tsx src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx: passed.
- yarn lint: passed.
- yarn run build: passed with existing warnings.
- yarn test:no-watch --runInBand: failed in unrelated existing work, wallet-admin, and engagements suites; failures include unresolved ~/ imports and assignment/payment test expectations outside the changed profile stylesheet.
