### PR TITLE
PM-5349: allow Talent Managers to access Talent tab

### DIFF
--- a/src/apps/reports/src/lib/components/NavTabs/NavTabs.tsx
+++ b/src/apps/reports/src/lib/components/NavTabs/NavTabs.tsx
@@ -15,7 +15,6 @@ import classNames from 'classnames'
 
 import { useClickOutside } from '~/libs/shared/lib/hooks'
 import { TabsNavItem } from '~/libs/ui'
-import { UserRole } from '~/libs/core'
 
 import {
     billingAccountsPageRouteId,
@@ -24,6 +23,7 @@ import {
     talentPageRouteId,
 } from '../../../config/routes.config'
 import { ReportsAppContext, ReportsAppContextModel } from '../../contexts'
+import { canAccessTalentReport } from '../../utils'
 
 import styles from './NavTabs.module.scss'
 
@@ -33,8 +33,8 @@ const NavTabs: FC = () => {
     const triggerRef = useRef<HTMLDivElement>(null)
     const { pathname }: { pathname: string } = useLocation()
     const { loginUserInfo }: ReportsAppContextModel = useContext(ReportsAppContext)
-    const isAdministrator = useMemo(() => (
-        !!loginUserInfo?.roles?.some(role => role.toLowerCase() === UserRole.administrator)
+    const canAccessTalent = useMemo(() => (
+        canAccessTalentReport(loginUserInfo?.roles)
     ), [loginUserInfo])
 
     const tabs = useMemo<TabsNavItem[]>(() => {
@@ -53,7 +53,7 @@ const NavTabs: FC = () => {
             },
         ]
 
-        return isAdministrator
+        return canAccessTalent
             ? [
                 ...baseTabs,
                 {
@@ -62,7 +62,7 @@ const NavTabs: FC = () => {
                 },
             ]
             : baseTabs
-    }, [isAdministrator])
+    }, [canAccessTalent])
 
     const activeTabPathName: string = useMemo<string>(() => {
         const matchingTabs = tabs

--- a/src/apps/reports/src/lib/utils/index.ts
+++ b/src/apps/reports/src/lib/utils/index.ts
@@ -1,5 +1,7 @@
 import { toast } from 'react-toastify'
 
+export { canAccessTalentReport } from './talent-access.utils'
+
 /**
  * Handles API errors by extracting the most useful message and showing a toast.
  * @param error Axios error-like object.

--- a/src/apps/reports/src/lib/utils/talent-access.utils.spec.ts
+++ b/src/apps/reports/src/lib/utils/talent-access.utils.spec.ts
@@ -1,0 +1,17 @@
+import { canAccessTalentReport } from './talent-access.utils'
+
+describe('talent-access utils', () => {
+    it('allows administrators and Talent Managers to access the Talent report', () => {
+        expect(canAccessTalentReport(['administrator']))
+            .toBe(true)
+        expect(canAccessTalentReport([' Talent Manager ']))
+            .toBe(true)
+    })
+
+    it('denies users without a Talent report role', () => {
+        expect(canAccessTalentReport(['Topcoder User']))
+            .toBe(false)
+        expect(canAccessTalentReport(undefined))
+            .toBe(false)
+    })
+})

--- a/src/apps/reports/src/lib/utils/talent-access.utils.ts
+++ b/src/apps/reports/src/lib/utils/talent-access.utils.ts
@@ -1,0 +1,14 @@
+const talentReportRoles = new Set<string>([
+    'administrator',
+    'talent manager',
+])
+
+/**
+ * Checks whether a user role list can access the reports Talent tab.
+ * @param roles Roles from the authenticated Topcoder profile or decoded token.
+ * @returns Whether the user is an administrator or Talent Manager.
+ */
+export function canAccessTalentReport(roles?: string[]): boolean {
+    return !!roles?.some(role => talentReportRoles.has(role.trim()
+        .toLowerCase()))
+}

--- a/src/apps/reports/src/pages/talent/TalentPage.tsx
+++ b/src/apps/reports/src/pages/talent/TalentPage.tsx
@@ -13,7 +13,6 @@ import { Navigate } from 'react-router-dom'
 import { EnvironmentConfig } from '~/config'
 import { ReportsAppContext, ReportsAppContextModel } from '~/apps/reports/src/lib'
 import { Pagination } from '~/apps/admin/src/lib'
-import { UserRole } from '~/libs/core'
 import {
     Button,
     IconOutline,
@@ -30,7 +29,7 @@ import {
     OpenToWorkTalentResponse,
     OpenToWorkTalentRoleCount,
 } from '../../lib/services'
-import { handleError } from '../../lib/utils'
+import { canAccessTalentReport, handleError } from '../../lib/utils'
 import { reportsPageRouteId, rootRoute } from '../../config/routes.config'
 
 import {
@@ -77,15 +76,6 @@ const availabilityOptions: AvailabilityOption[] = [
 ]
 
 /**
- * Returns true when the loaded token belongs to an administrator.
- * @param roles Roles from the decoded Topcoder token.
- * @returns Whether the role list includes the administrator role.
- */
-function hasAdministratorRole(roles?: string[]): boolean {
-    return !!roles?.some(role => role.toLowerCase() === UserRole.administrator)
-}
-
-/**
  * Builds the conic-gradient background used by the role summary chart.
  * @param segments Role count segments with colors and percentages.
  * @returns CSS background value for the donut chart.
@@ -121,7 +111,7 @@ function formatMemberName(member: OpenToWorkTalentMember): string {
 }
 
 /**
- * Admin-only Talent report page for open-to-work members.
+ * Administrator and Talent Manager report page for open-to-work members.
  *
  * It fetches preferred-role aggregates, renders a role-filterable member list,
  * and downloads the matching CSV export from reports-api.
@@ -130,7 +120,7 @@ function formatMemberName(member: OpenToWorkTalentMember): string {
 const TalentPage: FC = () => {
     const { loginUserInfo }: ReportsAppContextModel = useContext(ReportsAppContext)
     const isAuthLoaded = loginUserInfo !== undefined
-    const isAdministrator = hasAdministratorRole(loginUserInfo?.roles)
+    const canAccessTalent = canAccessTalentReport(loginUserInfo?.roles)
 
     const [selectedRole, setSelectedRole] = useState<string | undefined>(undefined)
     const [availability, setAvailability] = useState<OpenToWorkTalentAvailability | undefined>(undefined)
@@ -166,7 +156,7 @@ const TalentPage: FC = () => {
     } members`
 
     useEffect(() => {
-        if (!isAdministrator) {
+        if (!canAccessTalent) {
             return undefined
         }
 
@@ -194,7 +184,7 @@ const TalentPage: FC = () => {
         return () => {
             cancelled = true
         }
-    }, [availability, isAdministrator, page, perPage, refreshKey, selectedRole])
+    }, [availability, canAccessTalent, page, perPage, refreshKey, selectedRole])
 
     useEffect(() => {
         if (page > totalPages) {
@@ -244,7 +234,7 @@ const TalentPage: FC = () => {
         }
     }, [availability, selectedRole])
 
-    if (isAuthLoaded && !isAdministrator) {
+    if (isAuthLoaded && !canAccessTalent) {
         return <Navigate to={reportsLandingRoute} replace />
     }
 


### PR DESCRIPTION
What was broken
QA reported that Talent Manager role users still could not access the new reports Talent page.

Root cause
The previous UI fix added app-level reports access for Talent Managers, but the Talent tab visibility and Talent page fetch/redirect gate still checked only for administrators.

What was changed
Added a shared Talent report access utility for administrator and Talent Manager roles. The reports nav and Talent page now use that utility so both roles can see and load the Talent report.

Any added/updated tests
Added talent-access.utils.spec.ts coverage for administrator, Talent Manager, and denied user roles.

Passed: source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch TalentPage.utils talent-access.utils
Passed: source ~/.nvm/nvm.sh && nvm use && yarn lint
Passed: source ~/.nvm/nvm.sh && nvm use && yarn run build
Ran: source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch. The full suite still has unrelated existing failures in work and wallet-admin tests outside the reports Talent change.
