### PR TITLE
PM-5386: Update profile rating percentile display

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.module.scss
@@ -56,6 +56,7 @@
             .percentileValue {
                 background: rgba($tc-white, 0.06);
                 border-radius: 2px;
+                color: $tc-white;
                 font-family: $font-roboto;
                 font-size: 14px;
                 font-weight: $font-weight-bold;

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
@@ -119,6 +119,9 @@ describe('MemberRatingCard', () => {
             .toBeInTheDocument()
         expect(screen.getByText('Top 70%'))
             .toBeInTheDocument()
+        expect(screen.getByText('Top 70%'))
+            .not
+            .toHaveAttribute('style')
         expect(screen.getByText('Data Scientists'))
             .toBeInTheDocument()
     })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -175,7 +175,6 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
                             >
                                 <p
                                     className={classNames(styles.value, styles.percentileValue)}
-                                    style={{ color: compactRatingColor }}
                                 >
                                     {percentileLabel}
                                 </p>

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -134,6 +134,7 @@
 }
 
 .positionValue {
+    color: $black-100;
     font-family: $font-barlow-condensed;
     font-size: 32px;
     font-weight: $font-weight-medium;
@@ -147,20 +148,6 @@
     font-family: $font-roboto;
     font-size: 12px;
     line-height: 16px;
-}
-
-.tierPyramid {
-    align-items: center;
-    display: flex;
-    flex: 0 0 76px;
-    justify-content: center;
-    min-width: 0;
-}
-
-.tierPyramidSvg {
-    display: block;
-    height: 69px;
-    width: 76px;
 }
 
 .sectionTitle {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
 import type { PropsWithChildren } from 'react'
-import type { RenderResult } from '@testing-library/react'
 import { render, screen, within } from '@testing-library/react'
 
 import type { UserProfile } from '~/libs/core'
@@ -27,11 +26,6 @@ const ratingDistribution = {
     track: 'DATA_SCIENCE',
     updatedAt: '2026-06-04T00:00:00.000Z',
     updatedBy: 'test',
-}
-
-function getPyramidFills(container: HTMLElement): string[] {
-    return Array.from(container.querySelectorAll('polygon'))
-        .map((polygon: Element) => polygon.getAttribute('fill') ?? '')
 }
 
 jest.mock('~/libs/core', () => ({
@@ -62,7 +56,7 @@ jest.mock('../../../../lib', () => ({
 }))
 
 describe('MemberRatingInfoModal', () => {
-    it('keeps the pyramid graphic in the position summary cell', () => {
+    it('renders the position summary without the pyramid graphic', () => {
         render(
             <MemberRatingInfoModal
                 audienceLabel='developers'
@@ -82,39 +76,14 @@ describe('MemberRatingInfoModal', () => {
         expect(within(positionSummary)
             .getByText(/TOP\s+15%/))
             .toBeInTheDocument()
+        expect(within(positionSummary)
+            .getByText(/TOP\s+15%/))
+            .not
+            .toHaveAttribute('style')
         expect(positionSummary.querySelector('svg'))
+            .not
             .toBeInTheDocument()
         expect(screen.getByText('Where Emily ranks in the distribution'))
             .toBeInTheDocument()
-    })
-
-    it('highlights pyramid segments from top percentile buckets', () => {
-        const rendered: RenderResult = render(
-            <MemberRatingInfoModal
-                audienceLabel='developers'
-                onClose={jest.fn()}
-                percentile={8}
-                profile={baseProfile}
-                rating={1200}
-                ratingDistribution={ratingDistribution}
-            />,
-        )
-
-        expect(getPyramidFills(rendered.container))
-            .toEqual(['#616BD5', '#D4D4D4', '#D4D4D4', '#D4D4D4', '#D4D4D4'])
-
-        rendered.rerender(
-            <MemberRatingInfoModal
-                audienceLabel='developers'
-                onClose={jest.fn()}
-                percentile={59}
-                profile={baseProfile}
-                rating={1200}
-                ratingDistribution={ratingDistribution}
-            />,
-        )
-
-        expect(getPyramidFills(rendered.container))
-            .toEqual(['#D4D4D4', '#D4D4D4', '#D4D4D4', '#616BD5', '#D4D4D4'])
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -35,11 +35,6 @@ interface RatingTier {
     tierLabel: string
 }
 
-interface PyramidTierShape {
-    points: string
-    tierId: string
-}
-
 const ratingTiers: RatingTier[] = [{
     color: '#555555',
     end: 899,
@@ -103,23 +98,6 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
     value: 2200,
 }]
 
-const pyramidTierShapes: PyramidTierShape[] = [{
-    points: '50 0 60 16 40 16',
-    tierId: 'elite',
-}, {
-    points: '36 21 64 21 70 34 30 34',
-    tierId: 'advanced',
-}, {
-    points: '29 39 71 39 78 52 22 52',
-    tierId: 'skilled',
-}, {
-    points: '20 57 80 57 88 70 12 70',
-    tierId: 'intermediate',
-}, {
-    points: '12 75 88 75 100 91 0 91',
-    tierId: 'beginner',
-}]
-
 /**
  * Formats percentile values for the rating comparison modal.
  *
@@ -137,7 +115,7 @@ const formatPercentile = (percentile?: number): string => (
 /**
  * Returns the Topcoder rating tier metadata for a rating.
  *
- * Used by MemberRatingInfoModal to color the summary, histogram, pyramid, and legend.
+ * Used by MemberRatingInfoModal to color the summary, histogram, and legend.
  *
  * @param {number | undefined} rating - The member rating value or a rating range start.
  * @returns {RatingTier} The tier metadata that matches the rating.
@@ -161,39 +139,6 @@ const getRatingTier = (rating?: number): RatingTier => (
 const getRatingTierName = (rating?: number): string => (
     rating === undefined ? 'Unrated' : getRatingTier(rating).tierLabel
 )
-
-/**
- * Returns the pyramid tier that represents a member's top percentile.
- *
- * Used by MemberRatingInfoModal to place the highlighted pyramid segment by position instead of
- * rating range: top 10%, top 25%, top 50%, top 75%, then everyone else.
- *
- * @param {number | undefined} percentile - The member's top percentile in the selected audience.
- * @returns {RatingTier | undefined} The pyramid tier for the percentile, or undefined without a usable percentile.
- */
-const getPyramidTierByPercentile = (percentile?: number): RatingTier | undefined => {
-    if (percentile === undefined || !Number.isFinite(percentile)) {
-        return undefined
-    }
-
-    if (percentile <= 10) {
-        return ratingTiers[4]
-    }
-
-    if (percentile <= 25) {
-        return ratingTiers[3]
-    }
-
-    if (percentile <= 50) {
-        return ratingTiers[2]
-    }
-
-    if (percentile <= 75) {
-        return ratingTiers[1]
-    }
-
-    return ratingTiers[0]
-}
 
 /**
  * Parses the API distribution payload into ordered rating ranges.
@@ -313,7 +258,6 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const titleDisplayName: string = displayName
         .toUpperCase()
     const selectedRatingTier: RatingTier = getRatingTier(props.rating)
-    const selectedPyramidTier: RatingTier = getPyramidTierByPercentile(props.percentile) ?? selectedRatingTier
     const distributionRanges: RatingDistributionRange[] = useMemo(() => (
         getDistributionRanges(props.ratingDistribution?.distribution)
     ), [props.ratingDistribution])
@@ -365,33 +309,9 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                         className={classNames(styles.summaryMetric, styles.positionMetric)}
                         data-testid='rating-position-summary'
                     >
-                        <div className={styles.tierPyramid} aria-hidden='true'>
-                            <svg
-                                className={styles.tierPyramidSvg}
-                                viewBox='0 0 100 91'
-                                focusable='false'
-                            >
-                                {pyramidTierShapes.map((shape: PyramidTierShape) => {
-                                    const tier = ratingTiers.find((ratingTier: RatingTier) => (
-                                        ratingTier.id === shape.tierId
-                                    )) ?? ratingTiers[0]
-
-                                    return (
-                                        <polygon
-                                            key={shape.tierId}
-                                            points={shape.points}
-                                            fill={tier.id === selectedPyramidTier.id
-                                                ? selectedRatingTier.color
-                                                : '#D4D4D4'}
-                                        />
-                                    )
-                                })}
-                            </svg>
-                        </div>
-
                         <div className={styles.positionDetails}>
                             <span className={styles.summaryLabel}>Position</span>
-                            <span className={styles.positionValue} style={{ color: getRatingColor(props.rating) }}>
+                            <span className={styles.positionValue}>
                                 TOP
                                 {' '}
                                 {percentileLabel}


### PR DESCRIPTION
What was broken
The profile rating percentile reused the absolute rating color in both the compact card and comparison popup, even though the percentile is based on members per track rather than the absolute rating. The popup also still showed a small pyramid graphic that no longer matched the updated design.

Root cause (if identifiable)
The compact percentile and popup position value inherited the same rating-color styling used for absolute rating values, and the popup still rendered percentile-pyramid markup from the previous design.

What was changed
Kept the compact rating value color tied to rating, made the compact Top X% badge white, made the popup position value use the default black text color, and removed the popup pyramid markup and styles.

Any added/updated tests
Updated MemberRatingCard and MemberRatingInfoModal tests to verify the percentile text is not rating-colored inline and that the popup no longer renders the pyramid graphic.

Validation
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
- source ~/.nvm/nvm.sh && nvm use && yarn lint
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch (fails in unrelated work and wallet-admin suites already outside this profile change)
- source ~/.nvm/nvm.sh && nvm use && yarn run build
