### PR TITLE
PM-4300: use final MM scores for winners

### DIFF
--- a/src/apps/review/src/lib/hooks/useFetchChallengeResults.spec.ts
+++ b/src/apps/review/src/lib/hooks/useFetchChallengeResults.spec.ts
@@ -1,4 +1,5 @@
 import type { ChallengeWinner, SubmissionInfo } from '../models'
+import { getSubmissionFinalScoreCandidate } from '../utils/challengeResultSubmissions'
 import { submissionMatchesWinner } from '../utils/winnerMatching'
 
 const buildWinner = (overrides: Partial<ChallengeWinner> = {}): ChallengeWinner => ({
@@ -53,5 +54,28 @@ describe('submissionMatchesWinner', () => {
             }),
         ))
             .toBe(true)
+    })
+})
+
+describe('getSubmissionFinalScoreCandidate', () => {
+    it('uses final aggregate scores before review scores', () => {
+        expect(getSubmissionFinalScoreCandidate(buildSubmission({
+            aggregateScore: 96.01,
+            finalAggregateScore: 95.81,
+            review: {
+                finalScore: 100,
+            } as SubmissionInfo['review'],
+        })))
+            .toBe(95.81)
+    })
+
+    it('falls back to review final score instead of provisional aggregate scores', () => {
+        expect(getSubmissionFinalScoreCandidate(buildSubmission({
+            aggregateScore: 96.01,
+            review: {
+                finalScore: 100,
+            } as SubmissionInfo['review'],
+        })))
+            .toBe(100)
     })
 })

--- a/src/apps/review/src/lib/hooks/useFetchChallengeResults.ts
+++ b/src/apps/review/src/lib/hooks/useFetchChallengeResults.ts
@@ -27,7 +27,10 @@ import { PAST_CHALLENGE_STATUSES } from '../utils/challengeStatus'
 import {
     isContestSubmissionType,
 } from '../constants'
-import { buildChallengeResultSubmissionSource } from '../utils/challengeResultSubmissions'
+import {
+    buildChallengeResultSubmissionSource,
+    getSubmissionFinalScoreCandidate,
+} from '../utils/challengeResultSubmissions'
 import { submissionMatchesWinner } from '../utils/winnerMatching'
 
 type ResourceMemberMapping = ChallengeDetailContextModel['resourceMemberIdMapping']
@@ -181,9 +184,7 @@ const buildProjectResult = ({
         const fallbackReviews = submission?.reviews ?? []
         const mappedReviews = reviewsBySubmissionId.get(submission.id) ?? fallbackReviews
         const orderedReviews = orderReviewsByCreatedDate(mappedReviews)
-        const aggregateScoreCandidate = toFiniteNumber(submission?.aggregateScore)
-        const finalScoreCandidate = aggregateScoreCandidate
-            ?? toFiniteNumber(submission?.review?.finalScore)
+        const finalScoreCandidate = getSubmissionFinalScoreCandidate(submission)
         const computedFinalScore = computeFinalScore(orderedReviews, finalScoreCandidate)
         const initialScoreCandidate = toFiniteNumber(submission?.review?.initialScore)
         const computedInitialScore = initialScoreCandidate ?? computedFinalScore

--- a/src/apps/review/src/lib/models/SubmissionInfo.model.spec.ts
+++ b/src/apps/review/src/lib/models/SubmissionInfo.model.spec.ts
@@ -1,0 +1,95 @@
+import { BackendSubmissionStatus } from './BackendSubmissionStatus.enum'
+import type { BackendSubmission } from './BackendSubmission.model'
+import { convertBackendSubmissionToSubmissionInfo } from './SubmissionInfo.model'
+
+jest.mock('~/libs/core', () => ({
+    getRatingColor: jest.fn()
+        .mockReturnValue('#000000'),
+}), { virtual: true })
+
+/**
+ * Builds a minimal backend submission for submission model conversion specs.
+ *
+ * @param overrides - Submission fields to override for a test case.
+ * @returns Backend submission payload accepted by convertBackendSubmissionToSubmissionInfo.
+ * Used to keep Marathon Match review summation selection tests focused.
+ */
+function buildBackendSubmission(overrides: Partial<BackendSubmission> = {}): BackendSubmission {
+    return {
+        challengeId: 'challenge-1',
+        createdAt: '2026-06-05T05:00:00.000Z',
+        createdBy: 'system',
+        esId: 'es-1',
+        fileSize: undefined,
+        fileType: 'zip',
+        finalScore: '',
+        id: 'submission-1',
+        initialScore: '',
+        legacyChallengeId: 123,
+        legacySubmissionId: 'legacy-submission-1',
+        legacyUploadId: 'legacy-upload-1',
+        markForPurchase: false,
+        memberId: '1001',
+        placement: 1,
+        prizeId: 1,
+        review: [],
+        reviewSummation: [],
+        screeningScore: undefined,
+        status: BackendSubmissionStatus.ACTIVE,
+        submissionPhaseId: 'phase-1',
+        submittedDate: '2026-06-05T05:00:00.000Z',
+        systemFileName: undefined,
+        thurgoodJobId: undefined,
+        type: 'CONTEST_SUBMISSION',
+        updatedAt: '2026-06-05T05:00:00.000Z',
+        updatedBy: 'system',
+        uploadId: 'upload-1',
+        url: '',
+        userRank: 1,
+        viewCount: undefined,
+        ...overrides,
+    } as unknown as BackendSubmission
+}
+
+describe('convertBackendSubmissionToSubmissionInfo', () => {
+    it('uses metadata-only system summations as final aggregate scores', () => {
+        const result = convertBackendSubmissionToSubmissionInfo(buildBackendSubmission({
+            reviewSummation: [
+                {
+                    aggregateScore: 96.01,
+                    isProvisional: true,
+                    metadata: { testType: 'provisional' },
+                    updatedAt: '2026-06-05T05:10:00.000Z',
+                },
+                {
+                    aggregateScore: '100',
+                    metadata: { testProcess: 'system' },
+                    updatedAt: '2026-06-05T05:15:00.000Z',
+                },
+            ],
+        }))
+
+        expect(result.aggregateScore)
+            .toBe(100)
+        expect(result.finalAggregateScore)
+            .toBe(100)
+    })
+
+    it('does not expose a provisional summation as a final aggregate score', () => {
+        const result = convertBackendSubmissionToSubmissionInfo(buildBackendSubmission({
+            reviewSummation: [
+                {
+                    aggregateScore: 96.01,
+                    isProvisional: true,
+                    metadata: { testType: 'provisional' },
+                    updatedAt: '2026-06-05T05:10:00.000Z',
+                },
+            ],
+        }))
+
+        expect(result.aggregateScore)
+            .toBe(96.01)
+        expect(result.finalAggregateScore)
+            .toBeUndefined()
+    })
+})

--- a/src/apps/review/src/lib/models/SubmissionInfo.model.ts
+++ b/src/apps/review/src/lib/models/SubmissionInfo.model.ts
@@ -46,6 +46,10 @@ export interface SubmissionInfo {
      */
     aggregateScore?: number
     /**
+     * Aggregated system/final score from review summations when available.
+     */
+    finalAggregateScore?: number
+    /**
      * Indicates whether the latest review summation meets the passing threshold.
      */
     isPassingReview?: boolean
@@ -96,6 +100,180 @@ function normalizeSubmissionStatus(status: BackendSubmissionStatus | string | un
     return undefined
 }
 
+type ReviewSummationLike = {
+    aggregateScore?: unknown
+    createdAt?: unknown
+    isFinal?: unknown
+    isPassing?: unknown
+    metadata?: unknown
+    reviewedDate?: unknown
+    updatedAt?: unknown
+}
+
+/**
+ * Parses boolean-like review summation flags from Review API payloads.
+ *
+ * @param value - Raw flag value from a summation row or metadata object.
+ * @returns Parsed boolean, or undefined when the value is not boolean-like.
+ * Used while selecting final/system Marathon Match summations for display.
+ */
+function parseBooleanFlag(value: unknown): boolean | undefined {
+    if (typeof value === 'boolean') {
+        return value
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim()
+            .toLowerCase()
+        if (normalized === 'true') {
+            return true
+        }
+
+        if (normalized === 'false') {
+            return false
+        }
+    }
+
+    return undefined
+}
+
+/**
+ * Parses Review API summation metadata into an object.
+ *
+ * @param metadata - Raw metadata value, which may be an object or JSON string.
+ * @returns Metadata record, or an empty object when metadata is absent or malformed.
+ * Used for Marathon Match phase classification; malformed JSON is ignored.
+ */
+function parseSummationMetadata(metadata: unknown): Record<string, unknown> {
+    if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+        return metadata as Record<string, unknown>
+    }
+
+    if (typeof metadata === 'string' && metadata.trim()) {
+        try {
+            const parsed = JSON.parse(metadata)
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                ? parsed as Record<string, unknown>
+                : {}
+        } catch {
+            return {}
+        }
+    }
+
+    return {}
+}
+
+/**
+ * Normalizes Marathon Match scoring phase labels from summation metadata.
+ *
+ * @param value - Raw phase value such as testProcess or testType.
+ * @returns Normalized phase, or undefined when the value is not recognized.
+ * Used to treat metadata-only SYSTEM summations as final scores.
+ */
+function normalizeSummationPhase(value: unknown): 'example' | 'provisional' | 'system' | undefined {
+    const normalized = typeof value === 'string'
+        ? value.trim()
+            .toLowerCase()
+        : ''
+
+    if (normalized === 'system' || normalized === 'final') {
+        return 'system'
+    }
+
+    if (normalized === 'provisional') {
+        return 'provisional'
+    }
+
+    if (normalized === 'example') {
+        return 'example'
+    }
+
+    return undefined
+}
+
+/**
+ * Parses a finite aggregate score from a review summation.
+ *
+ * @param value - Raw aggregate score from Review API.
+ * @returns Numeric aggregate score, or undefined when not finite.
+ * Used by submission conversion before exposing score fields to tables.
+ */
+function parseAggregateScore(value: unknown): number | undefined {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined
+    }
+
+    if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value)
+        return Number.isFinite(parsed) ? parsed : undefined
+    }
+
+    return undefined
+}
+
+/**
+ * Resolves the best timestamp available for ordering review summations.
+ *
+ * @param summation - Review summation returned by Review API.
+ * @returns Epoch milliseconds, or 0 when no parseable timestamp exists.
+ * Used to prefer the newest final/system Marathon Match score.
+ */
+function getSummationTimestamp(summation: ReviewSummationLike): number {
+    const rawTimestamp = summation.updatedAt
+        ?? summation.reviewedDate
+        ?? summation.createdAt
+    const timestamp = typeof rawTimestamp === 'string' ? Date.parse(rawTimestamp) : Number.NaN
+
+    return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+/**
+ * Determines whether a summation represents Marathon Match system/final scoring.
+ *
+ * @param summation - Review summation returned by Review API.
+ * @returns True when flags or metadata identify the summation as final/system.
+ * Used so provisional scores do not drive the Winners tab final score.
+ */
+function isFinalReviewSummation(summation: ReviewSummationLike): boolean {
+    const metadata = parseSummationMetadata(summation.metadata)
+    const phase = normalizeSummationPhase(
+        metadata.testProcess ?? metadata.testType,
+    )
+    const stage = typeof metadata.stage === 'string'
+        ? metadata.stage.trim()
+            .toLowerCase()
+        : ''
+
+    return parseBooleanFlag(summation.isFinal) === true
+        || parseBooleanFlag(metadata.isFinal) === true
+        || phase === 'system'
+        || stage === 'final'
+}
+
+/**
+ * Selects the newest final/system review summation with a usable score.
+ *
+ * @param reviewSummations - Summations attached to one submission.
+ * @returns Preferred final/system summation, or undefined when none exist.
+ * Used to populate final-only aggregate scores for Marathon Match winners.
+ */
+function findFinalReviewSummation(
+    reviewSummations: ReviewSummationLike[],
+): ReviewSummationLike | undefined {
+    return reviewSummations
+        .map((summation, index) => ({
+            index,
+            score: parseAggregateScore(summation.aggregateScore),
+            summation,
+            timestamp: getSummationTimestamp(summation),
+        }))
+        .filter(item => item.score !== undefined && isFinalReviewSummation(item.summation))
+        .sort((first, second) => (
+            second.timestamp - first.timestamp
+            || second.index - first.index
+        ))[0]?.summation
+}
+
 /**
  * Update review info to show in ui
  * @param data data from backend response
@@ -130,20 +308,13 @@ export function convertBackendSubmissionToSubmissionInfo(
             .local()
             .format(TABLE_DATE_FORMAT)
         : undefined
-    const reviewSummations = Array.isArray(data.reviewSummation) ? data.reviewSummation : []
-    const preferredSummation = reviewSummations.find(
-        entry => entry?.isFinal === true,
-    ) ?? reviewSummations[0]
-    const aggregateScoreRaw = preferredSummation?.aggregateScore
-    const aggregateScoreParsed = typeof aggregateScoreRaw === 'number'
-        ? aggregateScoreRaw
-        : typeof aggregateScoreRaw === 'string'
-            ? Number.parseFloat(aggregateScoreRaw)
-            : undefined
-    const aggregateScore = typeof aggregateScoreParsed === 'number'
-        && Number.isFinite(aggregateScoreParsed)
-        ? aggregateScoreParsed
-        : undefined
+    const reviewSummations: ReviewSummationLike[] = Array.isArray(data.reviewSummation)
+        ? data.reviewSummation
+        : []
+    const finalSummation = findFinalReviewSummation(reviewSummations)
+    const preferredSummation = finalSummation ?? reviewSummations[0]
+    const aggregateScore = parseAggregateScore(preferredSummation?.aggregateScore)
+    const finalAggregateScore = parseAggregateScore(finalSummation?.aggregateScore)
     const isPassingReviewRaw = preferredSummation?.isPassing
     const isPassingReview = typeof isPassingReviewRaw === 'boolean'
         ? isPassingReviewRaw
@@ -165,6 +336,7 @@ export function convertBackendSubmissionToSubmissionInfo(
 
     return {
         aggregateScore,
+        finalAggregateScore,
         id: data.id,
         isFileSubmission: data.isFileSubmission,
         isLatest: data.isLatest,

--- a/src/apps/review/src/lib/utils/challengeResultSubmissions.ts
+++ b/src/apps/review/src/lib/utils/challengeResultSubmissions.ts
@@ -23,6 +23,31 @@ function normalizeIdentifier(value: unknown): string | undefined {
 }
 
 /**
+ * Returns a finite number when the value is already numeric and usable.
+ *
+ * @param value - Numeric candidate from a normalized submission.
+ * @returns Finite number, or undefined when absent or invalid.
+ * Used by winner score resolution before calculating fallback review averages.
+ */
+function toFiniteNumber(value?: number | null): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Resolves the final score candidate for a winner submission.
+ *
+ * @param submission - Submission being evaluated for a challenge winner row.
+ * @returns Final/system aggregate score, review final score, or undefined when neither exists.
+ * Used by the Winners tab so provisional Marathon Match aggregates do not override final review scores.
+ */
+export function getSubmissionFinalScoreCandidate(
+    submission: SubmissionInfo,
+): number | undefined {
+    return toFiniteNumber(submission.finalAggregateScore)
+        ?? toFiniteNumber(submission?.review?.finalScore)
+}
+
+/**
  * Enriches a submission with member-mapping user info when it is missing.
  *
  * @param submission - Submission to normalize.
@@ -105,6 +130,10 @@ function mergeSubmissionInfo(
         ...fallback,
         ...preferred,
         aggregateScore: preferDefinedValue(preferred.aggregateScore, fallback.aggregateScore),
+        finalAggregateScore: preferDefinedValue(
+            preferred.finalAggregateScore,
+            fallback.finalAggregateScore,
+        ),
         id: preferred.id || fallback.id,
         isFileSubmission: preferDefinedValue(preferred.isFileSubmission, fallback.isFileSubmission),
         isLatest: preferDefinedValue(preferred.isLatest, fallback.isLatest),


### PR DESCRIPTION
What was broken
The Review app Winners tab could display a Marathon Match provisional aggregate score as the Final Review Score. In the QA sample, the winner row showed the provisional score even though the system review/final scoring row had produced the final score.

Root cause
The prior aggregate-score fix made Review app tables prefer submission aggregate scores, but the winner-result path only had a single aggregateScore field and fell back to the first review summation when no isFinal boolean was present. Marathon Match summations can also identify final/system scoring through metadata, so provisional summations could be selected as the final-score candidate.

What was changed
The submission model now classifies final/system review summations using isFinal, metadata isFinal/testProcess/testType, and final stage. It stores finalAggregateScore separately from aggregateScore, preserves that value when merging winner submission sources, and the Winners tab resolver uses the final-only aggregate before falling back to review final scores.

Any added/updated tests
Added submission model tests for metadata-only system summations and provisional-only summations. Added winner score candidate tests to ensure provisional aggregates do not override final review scores.

Validation:
- COREPACK_ENABLE_PROJECT_SPEC=0 yarn test:no-watch --runTestsByPath src/apps/review/src/lib/models/SubmissionInfo.model.spec.ts src/apps/review/src/lib/hooks/useFetchChallengeResults.spec.ts passed.
- COREPACK_ENABLE_PROJECT_SPEC=0 yarn lint passed.
- COREPACK_ENABLE_PROJECT_SPEC=0 yarn run build passed with existing build warnings.
- COREPACK_ENABLE_PROJECT_SPEC=0 yarn test:no-watch was run; it failed in unrelated existing suites outside this Review app change, including wallet-admin module alias/config mocks, work engagement schema/payment specs, and work challenge editor specs.
