### PR TITLE
PM-5257: Fix rating card width at narrow mobile sizes

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
@@ -96,12 +96,14 @@
         }
 
         @include ltesm {
+            box-sizing: border-box;
             grid-template-columns: 1fr;
             column-gap: $sp-3;
             row-gap: $sp-1;
             justify-content: start;
             justify-items: stretch;
-            width: 300px;
+            max-width: 300px;
+            width: 100%;
 
             .percentileWrap {
                 .name {


### PR DESCRIPTION
What was broken
The previous mobile rating card fix stacked the rating data, but at very narrow widths the card still used a fixed 300px content-box width. Its horizontal padding made the rendered card wider than the available mobile content area, so the stacked data could still appear misaligned or overflow.

Root cause
The small-screen rule changed the grid to one column but left the card width as a fixed content-box value. With padding added on top of that width, max-width did not cap the rendered border-box size.

What was changed
Updated the small-screen rating card styles to size the card as a border-box, fill the available content width, and cap the rendered card at 300px while keeping the previous one-column alignment rules. This PR targets ai-ratings because PR #1903 was merged there and dev still has the older rating card implementation.

Any added/updated tests
No tests were added because this is a scoped SCSS layout fix. Validation run:

- source ~/.nvm/nvm.sh && nvm use && yarn lint
- source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn lint
- source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn run build
- source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
- source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch

Lint, build, and targeted profile rating tests passed. The full test suite was run and failed in unrelated work/engagement/wallet specs outside this CSS change.
