### PR TITLE
PM-5265: Add awards see less toggle

### DIFF
--- a/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx
+++ b/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
 import type { PropsWithChildren, ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import { useMemberBadges, type UserBadge, type UserBadgesResponse, type UserProfile } from '~/libs/core'
 
@@ -32,17 +32,24 @@ jest.mock('../../components', () => ({
 
 const mockUseMemberBadges = useMemberBadges as jest.MockedFunction<typeof useMemberBadges>
 
-function createBadge(badgeName: string): UserBadge {
+/**
+ * Builds a profile award fixture for CommunityAwards tests. The badge name and
+ * index are used to create stable display text and IDs, it returns a UserBadge
+ * accepted by the component, and it does not raise exceptions.
+ */
+function createBadge(badgeName: string, index: number = 1): UserBadge {
+    const badgeId: string = `badge-${index}`
+
     return {
         awarded_at: new Date('2026-06-04T00:00:00.000Z'),
         awarded_by: 'admin',
         org_badge: {
             active: true,
             badge_description: 'Awarded for AI profile work.',
-            badge_image_url: 'https://example.com/ai-rookie.svg',
+            badge_image_url: `https://example.com/${badgeId}.svg`,
             badge_name: badgeName,
             badge_status: 'active',
-            id: 'badge-1',
+            id: badgeId,
             organization_id: 'topcoder',
             orgranization: {
                 id: 'topcoder',
@@ -50,7 +57,7 @@ function createBadge(badgeName: string): UserBadge {
             },
             tags_id_tags: [],
         },
-        org_badge_id: 'badge-1',
+        org_badge_id: badgeId,
         user_handle: 'tester',
         user_id: '123',
     }
@@ -82,5 +89,39 @@ describe('CommunityAwards', () => {
             .toHaveAttribute('data-tooltip-content', 'AI Rookie')
         expect(mockUseMemberBadges)
             .toHaveBeenCalledWith(123, { limit: 500 })
+    })
+
+    it('lets members expand awards and collapse them back to the default view', () => {
+        const memberBadges: UserBadgesResponse = {
+            count: 6,
+            rows: Array.from({ length: 6 }, (_, index) => createBadge(`AI Award ${index + 1}`, index + 1)),
+        }
+
+        mockUseMemberBadges.mockReturnValue(memberBadges)
+
+        render(<CommunityAwards profile={{ userId: 123 } as UserProfile} />)
+
+        expect(screen.getByRole('button', { name: 'View AI Award 1 award details' }))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'View AI Award 4 award details' }))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'View AI Award 5 award details' }))
+            .not
+            .toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: '+ 2 more badges' }))
+
+        expect(screen.getByRole('button', { name: 'View AI Award 5 award details' }))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'See less' }))
+            .toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'See less' }))
+
+        expect(screen.queryByRole('button', { name: 'View AI Award 5 award details' }))
+            .not
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '+ 2 more badges' }))
+            .toBeInTheDocument()
     })
 })

--- a/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.tsx
+++ b/src/apps/profiles/src/member-profile/community-awards/CommunityAwards.tsx
@@ -37,8 +37,13 @@ const CommunityAwards: FC<CommunityAwardsProps> = (props: CommunityAwardsProps) 
         setIsAwardsExpanded(false)
     }, [props.profile?.userId])
 
-    function handleAwardsExpandClick(): void {
-        setIsAwardsExpanded(true)
+    /**
+     * Toggles the awards section between the collapsed four-badge preview and
+     * the expanded list. It is used by the more/less control, takes no
+     * parameters, returns nothing, and does not raise exceptions.
+     */
+    function handleAwardsToggleClick(): void {
+        setIsAwardsExpanded(isExpanded => !isExpanded)
     }
 
     function handleMemberBadgeModalClose(): void {
@@ -82,13 +87,15 @@ const CommunityAwards: FC<CommunityAwardsProps> = (props: CommunityAwardsProps) 
                 }
             </div>
 
-            {!isAwardsExpanded && additionalBadgeCount > 0 && (
+            {additionalBadgeCount > 0 && (
                 <button
                     className={styles.moreBadgesButton}
-                    onClick={handleAwardsExpandClick}
+                    onClick={handleAwardsToggleClick}
                     type='button'
                 >
-                    {`+ ${additionalBadgeCount} more ${additionalBadgeCount === 1 ? 'badge' : 'badges'}`}
+                    {isAwardsExpanded
+                        ? 'See less'
+                        : `+ ${additionalBadgeCount} more ${additionalBadgeCount === 1 ? 'badge' : 'badges'}`}
                 </button>
             )}
 


### PR DESCRIPTION
What was broken
The profile awards preview could expand from the default four-award view to show more awards, but there was no control to collapse the section back to the default view.

Root cause
The awards section only rendered the more-badges action while collapsed and removed that control after expansion.

What was changed
Updated CommunityAwards so the more-badges control toggles between expanding the full awards list and collapsing back to the default four-award preview.

Any added/updated tests
Added CommunityAwards coverage for expanding awards and collapsing them back to the default view.

Validation run
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/community-awards/CommunityAwards.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing project warnings.
- yarn test:no-watch was run and failed in unrelated wallet-admin, work, and engagements suites outside the awards/profile area; the new CommunityAwards spec passed.
