### PR TITLE
PM-5262: Fix points breakdown modal styling

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.module.scss
@@ -29,12 +29,13 @@
 
 .title {
     color: $black-100;
-    font-family: $font-roboto;
-    font-size: 18px;
+    font-family: $font-barlow;
+    font-size: 22px;
     font-weight: $font-weight-bold;
-    line-height: 24px;
+    line-height: 28px;
     margin: 0;
     padding-right: $sp-8;
+    text-transform: none;
 }
 
 .content {
@@ -101,11 +102,16 @@
 }
 
 .placement,
+.pointsHeader,
 .points {
     white-space: nowrap;
 }
 
+.pointsHeader {
+    text-align: right;
+}
+
 .points {
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-normal;
     text-align: right;
 }

--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.spec.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import type { PropsWithChildren, ReactNode } from 'react'
+import { render, screen, within } from '@testing-library/react'
+
+import MemberChallengePointsModal from './MemberChallengePointsModal'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        URLS: {
+            CHALLENGES_PAGE: 'https://www.topcoder.com/challenges',
+        },
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('~/libs/ui', () => ({
+    BaseModal: (props: PropsWithChildren<{ title?: ReactNode }>): JSX.Element => (
+        <section>
+            {props.title}
+            <div>{props.children}</div>
+        </section>
+    ),
+}), {
+    virtual: true,
+})
+
+describe('MemberChallengePointsModal', () => {
+    it('renders the points breakdown title and aligned points column hooks', () => {
+        render(
+            <MemberChallengePointsModal
+                challengePoints={{
+                    challenges: 2,
+                    details: [{
+                        challengeId: 'challenge-1',
+                        challengeName: 'Point challenge dev',
+                        placement: 1,
+                        points: 1000,
+                        userId: 123,
+                    }],
+                    total: 1000,
+                }}
+                onClose={jest.fn()}
+            />,
+        )
+
+        expect(screen.getByRole('heading', { name: 'Points Breakdown' }))
+            .toBeInTheDocument()
+
+        const tableHeader = screen.getByText('Place')
+            .parentElement as HTMLElement
+
+        expect(within(tableHeader)
+            .getByText('Points'))
+            .toHaveClass('pointsHeader')
+        expect(screen.getByText('1,000'))
+            .toHaveClass('points')
+    })
+})

--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.tsx
@@ -45,7 +45,7 @@ const MemberChallengePointsModal: FC<MemberChallengePointsModalProps> = (
             spacer={false}
             title={(
                 <h3 className={styles.title}>
-                    POINTS BREAKDOWN
+                    Points Breakdown
                 </h3>
             )}
             size='md'
@@ -57,7 +57,7 @@ const MemberChallengePointsModal: FC<MemberChallengePointsModalProps> = (
                     <div className={styles.tableHeader}>
                         <span>Place</span>
                         <span>Challenge</span>
-                        <span>Points</span>
+                        <span className={styles.pointsHeader}>Points</span>
                     </div>
 
                     {details.map((detail: UserChallengePointsDetail) => (


### PR DESCRIPTION
What was broken
The previous points modal cleanup fixed the broad content issues, but QA still reported that the title used the wrong typography, the Points column heading did not align with the right-aligned values, and the point values were bold instead of regular.

Root cause (if identifiable)
MemberChallengePointsModal kept the original Roboto 18px title style, only right-aligned the Points data cells, and explicitly set point values to bold.

What was changed
Updated the title to render as Points Breakdown with Barlow 22px styling, added a right-aligned Points heading hook, and changed point values to regular font weight. This PR targets ai-ratings because that branch contains the QA-failed points modal baseline; dev does not contain this modal yet.

Any added/updated tests
Added a focused MemberChallengePointsModal test covering the title text and Points column CSS hooks.

Validation:
- yarn test:no-watch --runInBand src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberChallengePointsModal.spec.tsx src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx: passed.
- yarn lint: passed.
- yarn run build: passed with existing warnings.
- yarn test:no-watch --runInBand: failed in unrelated existing wallet-admin, work, and engagements suites. The failures include undefined/missing mocked icons or alias imports in wallet-admin tests, missing mocked engagement assignment helpers, and existing assignment/payment expectation mismatches outside the changed profile modal files.
