### PR TITLE
PM-5385: Left align mobile role interest text

### DIFF
--- a/src/apps/profiles/src/member-profile/profile-header/ProfileHeader.module.scss
+++ b/src/apps/profiles/src/member-profile/profile-header/ProfileHeader.module.scss
@@ -187,10 +187,18 @@
     gap: $sp-4;
     align-items: end;
     max-width: 500px;
+
+    @include ltelg {
+        align-items: flex-start;
+    }
 }
 
 .openToWorkSummary {
     text-align: right;
+
+    @include ltelg {
+        text-align: left;
+    }
 }
 
 .roleText {


### PR DESCRIPTION
What was broken
The profile header's interested-in full-time or part-time roles summary stayed visually right aligned on mobile, so the text appeared offset instead of left aligned under the status area.

Root cause
The status summary container and paragraph used right alignment styles without a mobile breakpoint override.

What was changed
Added mobile breakpoint overrides to left-align the status summary container and the interested-in roles text on mobile while preserving the existing desktop right alignment.

Any added/updated tests
No tests were added for this CSS-only layout adjustment.

Validation run:
- `yarn lint` passed.
- `yarn test:no-watch src/apps/profiles` passed: 10 suites, 44 tests.
- `yarn run build` passed with existing warnings.
- `yarn test:no-watch` was run for the full repository but failed in unrelated `work` and `wallet-admin` suites that are outside this profile header change.
