### PR TITLE
PM-5231: Add scorer validation upload UI

### DIFF
--- a/src/apps/work/src/lib/models/MarathonMatch.model.ts
+++ b/src/apps/work/src/lib/models/MarathonMatch.model.ts
@@ -156,6 +156,28 @@ export interface MarathonMatchRerunResponse {
 }
 
 /**
+ * Payload used to upload one Marathon Match validation submission.
+ * Used by the scorer section to queue a pre-launch ECS scoring run.
+ */
+export interface MarathonMatchTestSubmissionInput {
+    configType: MarathonMatchConfigType
+    file: File
+}
+
+/**
+ * Response returned after uploading one Marathon Match validation submission.
+ * Used by the scorer section to show the created submission and queued ECS task.
+ */
+export interface MarathonMatchTestSubmissionResponse {
+    challengeId: string
+    cloudWatchLogsConsoleUrl?: string
+    configType: MarathonMatchConfigType
+    submissionId: string
+    taskArn: string
+    taskId: string
+}
+
+/**
  * Payload for creating a new marathon match scorer configuration.
  * Used by POST /challenge/:challengeId requests.
  */

--- a/src/apps/work/src/lib/services/marathon-match.service.spec.ts
+++ b/src/apps/work/src/lib/services/marathon-match.service.spec.ts
@@ -1,0 +1,95 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { xhrPostAsync } from '~/libs/core'
+
+import { uploadMarathonMatchTestSubmission } from './marathon-match.service'
+
+jest.mock('~/libs/core', () => ({
+    xhrGetAsync: jest.fn(),
+    xhrGetPaginatedAsync: jest.fn(),
+    xhrPostAsync: jest.fn(),
+    xhrPutAsync: jest.fn(),
+}), {
+    virtual: true,
+})
+jest.mock('../constants', () => ({
+    MARATHON_MATCH_API_URL: 'https://example.com/marathon-match',
+}))
+
+describe('marathon-match.service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('uploads validation submissions as multipart form data', async () => {
+        const mockedPostAsync = xhrPostAsync as jest.Mock
+        const file = new File(['zip'], 'solution.zip', {
+            type: 'application/zip',
+        })
+
+        mockedPostAsync.mockResolvedValue({
+            challengeId: '30000123',
+            cloudWatchLogsConsoleUrl: 'https://logs.example.com/task-1',
+            configType: 'PROVISIONAL',
+            submissionId: 'submission-1',
+            taskArn: 'arn:aws:ecs:task/task-1',
+            taskId: 'task-1',
+        })
+
+        await expect(
+            uploadMarathonMatchTestSubmission('30000123', {
+                configType: 'PROVISIONAL',
+                file,
+            }),
+        )
+            .resolves
+            .toEqual({
+                challengeId: '30000123',
+                cloudWatchLogsConsoleUrl: 'https://logs.example.com/task-1',
+                configType: 'PROVISIONAL',
+                submissionId: 'submission-1',
+                taskArn: 'arn:aws:ecs:task/task-1',
+                taskId: 'task-1',
+            })
+
+        expect(mockedPostAsync)
+            .toHaveBeenCalledWith(
+                'https://example.com/marathon-match/challenge/30000123/test-submission',
+                expect.any(FormData),
+                {
+                    headers: {
+                        'Content-Type': 'multipart/form-data',
+                    },
+                },
+            )
+
+        const formData = mockedPostAsync.mock.calls[0][1] as FormData
+        const uploadedFile = formData.get('file') as File
+
+        expect(formData.get('configType'))
+            .toBe('PROVISIONAL')
+        expect(formData.get('fileName'))
+            .toBe('solution.zip')
+        expect(uploadedFile.name)
+            .toBe('solution.zip')
+    })
+
+    it('rejects malformed validation submission responses', async () => {
+        const mockedPostAsync = xhrPostAsync as jest.Mock
+        const file = new File(['zip'], 'solution.zip', {
+            type: 'application/zip',
+        })
+
+        mockedPostAsync.mockResolvedValue({
+            challengeId: '30000123',
+        })
+
+        await expect(
+            uploadMarathonMatchTestSubmission('30000123', {
+                configType: 'PROVISIONAL',
+                file,
+            }),
+        )
+            .rejects
+            .toThrow('Marathon match validation upload response was invalid')
+    })
+})

--- a/src/apps/work/src/lib/services/marathon-match.service.ts
+++ b/src/apps/work/src/lib/services/marathon-match.service.ts
@@ -22,6 +22,8 @@ import {
     MarathonMatchScoreDirection,
     MarathonMatchTester,
     MarathonMatchTesterSummary,
+    MarathonMatchTestSubmissionInput,
+    MarathonMatchTestSubmissionResponse,
     UpdateMarathonMatchConfigInput,
 } from '../models'
 
@@ -39,6 +41,8 @@ export interface FetchTestersParams {
     page?: number
     perPage?: number
 }
+
+type TestSubmissionResponseConfigType = MarathonMatchTestSubmissionResponse['configType']
 
 function normalizeText(value: unknown): string | undefined {
     if (value === undefined || value === null) {
@@ -468,6 +472,40 @@ function normalizeMarathonMatchRerunResponse(
 }
 
 /**
+ * Normalizes a raw validation submission upload response.
+ * @param response Raw response from POST /challenge/:challengeId/test-submission.
+ * @returns Normalized upload response when required fields are present; otherwise `undefined`.
+ * Used by `uploadMarathonMatchTestSubmission` before resolving the API call.
+ */
+function normalizeMarathonMatchTestSubmissionResponse(
+    response: unknown,
+): MarathonMatchTestSubmissionResponse | undefined {
+    if (typeof response !== 'object' || !response) {
+        return undefined
+    }
+
+    const typedResponse = response as Record<string, unknown>
+    const challengeId = normalizeText(typedResponse.challengeId)
+    const configType = normalizeText(typedResponse.configType) as TestSubmissionResponseConfigType | undefined
+    const submissionId = normalizeText(typedResponse.submissionId)
+    const taskArn = normalizeText(typedResponse.taskArn)
+    const taskId = normalizeText(typedResponse.taskId)
+
+    if (!challengeId || !configType || !submissionId || !taskArn || !taskId) {
+        return undefined
+    }
+
+    return {
+        challengeId,
+        cloudWatchLogsConsoleUrl: normalizeText(typedResponse.cloudWatchLogsConsoleUrl),
+        configType,
+        submissionId,
+        taskArn,
+        taskId,
+    }
+}
+
+/**
  * Extracts tester-list pagination metadata from the response payload.
  * Used by `fetchTesters` to keep paging resilient when header metadata is absent.
  */
@@ -660,6 +698,46 @@ export async function rerunMarathonMatchScores(
         return normalizedResponse
     } catch (error) {
         throw normalizeError(error, 'Failed to rerun marathon match scores')
+    }
+}
+
+/**
+ * Uploads a test submission and queues scorer validation for a marathon match challenge.
+ * @param challengeId Challenge identifier used in the validation upload route path.
+ * @param input File and phase configuration type to score.
+ * @returns Created validation submission id and queued ECS task details.
+ * @throws Error When the API request fails or returns an invalid validation upload response.
+ * Used by `MarathonMatchScorerSection` before challenge launch.
+ */
+export async function uploadMarathonMatchTestSubmission(
+    challengeId: string,
+    input: MarathonMatchTestSubmissionInput,
+): Promise<MarathonMatchTestSubmissionResponse> {
+    const formData = new FormData()
+
+    formData.append('configType', input.configType)
+    formData.append('fileName', input.file.name)
+    formData.append('file', input.file, input.file.name)
+
+    try {
+        const response = await xhrPostAsync<FormData, unknown>(
+            `${MARATHON_MATCH_API_URL}/challenge/${encodeURIComponent(challengeId.trim())}/test-submission`,
+            formData,
+            {
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                },
+            },
+        )
+        const normalizedResponse = normalizeMarathonMatchTestSubmissionResponse(response)
+
+        if (!normalizedResponse) {
+            throw new Error('Marathon match validation upload response was invalid')
+        }
+
+        return normalizedResponse
+    } catch (error) {
+        throw normalizeError(error, 'Failed to upload marathon match validation submission')
     }
 }
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.module.scss
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.module.scss
@@ -169,6 +169,12 @@
     padding: 10px 12px;
 }
 
+.fieldGroup input:disabled {
+    background: $black-5;
+    color: $black-40;
+    cursor: not-allowed;
+}
+
 .selectInput {
     appearance: none;
     -webkit-appearance: none;
@@ -268,6 +274,45 @@
     font-size: 14px;
     line-height: 1.5;
     margin: 4px 0 0;
+}
+
+.operationPanel {
+    display: flex;
+    flex: 1 1 520px;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 280px;
+}
+
+.testSubmissionGrid {
+    align-items: flex-end;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: minmax(150px, 180px) minmax(220px, 1fr) auto;
+}
+
+.operationButton,
+.rerunButtonRow {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.testSubmissionResult {
+    align-items: center;
+    background: #eef7f3;
+    border: 1px solid #b5d8c7;
+    border-radius: 8px;
+    color: #137d60;
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 13px;
+    gap: 10px;
+    padding: 10px 12px;
+}
+
+.testSubmissionResult a {
+    color: $link-blue-dark;
+    font-weight: 600;
 }
 
 .validationCard {
@@ -408,5 +453,14 @@
     .footerActions,
     .modalActions {
         justify-content: stretch;
+    }
+
+    .testSubmissionGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .operationButton,
+    .rerunButtonRow {
+        justify-content: flex-start;
     }
 }

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.tsx
@@ -15,10 +15,12 @@ import {
     ChallengePhase,
     CreateMarathonMatchConfigInput,
     MarathonMatchConfig,
+    MarathonMatchConfigType,
     MarathonMatchDefaults,
     MarathonMatchPhaseConfig,
     MarathonMatchTester,
     MarathonMatchTesterSummary,
+    MarathonMatchTestSubmissionResponse,
     UpdateMarathonMatchConfigInput,
 } from '../../../../../lib/models'
 import {
@@ -29,6 +31,7 @@ import {
     fetchTesters,
     rerunMarathonMatchScores,
     updateMarathonMatchConfig,
+    uploadMarathonMatchTestSubmission,
 } from '../../../../../lib/services'
 import {
     showErrorToast,
@@ -109,6 +112,11 @@ interface TesterGroup {
 interface PhaseOption {
     label: string
     value: string
+}
+
+interface TestSubmissionPhaseOption {
+    label: string
+    value: MarathonMatchConfigType
 }
 
 interface PhaseConfigCardProps {
@@ -657,6 +665,41 @@ function buildSaveInput(
     }
 }
 
+/**
+ * Builds test-submission phase choices from saved scorer phase configs.
+ * Used by `MarathonMatchScorerSection` so validation upload only targets runnable saved phases.
+ */
+function getTestSubmissionPhaseOptions(
+    config: MarathonMatchConfig | undefined,
+): TestSubmissionPhaseOption[] {
+    if (!config) {
+        return []
+    }
+
+    return [
+        {
+            label: PHASE_LABELS.example,
+            phaseConfig: config.example,
+            value: PHASE_CONFIG_TYPES.example,
+        },
+        {
+            label: PHASE_LABELS.provisional,
+            phaseConfig: config.provisional,
+            value: PHASE_CONFIG_TYPES.provisional,
+        },
+        {
+            label: PHASE_LABELS.system,
+            phaseConfig: config.system,
+            value: PHASE_CONFIG_TYPES.system,
+        },
+    ]
+        .filter(item => !!item.phaseConfig)
+        .map(item => ({
+            label: item.label,
+            value: item.value as MarathonMatchConfigType,
+        }))
+}
+
 function getPhaseInputKeys(
     phaseKey: PhaseDraftKey,
 ): {
@@ -713,10 +756,15 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
     const [isLoading, setIsLoading] = useState<boolean>(true)
     const [isSaving, setIsSaving] = useState<boolean>(false)
     const [isRerunning, setIsRerunning] = useState<boolean>(false)
+    const [isUploadingTestSubmission, setIsUploadingTestSubmission] = useState<boolean>(false)
     const [loadError, setLoadError] = useState<string | undefined>()
     const [saveError, setSaveError] = useState<string | undefined>()
     const [rerunError, setRerunError] = useState<string | undefined>()
+    const [testSubmissionError, setTestSubmissionError] = useState<string | undefined>()
     const [testerLoadError, setTesterLoadError] = useState<string | undefined>()
+    const [selectedTestSubmissionFile, setSelectedTestSubmissionFile] = useState<File | undefined>()
+    const [testSubmissionConfigType, setTestSubmissionConfigType] = useState<MarathonMatchConfigType>('PROVISIONAL')
+    const [testSubmissionResult, setTestSubmissionResult] = useState<MarathonMatchTestSubmissionResponse | undefined>()
     const [showNewTesterModal, setShowNewTesterModal] = useState<boolean>(false)
     const [showNewVersionModal, setShowNewVersionModal] = useState<boolean>(false)
     const [showCompilationErrorsModal, setShowCompilationErrorsModal] = useState<boolean>(false)
@@ -729,6 +777,10 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
             }))
             .filter(option => !!option.value),
         [phases],
+    )
+    const testSubmissionPhaseOptions = useMemo(
+        (): TestSubmissionPhaseOption[] => getTestSubmissionPhaseOptions(config),
+        [config],
     )
 
     const validationErrors = useMemo(
@@ -1053,6 +1105,8 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
                 setDraft(nextDraft)
                 setSavedSnapshot(nextDraft)
                 setNumericInputs(buildNumericInputState(nextDraft))
+                setTestSubmissionError(undefined)
+                setTestSubmissionResult(undefined)
 
                 if (savedConfig.testerId) {
                     await loadTesterById(savedConfig.testerId, {
@@ -1111,6 +1165,26 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
         [handleTesterSelectionChange],
     )
 
+    const handleTestSubmissionPhaseChange = useCallback(
+        (event: ChangeEvent<HTMLSelectElement>): void => {
+            setTestSubmissionConfigType(event.target.value as MarathonMatchConfigType)
+            setTestSubmissionError(undefined)
+            setTestSubmissionResult(undefined)
+        },
+        [],
+    )
+
+    const handleTestSubmissionFileChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>): void => {
+            const nextFile = event.target.files?.[0]
+
+            setSelectedTestSubmissionFile(nextFile)
+            setTestSubmissionError(undefined)
+            setTestSubmissionResult(undefined)
+        },
+        [],
+    )
+
     useEffect(() => {
         phaseListRef.current = phases
     }, [phases])
@@ -1127,6 +1201,9 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
         setLoadError(undefined)
         setSaveError(undefined)
         setRerunError(undefined)
+        setTestSubmissionError(undefined)
+        setTestSubmissionResult(undefined)
+        setSelectedTestSubmissionFile(undefined)
         setTesterLoadError(undefined)
         setSelectedTester(undefined)
 
@@ -1320,6 +1397,19 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
         selectedTester?.id,
     ])
 
+    useEffect(() => {
+        if (testSubmissionPhaseOptions.some(option => option.value === testSubmissionConfigType)) {
+            return
+        }
+
+        setTestSubmissionConfigType(
+            testSubmissionPhaseOptions[0]?.value || 'PROVISIONAL',
+        )
+    }, [
+        testSubmissionConfigType,
+        testSubmissionPhaseOptions,
+    ])
+
     const currentTesterId = draft?.testerId || ''
     const currentVersionTarget = selectedTester
     const currentVersionMax = currentVersionTarget?.name
@@ -1330,6 +1420,58 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
         && !hasUnsavedChanges
         && !hasBlockingError
         && !isRerunning
+    const canUploadTestSubmission = !!config
+        && !hasUnsavedChanges
+        && !hasBlockingError
+        && !isUploadingTestSubmission
+        && !!selectedTestSubmissionFile
+        && testSubmissionPhaseOptions.some(option => option.value === testSubmissionConfigType)
+
+    const handleUploadTestSubmission = useCallback(
+        async (): Promise<void> => {
+            if (!canUploadTestSubmission || !selectedTestSubmissionFile) {
+                return
+            }
+
+            setIsUploadingTestSubmission(true)
+            setTestSubmissionError(undefined)
+            setTestSubmissionResult(undefined)
+
+            try {
+                const uploadResponse = await uploadMarathonMatchTestSubmission(
+                    challengeId,
+                    {
+                        configType: testSubmissionConfigType,
+                        file: selectedTestSubmissionFile,
+                    },
+                )
+
+                setTestSubmissionResult(uploadResponse)
+                showSuccessToast('Validation submission queued for scoring')
+            } catch (error) {
+                const errorMessage = getErrorMessage(
+                    error,
+                    'Failed to upload marathon match validation submission',
+                )
+
+                setTestSubmissionError(errorMessage)
+                showErrorToast(errorMessage)
+            } finally {
+                setIsUploadingTestSubmission(false)
+            }
+        },
+        [
+            canUploadTestSubmission,
+            challengeId,
+            selectedTestSubmissionFile,
+            testSubmissionConfigType,
+        ],
+    )
+
+    const handleUploadTestSubmissionClick = useCallback((): void => {
+        handleUploadTestSubmission()
+            .catch(() => undefined)
+    }, [handleUploadTestSubmission])
 
     const handleRerunScores = useCallback(
         async (): Promise<void> => {
@@ -1495,6 +1637,10 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
                     ? <div className={styles.error}>{rerunError}</div>
                     : undefined}
 
+                {testSubmissionError
+                    ? <div className={styles.error}>{testSubmissionError}</div>
+                    : undefined}
+
                 {selectedTester
                     ? (
                         <div className={styles.summaryGrid}>
@@ -1526,17 +1672,102 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
                         <div className={styles.rerunActions}>
                             <div>
                                 <h4>Score Operations</h4>
-                                <p>Queue the latest submissions for scoring with the saved scorer config.</p>
+                                <p>Queue validation or latest submissions with the saved scorer config.</p>
                             </div>
-                            <Button
-                                disabled={!canRerunScores}
-                                label={isRerunning ? 'Rerunning...' : 'Rerun scores'}
-                                loading={isRerunning}
-                                onClick={handleRerunScoresClick}
-                                secondary
-                                size='sm'
-                                type='button'
-                            />
+                            <div className={styles.operationPanel}>
+                                <div className={styles.testSubmissionGrid}>
+                                    <label className={styles.fieldGroup}>
+                                        <span>Validation Phase</span>
+                                        <select
+                                            className={styles.selectInput}
+                                            disabled={
+                                                isUploadingTestSubmission
+                                                || testSubmissionPhaseOptions.length === 0
+                                            }
+                                            onChange={handleTestSubmissionPhaseChange}
+                                            value={testSubmissionConfigType}
+                                        >
+                                            {testSubmissionPhaseOptions.length === 0
+                                                ? (
+                                                    <option value={testSubmissionConfigType}>
+                                                        No saved phase configs
+                                                    </option>
+                                                )
+                                                : testSubmissionPhaseOptions.map(option => (
+                                                    <option key={option.value} value={option.value}>
+                                                        {option.label}
+                                                    </option>
+                                                ))}
+                                        </select>
+                                    </label>
+
+                                    <label className={styles.fieldGroup}>
+                                        <span>Test Submission</span>
+                                        <input
+                                            accept='.zip,application/zip,application/x-zip-compressed'
+                                            disabled={isUploadingTestSubmission}
+                                            onChange={handleTestSubmissionFileChange}
+                                            type='file'
+                                        />
+                                    </label>
+
+                                    <div className={styles.operationButton}>
+                                        <Button
+                                            disabled={!canUploadTestSubmission}
+                                            label={
+                                                isUploadingTestSubmission
+                                                    ? 'Uploading...'
+                                                    : 'Upload test submission'
+                                            }
+                                            loading={isUploadingTestSubmission}
+                                            onClick={handleUploadTestSubmissionClick}
+                                            secondary
+                                            size='sm'
+                                            type='button'
+                                        />
+                                    </div>
+                                </div>
+
+                                {testSubmissionResult
+                                    ? (
+                                        <div className={styles.testSubmissionResult}>
+                                            <span>
+                                                Submission
+                                                {' '}
+                                                {testSubmissionResult.submissionId}
+                                            </span>
+                                            <span>
+                                                Task
+                                                {' '}
+                                                {testSubmissionResult.taskId}
+                                            </span>
+                                            {testSubmissionResult.cloudWatchLogsConsoleUrl
+                                                ? (
+                                                    <a
+                                                        href={testSubmissionResult.cloudWatchLogsConsoleUrl}
+                                                        rel='noreferrer'
+                                                        target='_blank'
+                                                    >
+                                                        CloudWatch logs
+                                                    </a>
+                                                )
+                                                : undefined}
+                                        </div>
+                                    )
+                                    : undefined}
+
+                                <div className={styles.rerunButtonRow}>
+                                    <Button
+                                        disabled={!canRerunScores}
+                                        label={isRerunning ? 'Rerunning...' : 'Rerun scores'}
+                                        loading={isRerunning}
+                                        onClick={handleRerunScoresClick}
+                                        secondary
+                                        size='sm'
+                                        type='button'
+                                    />
+                                </div>
+                            </div>
                         </div>
                     )
                     : undefined}


### PR DESCRIPTION
What was broken

Challenge managers and copilots could configure Marathon Match scoring in Work Manager but could not upload a test submission from the scorer section to validate the ECS runner flow before launch.

Root cause

The work app only exposed saved config editing and latest-submission rerun controls. It had no service call or UI state for multipart validation submission upload.

What was changed

Added a Marathon Match validation upload service, response model, and score-operations controls for selecting a saved phase config, uploading a ZIP test submission, and showing the queued submission/task result.

Any added/updated tests

Added service tests for multipart validation upload requests and malformed response handling.
