### PR TITLE
PM-5263: Improve low-rating card contrast

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -17,6 +17,7 @@ import { getPreferredRolesText, numberToFixed } from '../../../lib'
 
 import {
     calculateTopPercentileFromDistribution,
+    getCompactRatingColor,
     getLatestProfileRating,
     getPreferredRolesDisplay,
     getRatingAudienceLabel,
@@ -47,6 +48,7 @@ const formatPercentile = (percentile: number): string => (
 const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProps) => {
     const memberStats: UserStats | undefined = useMemberStats(props.profile.handle)
     const rating: number | undefined = useMemo(() => getLatestProfileRating(memberStats), [memberStats])
+    const compactRatingColor: string = getCompactRatingColor(rating, getRatingColor(rating))
 
     const [isInfoModalOpen, setIsInfoModalOpen]: [boolean, Dispatch<SetStateAction<boolean>>] = useState(false)
 
@@ -151,7 +153,7 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
         <div className={styles.container}>
             <div className={styles.innerWrap}>
                 <button type='button' className={styles.valueWrap} onClick={handleInfoModalOpen}>
-                    <p className={styles.value} style={{ color: getRatingColor(rating) }}>
+                    <p className={styles.value} style={{ color: compactRatingColor }}>
                         {rating}
                     </p>
                     <p className={styles.name}>Rating</p>
@@ -180,7 +182,7 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
                             >
                                 <p
                                     className={classNames(styles.value, styles.percentileValue)}
-                                    style={{ color: getRatingColor(rating) }}
+                                    style={{ color: compactRatingColor }}
                                 >
                                     {percentileLabel}
                                 </p>

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -2,12 +2,31 @@ import type { UserStats, UserStatsDistributionResponse } from '~/libs/core'
 
 import {
     calculateTopPercentileFromDistribution,
+    getCompactRatingColor,
     getLatestProfileRating,
     getPreferredRolesDisplay,
     getRatingAudienceLabel,
     getRatingDistributionQuery,
     parsePreferredRolesText,
 } from './MemberRatingCard.utils'
+
+describe('getCompactRatingColor', () => {
+    it('uses the lighter grey value for the lowest rating tier on the dark compact card', () => {
+        expect(getCompactRatingColor(840, '#555555'))
+            .toBe('#7F7F7F')
+    })
+
+    it('keeps the shared rating colors for higher rating tiers', () => {
+        expect(getCompactRatingColor(900, '#2D7E2D'))
+            .toBe('#2D7E2D')
+        expect(getCompactRatingColor(1200, '#616BD5'))
+            .toBe('#616BD5')
+        expect(getCompactRatingColor(1500, '#F2C900'))
+            .toBe('#F2C900')
+        expect(getCompactRatingColor(2200, '#EF3A3A'))
+            .toBe('#EF3A3A')
+    })
+})
 
 describe('getLatestProfileRating', () => {
     it('uses the newest rated track instead of the historical max rating', () => {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -1,4 +1,4 @@
-import { UserStats, UserStatsDistributionResponse } from '~/libs/core'
+import type { UserStats, UserStatsDistributionResponse } from '~/libs/core'
 
 interface RatingCandidate {
     rating: number
@@ -27,6 +27,8 @@ export interface PreferredRolesDisplay {
 type StatsRecord = Record<string, unknown>
 
 const maxCollapsedPreferredRoles = 2
+const lowestRatingTierLimit = 900
+const compactLowestRatingColor = '#7F7F7F'
 
 const aiEngineeringTrackNames: Set<string> = new Set([
     'AI',
@@ -257,6 +259,25 @@ export const calculateTopPercentileFromDistribution = (
 
     return (membersAtOrAboveRating / totalMembers) * 100
 }
+
+/**
+ * Returns the rating text color for the dark compact profile rating card.
+ *
+ * The shared grey rating color is too dark against the compact card background,
+ * so the lowest rating tier is mapped to the lighter grey palette value while
+ * all other rating tiers continue to use the shared Topcoder rating color passed in.
+ * Used by MemberRatingCard for the rating value and top-percentile badge.
+ *
+ * @param {number | undefined} rating - The profile rating rendered in the compact card.
+ * @param {string} ratingColor - Shared Topcoder rating color for the same rating.
+ * @returns {string} Hex color to use for compact card rating text.
+ * @throws Does not throw.
+ */
+export const getCompactRatingColor = (rating: number | undefined, ratingColor: string): string => (
+    rating !== undefined && rating < lowestRatingTierLimit
+        ? compactLowestRatingColor
+        : ratingColor
+)
 
 /**
  * Extracts rated candidates from a design or development subtrack list.


### PR DESCRIPTION
What was broken
The compact profile rating card rendered the lowest rating tier in the shared dark grey, making the rating and Top percentage badge hard to read on the dark AI Ratings card.

Root cause (if identifiable)
MemberRatingCard reused the global rating color directly. The lowest-tier grey works on light backgrounds but has poor contrast against the card's navy background.

What was changed
Added a compact-card rating color helper that maps the lowest rating tier to the lighter grey palette value while preserving the existing shared colors for higher tiers, and used it for the card rating value and Top percentage badge.

Any added/updated tests
Updated MemberRatingCard.utils.spec.ts to cover the low-tier compact color mapping and to verify higher rating tiers keep their shared colors.

Validation notes:
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts passed.
- yarn lint passed.
- yarn build passed with existing warnings.
- yarn test:no-watch was run and failed in unrelated work/wallet-admin suites outside the profile rating change.
