### PR TITLE
PM-5274: Enlarge challenge points breakdown arrow

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import type { PropsWithChildren } from 'react'
+import { render, screen, within } from '@testing-library/react'
+
+import type { UserProfile } from '~/libs/core'
+
+import { MemberChallengePointsBar } from './MemberStatsBlock'
+
+jest.mock('~/libs/core', () => ({
+    getRatingColor: jest.fn(() => '#000000'),
+    useMemberStats: jest.fn(),
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/ui', () => ({
+    BaseModal: (props: PropsWithChildren): JSX.Element => <div>{props.children}</div>,
+    IconOutline: {
+        ChevronRightIcon: (props: { className?: string }): JSX.Element => (
+            <svg
+                className={props.className}
+                data-testid='breakdown-chevron'
+            />
+        ),
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('../../../member-profile/MemberProfile.context', () => ({
+    useMemberProfileContext: jest.fn(() => ({
+        statsRoute: jest.fn(),
+    })),
+}))
+
+jest.mock('./MemberChallengePointsModal', () => jest.fn(() => ''))
+
+jest.mock('../../../lib', () => ({
+    formatPlural: (count: number, label: string): string => `${label}${count === 1 ? '' : 's'}`,
+    WinnerIcon: (props: { className?: string }): JSX.Element => <svg className={props.className} />,
+}))
+
+describe('MemberChallengePointsBar', () => {
+    it('renders the breakdown chevron with the larger icon size', () => {
+        render(
+            <MemberChallengePointsBar
+                profile={{
+                    challengePoints: {
+                        challenges: 5,
+                        details: [{
+                            challengeId: 'challenge-1',
+                            challengeName: 'AI Challenge',
+                            placement: 1,
+                            points: 2325,
+                            userId: 123,
+                        }],
+                        total: 2325,
+                    },
+                    handle: 'tester',
+                } as UserProfile}
+            />,
+        )
+
+        const breakdownButton = screen.getByRole('button', {
+            name: /view breakdown/i,
+        })
+        const chevron = within(breakdownButton)
+            .getByTestId('breakdown-chevron')
+
+        expect(chevron)
+            .toHaveClass('icon-lg')
+        expect(chevron)
+            .not
+            .toHaveClass('icon-sm')
+    })
+})

--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.tsx
@@ -148,7 +148,7 @@ const ChallengePointsBar: FC<ChallengePointsBarProps> = props => (
                 type='button'
             >
                 View breakdown
-                <IconOutline.ChevronRightIcon className='icon-sm' />
+                <IconOutline.ChevronRightIcon className='icon-lg' />
             </button>
         )}
     </div>


### PR DESCRIPTION
What was broken
The challenge points banner rendered the "View breakdown" chevron too small compared with the adjacent label and profile stats arrows.

Root cause
The breakdown trigger used the shared `icon-sm` class, which renders an 8px icon. The affected banner is currently on the existing PM-5256 profile challenge-points stack, so this branch is stacked on that work while targeting `dev` as requested.

What was changed
Changed the breakdown chevron to use `icon-lg` so it renders at the larger profile action size.

Any added/updated tests
Added a MemberChallengePointsBar regression test that renders a breakdown-capable points bar and asserts the chevron uses `icon-lg` instead of `icon-sm`.

Validation run
`yarn lint` passed.
`yarn test:no-watch --runTestsByPath src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx` passed.
`yarn run build` passed with existing warnings.
`yarn test:no-watch` was run and failed in unrelated work and wallet-admin suites already outside this ticket scope.
