### PR TITLE
PM-5257: Keep mobile rating data in one row

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
@@ -97,25 +97,12 @@
 
         @include ltesm {
             box-sizing: border-box;
-            grid-template-columns: 1fr;
+            grid-template-columns: 52px 104px minmax(0, 1fr);
             column-gap: $sp-3;
-            row-gap: $sp-1;
             justify-content: start;
             justify-items: stretch;
             max-width: 300px;
             width: 100%;
-
-            .percentileWrap {
-                .name {
-                    margin-left: 0;
-                }
-            }
-
-            .link {
-                grid-column: 1;
-                justify-self: start;
-                margin-top: 0;
-            }
         }
     }
 }


### PR DESCRIPTION
What was broken
PR #1903 stacked the mobile rating data into one column, and PR #1923 kept that layout while capping the small-screen card width. QA still saw the Rating section misaligned on iOS 26.5 Safari on iPhone 15 Pro Max because the rating, percentile, audience label, and help link were still vertically stacked instead of aligned like the AI Ratings layout.

Root cause
The `ltesm` breakpoint changed the rating card grid to `1fr`. iPhone 15 Pro Max portrait falls inside that breakpoint, so the browser used the stacked mobile override even though the card has enough width to keep the three data groups in one row.

What was changed
Kept the border-box sizing and 300px rendered width cap from the prior follow-up, but restored the small-screen card to a three-column grid with a flexible final column. This preserves the overflow fix while keeping the rating data aligned in one row on mobile Safari-sized viewports.

Any added/updated tests
No tests were added because this is a scoped SCSS layout fix. Validation run:

- `source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn lint`
- `source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn run build`
- `source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx`
- `source ~/.nvm/nvm.sh && nvm use && COREPACK_ENABLE_AUTO_PIN=0 yarn test:no-watch`
- `rg -o "grid-template-columns:52px 104px minmax\(0,1fr\)" build/static/css -S`

Lint passed. Build passed with existing warnings. Targeted profile rating tests passed. The full test command was run and still fails in unrelated work and wallet suites outside this SCSS change. A watcher-based local dev server check was attempted but the machine hit the existing `ENOSPC` file watcher limit; the production bundle was served statically and the generated CSS was verified to include the intended mobile grid rule.
