### PR TITLE
PM-5259: Fix rating popup position tiers

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -102,8 +102,11 @@
     @include ltesm {
         border-left: 0;
         border-top: 1px solid $black-10;
+        flex-direction: row;
+        flex-wrap: nowrap;
         gap: $sp-4;
         grid-column: 1 / -1;
+        justify-content: center;
     }
 }
 

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -1,11 +1,38 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
 import type { PropsWithChildren } from 'react'
+import type { RenderResult } from '@testing-library/react'
 import { render, screen, within } from '@testing-library/react'
 
 import type { UserProfile } from '~/libs/core'
 
 import MemberRatingInfoModal from './MemberRatingInfoModal'
+
+const baseProfile = {
+    firstName: 'Emily',
+    handle: 'emily',
+    photoURL: 'https://example.com/photo.png',
+} as UserProfile
+
+const ratingDistribution = {
+    createdAt: '2026-06-04T00:00:00.000Z',
+    createdBy: 'test',
+    distribution: {
+        ratingRange0To899: 10,
+        ratingRange900To1199: 20,
+        ratingRange1200To1499: 30,
+        ratingRange1500To2199: 40,
+    },
+    subTrack: 'AI',
+    track: 'DATA_SCIENCE',
+    updatedAt: '2026-06-04T00:00:00.000Z',
+    updatedBy: 'test',
+}
+
+function getPyramidFills(container: HTMLElement): string[] {
+    return Array.from(container.querySelectorAll('polygon'))
+        .map((polygon: Element) => polygon.getAttribute('fill') ?? '')
+}
 
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(() => '#616BD5'),
@@ -41,26 +68,9 @@ describe('MemberRatingInfoModal', () => {
                 audienceLabel='developers'
                 onClose={jest.fn()}
                 percentile={15}
-                profile={{
-                    firstName: 'Emily',
-                    handle: 'emily',
-                    photoURL: 'https://example.com/photo.png',
-                } as UserProfile}
+                profile={baseProfile}
                 rating={1646}
-                ratingDistribution={{
-                    createdAt: '2026-06-04T00:00:00.000Z',
-                    createdBy: 'test',
-                    distribution: {
-                        ratingRange0To899: 10,
-                        ratingRange900To1199: 20,
-                        ratingRange1200To1499: 30,
-                        ratingRange1500To2199: 40,
-                    },
-                    subTrack: 'AI',
-                    track: 'DATA_SCIENCE',
-                    updatedAt: '2026-06-04T00:00:00.000Z',
-                    updatedBy: 'test',
-                }}
+                ratingDistribution={ratingDistribution}
             />,
         )
 
@@ -76,5 +86,35 @@ describe('MemberRatingInfoModal', () => {
             .toBeInTheDocument()
         expect(screen.getByText('Where Emily ranks in the distribution'))
             .toBeInTheDocument()
+    })
+
+    it('highlights pyramid segments from top percentile buckets', () => {
+        const rendered: RenderResult = render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={8}
+                profile={baseProfile}
+                rating={1200}
+                ratingDistribution={ratingDistribution}
+            />,
+        )
+
+        expect(getPyramidFills(rendered.container))
+            .toEqual(['#616BD5', '#D4D4D4', '#D4D4D4', '#D4D4D4', '#D4D4D4'])
+
+        rendered.rerender(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={59}
+                profile={baseProfile}
+                rating={1200}
+                ratingDistribution={ratingDistribution}
+            />,
+        )
+
+        expect(getPyramidFills(rendered.container))
+            .toEqual(['#D4D4D4', '#D4D4D4', '#D4D4D4', '#616BD5', '#D4D4D4'])
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -163,6 +163,39 @@ const getRatingTierName = (rating?: number): string => (
 )
 
 /**
+ * Returns the pyramid tier that represents a member's top percentile.
+ *
+ * Used by MemberRatingInfoModal to place the highlighted pyramid segment by position instead of
+ * rating range: top 10%, top 25%, top 50%, top 75%, then everyone else.
+ *
+ * @param {number | undefined} percentile - The member's top percentile in the selected audience.
+ * @returns {RatingTier | undefined} The pyramid tier for the percentile, or undefined without a usable percentile.
+ */
+const getPyramidTierByPercentile = (percentile?: number): RatingTier | undefined => {
+    if (percentile === undefined || !Number.isFinite(percentile)) {
+        return undefined
+    }
+
+    if (percentile <= 10) {
+        return ratingTiers[4]
+    }
+
+    if (percentile <= 25) {
+        return ratingTiers[3]
+    }
+
+    if (percentile <= 50) {
+        return ratingTiers[2]
+    }
+
+    if (percentile <= 75) {
+        return ratingTiers[1]
+    }
+
+    return ratingTiers[0]
+}
+
+/**
  * Parses the API distribution payload into ordered rating ranges.
  *
  * Used by MemberRatingInfoModal to render custom histogram bars from the same
@@ -279,7 +312,8 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const displayName: string = getMemberDisplayName(props.profile)
     const titleDisplayName: string = displayName
         .toUpperCase()
-    const selectedTier: RatingTier = getRatingTier(props.rating)
+    const selectedRatingTier: RatingTier = getRatingTier(props.rating)
+    const selectedPyramidTier: RatingTier = getPyramidTierByPercentile(props.percentile) ?? selectedRatingTier
     const distributionRanges: RatingDistributionRange[] = useMemo(() => (
         getDistributionRanges(props.ratingDistribution?.distribution)
     ), [props.ratingDistribution])
@@ -346,7 +380,9 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                                         <polygon
                                             key={shape.tierId}
                                             points={shape.points}
-                                            fill={tier.id === selectedTier.id ? tier.color : '#D4D4D4'}
+                                            fill={tier.id === selectedPyramidTier.id
+                                                ? selectedRatingTier.color
+                                                : '#D4D4D4'}
                                         />
                                     )
                                 })}
@@ -438,7 +474,7 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
 
                 <div className={styles.legend}>
                     {ratingTiers.map((tier: RatingTier) => {
-                        const isActive = tier.id === selectedTier.id
+                        const isActive = tier.id === selectedRatingTier.id
 
                         return (
                             <div


### PR DESCRIPTION
What was broken
The rating comparison popup highlighted the pyramid using rating ranges, so the position graphic could point at the wrong tier for a member's Top %.

Root cause
The modal reused the selected rating tier for both the rating legend and the position pyramid, even though the pyramid should be based on Top % thresholds.

What was changed
Added percentile-bucket selection for the pyramid: top 10% or less, 25% or less, 50% or less, 75% or less, and greater than 75%.
Kept the highlighted segment color aligned with the member's rating color and made the mobile pyramid/position row explicit.

Any added/updated tests
Updated MemberRatingInfoModal tests to assert the position summary and percentile bucket highlighting.

Validation
- yarn test:no-watch MemberRatingInfoModal: passed.
- yarn lint: passed.
- yarn run build: passed with existing warnings.
- yarn test:no-watch --runInBand --silent: failed in unrelated work, engagements, and wallet-admin suites; the updated profiles modal spec passed.
