### PR TITLE
PM-5293: Move specification resize handle inside editor

### DIFF
--- a/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.module.scss
+++ b/src/apps/work/src/lib/components/form/FormMarkdownEditor/FormMarkdownEditor.module.scss
@@ -1,15 +1,21 @@
 .editor {
-    height: 420px;
     min-height: 280px;
-    overflow: hidden;
-    resize: vertical;
-
-    :global(.EasyMDEContainer) {
-        min-height: 280px;
-    }
 }
 
 .editor .markdownEditor {
-    height: 100%;
+    height: auto;
     min-height: 280px;
+
+    :global(.EasyMDEContainer) {
+        height: auto;
+        min-height: 280px;
+    }
+
+    :global(.EasyMDEContainer .CodeMirror.CodeMirror-wrap) {
+        flex: none;
+        height: 340px;
+        min-height: 180px;
+        overflow: hidden;
+        resize: vertical;
+    }
 }


### PR DESCRIPTION
What was broken
The challenge specification markdown editor could be resized only from an unbordered wrapper below the visible editor area, so the resize affordance appeared outside the text box and was easy to miss.

Root cause (if identifiable)
The resize styles were applied to the outer FormMarkdownEditor wrapper instead of the bordered EasyMDE CodeMirror surface.

What was changed
Moved vertical resize behavior to the CodeMirror editor element and allowed the markdown editor container to grow around that surface while preserving the existing minimum editor height.

Any added/updated tests
No test was added because the native browser resize handle is a visual CSS behavior that is not represented in jsdom.

Validation
- Passed: yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeDescriptionField.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengePrivateDescriptionField.spec.tsx
- Passed: yarn lint
- Passed: yarn run build
- Full suite note: yarn test:no-watch and yarn test:no-watch --runInBand were run and failed in unrelated pre-existing suites outside this ticket, including wallet-admin payment view/service module-resolution issues and engagement assignment/payment utility expectations.
