### PR TITLE
Hotfix fix sorting for multiple ai runs

### DIFF
--- a/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
+++ b/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
@@ -154,13 +154,14 @@ export function useFetchAiWorkflowsRuns(
         orderBy(
             runs,
             [
-                (run) => run.startedAt ?? '',
-                (run) => run.completedAt ?? '',
+                run => run.startedAt ?? '',
+                run => run.completedAt ?? '',
             ],
             ['desc', 'desc'],
         ),
         'workflow.id',
-    ).reverse()
+    )
+        .reverse()
 
     return {
         isLoading,

--- a/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
+++ b/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
@@ -150,8 +150,17 @@ export function useFetchAiWorkflowsRuns(
         }
     }, [fetchError])
 
-    const uniqueRuns = uniqBy(orderBy(runs, ['startedAt', 'completedAt'], ['desc', 'desc']), 'workflow.id')
-        .reverse()
+    const uniqueRuns = uniqBy(
+        orderBy(
+            runs,
+            [
+                (run) => run.startedAt ?? '',
+                (run) => run.completedAt ?? '',
+            ],
+            ['desc', 'desc'],
+        ),
+        'workflow.id',
+    ).reverse()
 
     return {
         isLoading,


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request makes a small improvement to the sorting logic of workflow runs in the `useFetchAiWorkflowRuns` hook. The change ensures that sorting works correctly even when `startedAt` or `completedAt` fields are missing by providing default empty string values.

- Improved sorting of `runs` by using accessor functions that handle missing `startedAt` or `completedAt` fields, ensuring robust ordering.