### PR TITLE
PM-5245: Use persisted engagement payment splits

### DIFF
--- a/src/apps/engagements/src/lib/hooks/useTermsAgreementGate.ts
+++ b/src/apps/engagements/src/lib/hooks/useTermsAgreementGate.ts
@@ -8,7 +8,7 @@ import {
     getDocuSignUrl,
     getTermDetails,
 } from '../services'
-import { extractTermId } from '../utils'
+import { extractTermId, resolveStandardTermsConfig } from '../utils'
 
 type TermsConfig = {
     id: string
@@ -56,11 +56,15 @@ type TermsViewData = {
     isElectronicallyAgreeable: boolean
 }
 
-const TERMS_ID = extractTermId(EnvironmentConfig.TERMS_URL)
+const STANDARD_TERMS = resolveStandardTermsConfig(
+    EnvironmentConfig.DEFAULT_STANDARD_TERMS_UUID,
+    EnvironmentConfig.TERMS_URL,
+)
+const TERMS_ID = STANDARD_TERMS.id
 const NDA_TERMS_ID = extractTermId(EnvironmentConfig.NDA_TERMS_URL)
 
 const TERMS_CONFIG: TermsConfig[] = [
-    { id: TERMS_ID ?? '', label: 'Standard Topcoder Terms', url: EnvironmentConfig.TERMS_URL },
+    { id: TERMS_ID ?? '', label: 'Standard Topcoder Terms', url: STANDARD_TERMS.url },
     { id: NDA_TERMS_ID ?? '', label: 'Topcoder NDA', url: EnvironmentConfig.NDA_TERMS_URL },
 ].filter(term => term.id)
 

--- a/src/apps/engagements/src/lib/utils/terms.utils.spec.ts
+++ b/src/apps/engagements/src/lib/utils/terms.utils.spec.ts
@@ -1,0 +1,37 @@
+import {
+    extractTermId,
+    replaceTermIdInUrl,
+    resolveStandardTermsConfig,
+} from './terms.utils'
+
+describe('engagement terms utils', () => {
+    const OLD_TERMS_ID = '317cd8f9-d66c-4f2a-8774-63c612d99cd4'
+    const NEW_TERMS_ID = '0a507fb7-3fe0-402b-b121-1a24af4a9cf1'
+    const TERMS_URL = `https://www.topcoder-dev.com/challenges/terms/detail/${OLD_TERMS_ID}`
+
+    it('extracts the terms id from a terms detail URL', () => {
+        expect(extractTermId(TERMS_URL))
+            .toBe(OLD_TERMS_ID)
+    })
+
+    it('rewrites a terms detail URL with the configured term id', () => {
+        expect(replaceTermIdInUrl(TERMS_URL, NEW_TERMS_ID))
+            .toBe(`https://www.topcoder-dev.com/challenges/terms/detail/${NEW_TERMS_ID}`)
+    })
+
+    it('prefers the configured Standard Terms id over the fallback terms URL id', () => {
+        expect(resolveStandardTermsConfig(NEW_TERMS_ID, TERMS_URL))
+            .toEqual({
+                id: NEW_TERMS_ID,
+                url: `https://www.topcoder-dev.com/challenges/terms/detail/${NEW_TERMS_ID}`,
+            })
+    })
+
+    it('falls back to the terms URL id when no configured Standard Terms id is provided', () => {
+        expect(resolveStandardTermsConfig(undefined, TERMS_URL))
+            .toEqual({
+                id: OLD_TERMS_ID,
+                url: TERMS_URL,
+            })
+    })
+})

--- a/src/apps/engagements/src/lib/utils/terms.utils.ts
+++ b/src/apps/engagements/src/lib/utils/terms.utils.ts
@@ -1,3 +1,14 @@
+export type ResolvedTermsConfig = {
+    id?: string
+    url?: string
+}
+
+/**
+ * Extracts the trailing terms identifier from a terms detail URL or path.
+ *
+ * @param termsUrl - Full terms URL, relative path, or plain slash-delimited terms path.
+ * @returns The trailing terms identifier, or undefined when the input is empty.
+ */
 export const extractTermId = (termsUrl?: string): string | undefined => {
     if (!termsUrl) {
         return undefined
@@ -17,5 +28,70 @@ export const extractTermId = (termsUrl?: string): string | undefined => {
         const parts = trimmed.split('/')
             .filter(Boolean)
         return parts[parts.length - 1]
+    }
+}
+
+/**
+ * Rewrites an existing terms detail URL so it points at the supplied terms identifier.
+ *
+ * @param termsUrl - Current terms detail URL or path used as the URL template.
+ * @param termId - Terms identifier that should replace the trailing URL segment.
+ * @returns A terms detail URL for the supplied identifier, or the original URL when it cannot be rewritten.
+ */
+export const replaceTermIdInUrl = (
+    termsUrl?: string,
+    termId?: string,
+): string | undefined => {
+    const trimmedTermId = termId?.trim()
+    if (!termsUrl || !trimmedTermId) {
+        return termsUrl
+    }
+
+    const trimmedTermsUrl = termsUrl.trim()
+    if (!trimmedTermsUrl) {
+        return undefined
+    }
+
+    try {
+        const parsed = new URL(trimmedTermsUrl)
+        const parts = parsed.pathname.split('/')
+            .filter(Boolean)
+
+        if (parts.length === 0) {
+            return trimmedTermsUrl
+        }
+
+        parts[parts.length - 1] = trimmedTermId
+        parsed.pathname = `/${parts.join('/')}`
+        return parsed.toString()
+    } catch {
+        const parts = trimmedTermsUrl.split('/')
+            .filter(Boolean)
+
+        if (parts.length === 0) {
+            return trimmedTermsUrl
+        }
+
+        parts[parts.length - 1] = trimmedTermId
+        return parts.join('/')
+    }
+}
+
+/**
+ * Resolves the Standard Terms ID and detail URL used by engagement agreement checks.
+ *
+ * @param defaultStandardTermsId - Preferred Standard Terms UUID from environment configuration.
+ * @param termsUrl - Fallback Standard Terms detail URL.
+ * @returns The resolved Standard Terms identifier and a matching detail URL.
+ */
+export const resolveStandardTermsConfig = (
+    defaultStandardTermsId?: string,
+    termsUrl?: string,
+): ResolvedTermsConfig => {
+    const id = defaultStandardTermsId?.trim() || extractTermId(termsUrl)
+
+    return {
+        id,
+        url: replaceTermIdInUrl(termsUrl, id),
     }
 }

--- a/src/apps/engagements/src/pages/application-form/ApplicationFormPage.tsx
+++ b/src/apps/engagements/src/pages/application-form/ApplicationFormPage.tsx
@@ -19,7 +19,7 @@ import {
     getUserDataForApplication,
     updateUserDataForApplication,
 } from '../../lib/services'
-import { extractTermId } from '../../lib/utils'
+import { extractTermId, resolveStandardTermsConfig } from '../../lib/utils'
 import { rootRoute } from '../../engagements.routes'
 
 import type { ApplicationFormData, PrePopulatedUserData } from './application-form.types'
@@ -50,9 +50,14 @@ const getIsSubmitDisabled = (params: SubmitDisabledParams): boolean => (
     || (params.hasSubmitted && !params.isValid)
 )
 
+const STANDARD_TERMS = resolveStandardTermsConfig(
+    EnvironmentConfig.DEFAULT_STANDARD_TERMS_UUID,
+    EnvironmentConfig.TERMS_URL,
+)
+
 const TERMS_STATUS_CONFIG: TermsStatusConfig[] = [
     {
-        id: extractTermId(EnvironmentConfig.TERMS_URL) ?? '',
+        id: STANDARD_TERMS.id ?? '',
         label: 'Standard Topcoder Terms',
     },
     {

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx
@@ -377,6 +377,35 @@ describe('BillingAccountLineItemsModal', () => {
             )
     })
 
+    it('uses persisted engagement payment split amounts before deriving markup', () => {
+        renderModal({
+            ...baseBillingAccountDetails,
+            consumedAmounts: [
+                {
+                    amount: '762.66',
+                    challengeFee: '420.66',
+                    date: '2026-06-02T13:10:48.235Z',
+                    externalId: 'assignment-5245',
+                    externalName: 'Eng BA',
+                    externalType: 'ENGAGEMENT',
+                    paymentAmount: '342.00',
+                },
+            ],
+            consumedBudget: 762.66,
+            markup: 0.01226408,
+            totalBudgetRemaining: 237.34,
+        })
+
+        expect(screen.getByText('$342.00'))
+            .toBeTruthy()
+        expect(screen.getByText('$420.66'))
+            .toBeTruthy()
+        expect(screen.queryByText('$753.42'))
+            .toBeNull()
+        expect(screen.queryByText('$9.24'))
+            .toBeNull()
+    })
+
     it('builds engagement links from assignment-backed billing rows for copilot views', () => {
         mockedUseFetchEngagements.mockReturnValue({
             engagements: [

--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -371,10 +371,11 @@ function getConsumedChallengeFeeAmount(
  * @param displayAmount Member-payment amount selected for display.
  * @param billingAccountDetails Billing account detail payload containing hidden markup when available.
  * @param challengeDetailsById Hydrated challenge details, or `undefined` while loading.
- * @returns Persisted consumed challenge fee, calculated markup fee, or
+ * @returns Persisted engagement or consumed challenge fee, calculated markup fee, or
  * `undefined` when the fee cannot be derived.
- * @remarks Consumed challenge rows with an explicit member subtotal do not
- * need challenge markup hydration to show the correct fee.
+ * @remarks Engagement payment rows can expose the exact finance split.
+ * Consumed challenge rows with an explicit member subtotal do not need
+ * challenge markup hydration to show the correct fee.
  */
 function getLineItemChallengeFeeAmount(
     item: BillingAccountLineItem,
@@ -382,6 +383,10 @@ function getLineItemChallengeFeeAmount(
     billingAccountDetails: BillingAccountDetails,
     challengeDetailsById: ChallengeDetailsById | undefined,
 ): number | undefined {
+    if (item.externalType === 'ENGAGEMENT' && item.challengeFee !== undefined) {
+        return Number(item.challengeFee.toFixed(2))
+    }
+
     const consumedChallengeFeeAmount = getConsumedChallengeFeeAmount(item)
 
     if (consumedChallengeFeeAmount !== undefined) {
@@ -401,13 +406,18 @@ function getLineItemChallengeFeeAmount(
  * @param item Raw locked or consumed billing-account engagement line item.
  * @param billingAccountDetails Billing account detail payload containing markup when available.
  * @returns Member payment amount when it can be derived.
- * @remarks Engagement rows prefer API-provided member-payment amounts. When
- * only the billing-account charge is available, markup is removed once.
+ * @remarks Engagement rows prefer persisted finance payment amounts, then
+ * API-provided member-payment aliases. When only the billing-account charge
+ * is available, markup is removed once.
  */
 function getEngagementMemberPaymentAmount(
     item: BillingAccountLineItem,
     billingAccountDetails: BillingAccountDetails,
 ): number | undefined {
+    if (item.paymentAmount !== undefined) {
+        return item.paymentAmount
+    }
+
     if (item.memberPaymentAmount !== undefined) {
         return item.memberPaymentAmount
     }

--- a/src/apps/work/src/lib/services/billing-accounts.service.spec.ts
+++ b/src/apps/work/src/lib/services/billing-accounts.service.spec.ts
@@ -177,12 +177,14 @@ describe('combineBillingAccountLineItems', () => {
             budget: 2000,
             consumedAmounts: [
                 {
-                    amount: '75',
+                    amount: '762.66',
+                    challengeFee: '420.66',
                     date: '2026-02-12T00:00:00.000Z',
                     engagementId: 'engagement-300',
                     externalId: 'assignment-300',
                     externalName: 'Engagement Assignment',
                     externalType: 'ENGAGEMENT',
+                    paymentAmount: '342.00',
                 },
                 {
                     amount: '75',
@@ -192,7 +194,7 @@ describe('combineBillingAccountLineItems', () => {
                     externalType: 'ENGAGEMENT',
                 },
             ],
-            consumedBudget: 150,
+            consumedBudget: 837.66,
             id: 80001063,
             lockedAmounts: [
                 {
@@ -249,10 +251,12 @@ describe('combineBillingAccountLineItems', () => {
             .toHaveLength(2)
         expect(consumedRows[0])
             .toMatchObject({
+                challengeFee: 420.66,
                 date: '2026-02-12T00:00:00.000Z',
                 engagementId: 'engagement-300',
                 externalId: 'assignment-300',
                 externalType: 'ENGAGEMENT',
+                paymentAmount: 342,
                 status: 'consumed',
             })
         expect(consumedRows[1])

--- a/src/apps/work/src/lib/services/billing-accounts.service.ts
+++ b/src/apps/work/src/lib/services/billing-accounts.service.ts
@@ -25,12 +25,14 @@ export type BillingAccountExternalType = 'CHALLENGE' | 'ENGAGEMENT'
 export interface BillingAccountBudgetEntry {
     amount: number | string
     challengeId?: string
+    challengeFee?: number | string
     date: string
     engagementId?: string
     externalId?: string
     externalName: string | null
     externalType: BillingAccountExternalType
     memberPaymentAmount?: number | string
+    paymentAmount?: number | string
 }
 
 export type BillingAccountLockedAmount = BillingAccountBudgetEntry
@@ -40,12 +42,14 @@ export interface BillingAccountLineItem {
     id: string
     amount: number
     challengeId?: string
+    challengeFee?: number
     date: string
     engagementId?: string
     externalId?: string
     externalName?: string | null
     externalType: BillingAccountExternalType
     memberPaymentAmount?: number
+    paymentAmount?: number
     status: BillingAccountLineItemStatus
 }
 
@@ -170,8 +174,9 @@ function createLineItemKey(
  * @param index The entry index within its source bucket, used in the generated row key.
  * @returns A normalized line item with numeric amount, original date, display
  * fallback for nullable external names, optional canonical external id,
- * optional engagement id, optional legacy challenge id, optional copilot-safe
- * member payment amount, and a deterministic UI row key.
+ * optional engagement id, optional legacy challenge id, optional persisted
+ * payment split amounts, optional copilot-safe member payment amount, and a
+ * deterministic UI row key.
  */
 function createLineItem(
     status: BillingAccountLineItemStatus,
@@ -209,6 +214,18 @@ function createLineItem(
 
     if (Number.isFinite(memberPaymentAmount)) {
         lineItem.memberPaymentAmount = memberPaymentAmount
+    }
+
+    const paymentAmount = Number(item.paymentAmount)
+
+    if (Number.isFinite(paymentAmount)) {
+        lineItem.paymentAmount = paymentAmount
+    }
+
+    const challengeFee = Number(item.challengeFee)
+
+    if (Number.isFinite(challengeFee)) {
+        lineItem.challengeFee = challengeFee
     }
 
     return lineItem
@@ -257,10 +274,11 @@ export async function searchBillingAccounts(
  * Fetches a single billing account by its identifier.
  *
  * The detail payload includes budget totals plus locked and consumed external
- * entries with `amount`, optional copilot-safe `memberPaymentAmount`, `date`,
+ * entries with `amount`, optional persisted `paymentAmount` and
+ * `challengeFee`, optional copilot-safe `memberPaymentAmount`, `date`,
  * optional canonical `externalId`, optional `engagementId`, `externalType`,
- * and nullable `externalName`. Top-level `id` and `name` remain available
- * for lookup labels.
+ * and nullable `externalName`. Top-level `id` and `name` remain available for
+ * lookup labels.
  */
 export async function fetchBillingAccountById(
     billingAccountId: string,
@@ -285,8 +303,8 @@ export async function fetchBillingAccountById(
  *
  * @param details Billing account details containing locked and consumed entry arrays.
  * @returns Normalized line items with numeric amounts, optional engagement
- * ids, optional member payment amounts, API dates, external metadata,
- * status, and UI row keys.
+ * ids, optional persisted payment split amounts, optional member payment
+ * amounts, API dates, external metadata, status, and UI row keys.
  */
 export function combineBillingAccountLineItems(
     details: BillingAccountDetails,


### PR DESCRIPTION
What was broken
The billing account details modal could show the wrong member payment and challenge fee split for consumed engagement payments.

Root cause
Billing-account line item normalization dropped the finance paymentAmount and challengeFee fields, so engagement rows fell back to recalculating the split from billing-account markup.

What was changed
Preserved paymentAmount and challengeFee on billing-account line items and made engagement rows prefer those persisted finance values before deriving amounts from markup.

Any added/updated tests
Updated billing-account normalization coverage and added a modal regression test for a production-shaped engagement payment split.

Validation run:
- yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx src/apps/work/src/lib/services/billing-accounts.service.spec.ts passed.
- yarn lint passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch was run and failed in unrelated existing suites outside this change, including engagement-editor schema, PaymentFormModal, ReviewersField, ChallengePrizesField, and wallet-admin module/mocking failures.
