### PR TITLE
PM-5264: Show top one percent for highest ratings

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -13,10 +13,11 @@ import {
 import { Tooltip } from '~/libs/ui'
 
 import { EditMemberPropertyBtn } from '../../../components'
-import { getPreferredRolesText, numberToFixed } from '../../../lib'
+import { getPreferredRolesText } from '../../../lib'
 
 import {
     calculateTopPercentileFromDistribution,
+    formatTopPercentile,
     getCompactRatingColor,
     getLatestProfileRating,
     getPreferredRolesDisplay,
@@ -34,16 +35,6 @@ interface MemberRatingCardProps {
     mutatePersonalizationTraits: () => void
     profile: UserProfile
 }
-
-/**
- * Formats percentile values for the compact rating card.
- *
- * @param {number} percentile - The percentile value calculated from the rating distribution.
- * @returns {string} A display-ready percentage without unnecessary decimal places.
- */
-const formatPercentile = (percentile: number): string => (
-    numberToFixed(percentile, 0)
-)
 
 const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProps) => {
     const memberStats: UserStats | undefined = useMemberStats(props.profile.handle)
@@ -71,7 +62,7 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
     ), [rating, ratingDistribution])
     const audienceLabel: string = getRatingAudienceLabel(memberStats)
     const percentileLabel: string | undefined = maxPercentile
-        ? `Top ${formatPercentile(maxPercentile)}%`
+        ? `Top ${formatTopPercentile(maxPercentile)}%`
         : undefined
     const canEditPreferredRoles: boolean = props.authProfile?.handle === props.profile.handle
     const preferredRolesText: string = useMemo(

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -2,6 +2,7 @@ import type { UserStats, UserStatsDistributionResponse } from '~/libs/core'
 
 import {
     calculateTopPercentileFromDistribution,
+    formatTopPercentile,
     getCompactRatingColor,
     getLatestProfileRating,
     getPreferredRolesDisplay,
@@ -130,6 +131,20 @@ describe('calculateTopPercentileFromDistribution', () => {
             .toBeUndefined()
         expect(calculateTopPercentileFromDistribution({}, 1500))
             .toBeUndefined()
+    })
+})
+
+describe('formatTopPercentile', () => {
+    it('shows top one percent for positive percentages that would round to zero', () => {
+        expect(formatTopPercentile(0.4))
+            .toBe('1')
+    })
+
+    it('keeps normal whole-number rounding for visible top percentages', () => {
+        expect(formatTopPercentile(12.4))
+            .toBe('12')
+        expect(formatTopPercentile(12.5))
+            .toBe('13')
     })
 })
 

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -261,6 +261,19 @@ export const calculateTopPercentileFromDistribution = (
 }
 
 /**
+ * Formats the compact rating card's visible top percentage.
+ *
+ * @param {number} percentile - Top percentage calculated from the rating distribution.
+ * @returns {string} Rounded whole percentage, with positive values clamped to at least 1.
+ * @throws Does not throw.
+ */
+export const formatTopPercentile = (percentile: number): string => {
+    const roundedPercentile = Math.round(percentile)
+
+    return `${percentile > 0 ? Math.max(roundedPercentile, 1) : roundedPercentile}`
+}
+
+/**
  * Returns the rating text color for the dark compact profile rating card.
  *
  * The shared grey rating color is too dark against the compact card background,


### PR DESCRIPTION
What was broken

The compact profile rating card rounded distribution-derived top percentages to a whole number. Highest-rated members with a calculated positive top percentage below one could render as Top 0%.

Root cause

The display formatter rounded the top percentage without enforcing a positive lower bound for ranked members.

What was changed

Moved top-percentage display formatting into the rating-card utility and clamp positive values to at least 1 before rendering Top X%.

Any added/updated tests

Added rating-card utility coverage for sub-one positive percentages and normal whole-number rounding.

Validation:

- Passed: source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
- Passed: source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn lint
- Passed: source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn run build
- Failed on unrelated existing ai-ratings branch baseline failures: source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch. Failures were in work/payment/wallet-admin/challenge editor suites, including missing mocked assignment utility exports and module alias resolution errors unrelated to the profile rating card.
