### PR TITLE
PM-5382: Clip profile avatar to circular mask

### DIFF
--- a/src/libs/shared/lib/components/profile-picture/ProfilePicture.module.scss
+++ b/src/libs/shared/lib/components/profile-picture/ProfilePicture.module.scss
@@ -7,6 +7,7 @@
     width: 100%;
     aspect-ratio: 1 / 1;
     border-radius: 50%;
+    clip-path: circle(50%);
     overflow: hidden;
 
     display: flex;


### PR DESCRIPTION
What was broken
On mobile profiles, a square backing layer could render behind the circular user avatar.

Root cause
The shared profile picture component relied on border-radius and overflow to mask its image/background layers. Mobile browser rendering could allow that square layer to remain visible outside the intended circular avatar.

What was changed
Added a circular clip-path to the shared ProfilePicture wrapper so its image, background layer, and border are clipped to the same circular boundary. The production build output includes both -webkit-clip-path and clip-path for the rule.

Any added/updated tests
No automated tests were added because this is a browser CSS clipping fix that Jest does not assert through layout/paint behavior.

Validation run:
- yarn lint: passed
- yarn run build: passed with existing warnings
- yarn test:no-watch --testPathPattern=src/apps/profiles: passed, 10 suites and 44 tests
- yarn test:no-watch: failed in unrelated work and wallet-admin suites already outside this CSS-only profile change; rerun confirmed 12 failed suites and 142 passed suites
