### PR TITLE
PM-5383: Show principal skills preview toggle

### DIFF
--- a/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.module.scss
+++ b/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.module.scss
@@ -53,6 +53,30 @@
     gap: $sp-2;
 }
 
+.principalSkillsToggle {
+    @include resetBtnStyle;
+
+    align-self: center;
+    color: $link-blue-dark;
+    cursor: pointer;
+    font-family: $font-roboto;
+    font-size: 12px;
+    line-height: 16px;
+    padding: $sp-2 0;
+    text-align: left;
+
+    &:hover {
+        color: darken($link-blue-dark, 5);
+        text-decoration: underline;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $link-blue-dark;
+        outline-offset: $sp-1;
+        border-radius: $sp-1;
+    }
+}
+
 .additionalSkillsWrap {
     display: flex;
     flex-direction: column;

--- a/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.spec.tsx
+++ b/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.spec.tsx
@@ -1,0 +1,168 @@
+/* eslint-disable import/first, import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+type TestSkill = {
+    category: {
+        id: string
+        name: string
+    }
+    displayMode: {
+        id: string
+        name: string
+    }
+    id: string
+    levels: Array<unknown>
+    name: string
+}
+
+jest.mock('~/libs/core', () => ({
+    getMemberSkillDetails: jest.fn(),
+    UserRole: {
+        administrator: 'administrator',
+        talentManager: 'talentManager',
+    },
+    UserSkillDisplayModes: {
+        additional: 'additional',
+        principal: 'principal',
+    },
+}), { virtual: true })
+
+jest.mock('~/libs/shared', () => {
+    const React = jest.requireActual('react')
+
+    return {
+        GroupedSkillsUI: (): JSX.Element => <div data-testid='grouped-skills' />,
+        HowSkillsWorkModal: (): JSX.Element => <div data-testid='how-skills-work-modal' />,
+        isSkillVerified: (): boolean => false,
+        SkillPill: (props: { skill: Pick<TestSkill, 'name'> }): JSX.Element => (
+            <span>{props.skill.name}</span>
+        ),
+        useLocalStorage: (_key: string, initialValue: unknown): [unknown, (value: unknown) => void] => (
+            React.useState(initialValue)
+        ),
+    }
+}, { virtual: true })
+
+jest.mock('~/libs/ui', () => ({
+    Button: (props: { label: string, onClick: () => void }): JSX.Element => (
+        <button type='button' onClick={props.onClick}>{props.label}</button>
+    ),
+    IconSolid: {
+        ChevronDownIcon: (): JSX.Element => <svg data-testid='chevron-down' />,
+        ChevronUpIcon: (): JSX.Element => <svg data-testid='chevron-up' />,
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('../../components', () => ({
+    AddButton: (props: { label: string, onClick: () => void }): JSX.Element => (
+        <button type='button' onClick={props.onClick}>{props.label}</button>
+    ),
+    EditMemberPropertyBtn: (props: { onClick: () => void }): JSX.Element => (
+        <button type='button' onClick={props.onClick}>Edit</button>
+    ),
+    EmptySection: (props: PropsWithChildren<{ title: string }>): JSX.Element => (
+        <section>
+            <h4>{props.title}</h4>
+            {props.children}
+        </section>
+    ),
+}))
+
+jest.mock('../MemberProfile.context', () => ({
+    useMemberProfileContext: (): { isTalentSearch: boolean } => ({
+        isTalentSearch: false,
+    }),
+}))
+
+jest.mock('./ModifySkillsModal', () => ({
+    ModifySkillsModal: (): JSX.Element => <div data-testid='modify-skills-modal' />,
+}))
+
+jest.mock('./PrincipalSkillsModal', () => ({
+    PrincipalSkillsModal: (): JSX.Element => <div data-testid='principal-skills-modal' />,
+}))
+
+import MemberSkillsInfo from './MemberSkillsInfo'
+
+/**
+ * Creates a principal UserSkill test fixture with stable IDs and display mode.
+ *
+ * @param name Display name for the skill.
+ * @param index Numeric suffix used to keep IDs deterministic.
+ * @returns A UserSkill fixture that can be rendered by MemberSkillsInfo.
+ * @throws This helper does not throw errors.
+ */
+function createPrincipalSkill(name: string, index: number): TestSkill {
+    return {
+        category: {
+            id: 'category-design',
+            name: 'Design',
+        },
+        displayMode: {
+            id: 'display-principal',
+            name: 'principal',
+        },
+        id: `skill-${index}`,
+        levels: [],
+        name,
+    }
+}
+
+describe('MemberSkillsInfo', () => {
+    it('shows five principal skills before expanding the remaining skills', () => {
+        const profile = {
+            handle: 'tester',
+            skills: [
+                'AI',
+                'BDD',
+                'BIOS',
+                'CAL',
+                'Documentation',
+                'NLP',
+                'Security Testing',
+            ].map(createPrincipalSkill),
+        }
+
+        render(
+            <MemoryRouter>
+                <MemberSkillsInfo
+                    authProfile={undefined}
+                    profile={profile as any}
+                    refreshProfile={jest.fn()}
+                />
+            </MemoryRouter>,
+        )
+
+        expect(screen.getByText('AI'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Documentation'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('NLP'))
+            .not
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '+ 2 more skills' }))
+            .toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: '+ 2 more skills' }))
+
+        expect(screen.getByText('NLP'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Security Testing'))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'See less' }))
+            .toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'See less' }))
+
+        expect(screen.queryByText('NLP'))
+            .not
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '+ 2 more skills' }))
+            .toBeInTheDocument()
+    })
+})

--- a/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.tsx
+++ b/src/apps/profiles/src/member-profile/skills/MemberSkillsInfo.tsx
@@ -15,6 +15,8 @@ import { ModifySkillsModal } from './ModifySkillsModal'
 import { PrincipalSkillsModal } from './PrincipalSkillsModal'
 import styles from './MemberSkillsInfo.module.scss'
 
+const COLLAPSED_PRINCIPAL_SKILL_COUNT = 5
+
 interface MemberSkillsInfoProps {
     profile: UserProfile
     authProfile: UserProfile | undefined
@@ -81,8 +83,14 @@ const MemberSkillsInfo: FC<MemberSkillsInfoProps> = (props: MemberSkillsInfoProp
         setIsAdditionalSkillsExpanded,
     ]: [boolean, Dispatch<SetStateAction<boolean>>] = useState<boolean>(false)
 
+    const [
+        isPrincipalSkillsExpanded,
+        setIsPrincipalSkillsExpanded,
+    ]: [boolean, Dispatch<SetStateAction<boolean>>] = useState<boolean>(false)
+
     useEffect(() => {
         setIsAdditionalSkillsExpanded(false)
+        setIsPrincipalSkillsExpanded(false)
     }, [props.profile.handle])
 
     useEffect(() => {
@@ -143,6 +151,16 @@ const MemberSkillsInfo: FC<MemberSkillsInfoProps> = (props: MemberSkillsInfoProp
     }
 
     /**
+     * Toggles Principal Skills between the five-skill preview and full list.
+     *
+     * Used by the Principal Skills more/less control on the member profile
+     * page. It takes no parameters, returns no value, and does not throw.
+     */
+    function handlePrincipalSkillsToggle(): void {
+        setIsPrincipalSkillsExpanded(isExpanded => !isExpanded)
+    }
+
+    /**
      * Toggles visibility for the Additional Skills section from the section arrow.
      *
      * Used by the Additional Skills header button to expand or collapse grouped
@@ -163,6 +181,14 @@ const MemberSkillsInfo: FC<MemberSkillsInfoProps> = (props: MemberSkillsInfoProp
 
             throw e
         }), [props.profile.handle])
+
+    const visiblePrincipalSkills: UserSkill[] = isPrincipalSkillsExpanded
+        ? principalSkills
+        : principalSkills.slice(0, COLLAPSED_PRINCIPAL_SKILL_COUNT)
+    const hiddenPrincipalSkillCount: number = Math.max(
+        principalSkills.length - COLLAPSED_PRINCIPAL_SKILL_COUNT,
+        0,
+    )
 
     return (
         <div className={styles.container}>
@@ -202,7 +228,7 @@ const MemberSkillsInfo: FC<MemberSkillsInfoProps> = (props: MemberSkillsInfoProp
                             Principal Skills
                         </div>
                         <div className={styles.principalSkills}>
-                            {principalSkills.map((skill: UserSkill) => (
+                            {visiblePrincipalSkills.map((skill: UserSkill) => (
                                 <SkillPill
                                     skill={skill}
                                     key={skill.id}
@@ -210,6 +236,17 @@ const MemberSkillsInfo: FC<MemberSkillsInfoProps> = (props: MemberSkillsInfoProp
                                     fetchSkillDetails={canFetchSkillDetails ? fetchSkillDetails : undefined}
                                 />
                             ))}
+                            {hiddenPrincipalSkillCount > 0 && (
+                                <button
+                                    type='button'
+                                    className={styles.principalSkillsToggle}
+                                    onClick={handlePrincipalSkillsToggle}
+                                >
+                                    {isPrincipalSkillsExpanded
+                                        ? 'See less'
+                                        : `+ ${hiddenPrincipalSkillCount} more skills`}
+                                </button>
+                            )}
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
What was broken
The profile Principal Skills section rendered every principal skill immediately instead of matching the Figma behavior that shows only the first five skills with a + more skills control.

Root cause (if identifiable)
MemberSkillsInfo mapped over the full principal skills array and had no expanded or collapsed state for that section.

What was changed
Limited the default Principal Skills view to five skills, added a + N more skills toggle, added a See less state, and reset the expanded state when the viewed profile changes.

Any added/updated tests
Added MemberSkillsInfo coverage for the collapsed principal skills preview, expansion, and collapse behavior.

Validation run:
- yarn lint: passed
- yarn run build: passed with existing warning noise
- yarn test:no-watch -- MemberSkillsInfo: passed
- yarn test:no-watch -- src/apps/profiles: passed
- yarn test:no-watch: failed in unrelated work and wallet-admin suites outside this change
