### PR TITLE
PM-5387: Show highest profile rating

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -19,8 +19,8 @@ import {
     calculateTopPercentileFromDistribution,
     formatTopPercentile,
     getCompactRatingColor,
-    getLatestProfileRating,
     getPreferredRolesDisplay,
+    getProfileRating,
     getRatingAudienceLabel,
     getRatingDistributionQuery,
     parsePreferredRolesText,
@@ -38,7 +38,7 @@ interface MemberRatingCardProps {
 
 const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProps) => {
     const memberStats: UserStats | undefined = useMemberStats(props.profile.handle)
-    const rating: number | undefined = useMemo(() => getLatestProfileRating(memberStats), [memberStats])
+    const rating: number | undefined = useMemo(() => getProfileRating(memberStats), [memberStats])
     const compactRatingColor: string = getCompactRatingColor(rating, getRatingColor(rating))
 
     const [isInfoModalOpen, setIsInfoModalOpen]: [boolean, Dispatch<SetStateAction<boolean>>] = useState(false)

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -4,8 +4,8 @@ import {
     calculateTopPercentileFromDistribution,
     formatTopPercentile,
     getCompactRatingColor,
-    getLatestProfileRating,
     getPreferredRolesDisplay,
+    getProfileRating,
     getRatingAudienceLabel,
     getRatingDistributionQuery,
     parsePreferredRolesText,
@@ -29,41 +29,38 @@ describe('getCompactRatingColor', () => {
     })
 })
 
-describe('getLatestProfileRating', () => {
-    it('uses the newest rated track instead of the historical max rating', () => {
-        expect(getLatestProfileRating({
+describe('getProfileRating', () => {
+    it('uses the highest rated track instead of the newest lower rating', () => {
+        expect(getProfileRating({
             DATA_SCIENCE: {
                 'AI Engineering': {
                     mostRecentEventDate: 1000,
                     rank: {
-                        rating: 840,
+                        rating: 1200,
+                    },
+                },
+                Challenge: {
+                    mostRecentEventDate: 2000,
+                    rank: {
+                        rating: 732,
                     },
                 },
             },
-            DEVELOP: {
-                subTracks: [{
-                    mostRecentEventDate: 2000,
-                    name: 'Challenge',
-                    rank: {
-                        rating: 748,
-                    },
-                }],
-            },
             maxRating: {
-                rating: 840,
-                ratingColor: '#9D9FA0',
+                rating: 1200,
+                ratingColor: '#616BD5',
                 subTrack: 'AI Engineering',
                 track: 'DATA_SCIENCE',
             },
         } as unknown as UserStats))
-            .toBe(748)
+            .toBe(1200)
     })
 
-    it('uses configured data science rating paths when they are newest', () => {
-        expect(getLatestProfileRating({
+    it('uses configured data science rating paths when they are highest', () => {
+        expect(getProfileRating({
             DATA_SCIENCE: {
                 AI: {
-                    mostRecentEventDate: 2000,
+                    mostRecentEventDate: 1000,
                     rank: {
                         rating: 840,
                     },
@@ -71,7 +68,7 @@ describe('getLatestProfileRating', () => {
             },
             DEVELOP: {
                 subTracks: [{
-                    mostRecentEventDate: 1000,
+                    mostRecentEventDate: 2000,
                     name: 'Challenge',
                     rank: {
                         rating: 748,
@@ -89,7 +86,7 @@ describe('getLatestProfileRating', () => {
     })
 
     it('falls back to maxRating when no rated track entries are available', () => {
-        expect(getLatestProfileRating({
+        expect(getProfileRating({
             DEVELOP: {
                 subTracks: [{
                     mostRecentEventDate: 2000,
@@ -200,7 +197,7 @@ describe('getRatingAudienceLabel', () => {
             .toBe('QA Professionals')
     })
 
-    it('uses the latest rating track for the audience label', () => {
+    it('uses the highest rating track for the audience label', () => {
         expect(getRatingAudienceLabel({
             DATA_SCIENCE: {
                 SRM: {
@@ -226,7 +223,7 @@ describe('getRatingAudienceLabel', () => {
                 track: 'DATA_SCIENCE',
             },
         } as unknown as UserStats))
-            .toBe('Developers')
+            .toBe('Data Scientists')
     })
 })
 
@@ -246,7 +243,7 @@ describe('getRatingDistributionQuery', () => {
             })
     })
 
-    it('uses the latest rating track and subtrack for distribution lookup', () => {
+    it('uses the highest rating track and subtrack for distribution lookup', () => {
         expect(getRatingDistributionQuery({
             DATA_SCIENCE: {
                 SRM: {
@@ -273,8 +270,8 @@ describe('getRatingDistributionQuery', () => {
             },
         } as unknown as UserStats))
             .toEqual({
-                subTrack: 'Challenge',
-                track: 'DEVELOP',
+                subTrack: 'SRM',
+                track: 'DATA_SCIENCE',
             })
     })
 

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -341,7 +341,7 @@ const getAIEngineeringRatingCandidates = (memberStats?: UserStats): RatingCandid
 }
 
 /**
- * Builds the fallback rating candidate from the historical maximum rating payload.
+ * Builds a rating candidate from the API maxRating payload.
  *
  * @param {UserStats | undefined} memberStats - Raw member stats for the profile user.
  * @returns {RatingCandidate | undefined} Max rating candidate when enough metadata is available.
@@ -363,41 +363,48 @@ const getMaxRatingCandidate = (memberStats?: UserStats): RatingCandidate | undef
 }
 
 /**
- * Returns the latest rated track candidate used by the compact rating card.
+ * Returns the highest rated track candidate used by the compact rating card.
  *
  * @param {UserStats | undefined} memberStats - Raw member stats for the profile user.
- * @returns {RatingCandidate | undefined} Latest current rating candidate, or max rating fallback.
+ * @returns {RatingCandidate | undefined} Highest current rating candidate, with event date as a tie-breaker.
  */
-const getLatestProfileRatingCandidate = (memberStats?: UserStats): RatingCandidate | undefined => {
+const getProfileRatingCandidate = (memberStats?: UserStats): RatingCandidate | undefined => {
     const candidates: RatingCandidate[] = [
+        getMaxRatingCandidate(memberStats),
         ...getSubTrackRatingCandidates('DEVELOP', memberStats?.DEVELOP?.subTracks),
         ...getSubTrackRatingCandidates('DESIGN', memberStats?.DESIGN?.subTracks),
         ...getDataScienceRatingCandidates(memberStats?.DATA_SCIENCE),
         ...getAIEngineeringRatingCandidates(memberStats),
-    ]
+    ].filter((candidate: RatingCandidate | undefined): candidate is RatingCandidate => candidate !== undefined)
 
-    const latestCandidate: RatingCandidate | undefined = candidates.reduce((
-        latest: RatingCandidate | undefined,
+    return candidates.reduce((
+        highest: RatingCandidate | undefined,
         candidate: RatingCandidate,
-    ) => (
-        latest === undefined || candidate.ratingDate > latest.ratingDate ? candidate : latest
-    ), undefined)
+    ) => {
+        if (
+            highest === undefined
+            || candidate.rating > highest.rating
+            || (candidate.rating === highest.rating && candidate.ratingDate > highest.ratingDate)
+        ) {
+            return candidate
+        }
 
-    return latestCandidate ?? getMaxRatingCandidate(memberStats)
+        return highest
+    }, undefined)
 }
 
 /**
  * Returns the rating that should be shown on the compact profile rating card.
  *
- * The card should show the latest current rating from the user's rated tracks,
- * not the historical maximum rating. `maxRating` is used only as a fallback
- * when the stats payload does not include any rated track entries.
+ * The card should show the highest current rating from the user's rated tracks.
+ * The API `maxRating` payload participates in selection so the compact card
+ * stays aligned with the stats response, while rating event date only breaks ties.
  *
  * @param {UserStats | undefined} memberStats - Raw member stats for the profile user.
- * @returns {number | undefined} Latest current rating, or the max rating fallback when no track rating exists.
+ * @returns {number | undefined} Highest current rating when available.
  */
-export const getLatestProfileRating = (memberStats?: UserStats): number | undefined => (
-    getLatestProfileRatingCandidate(memberStats)?.rating
+export const getProfileRating = (memberStats?: UserStats): number | undefined => (
+    getProfileRatingCandidate(memberStats)?.rating
 )
 
 /**
@@ -418,7 +425,7 @@ const isAIEngineeringRatingCandidate = (ratingCandidate: RatingCandidate): boole
  * @returns {RatingDistributionQuery | undefined} The API query for rating distribution data.
  */
 export const getRatingDistributionQuery = (memberStats?: UserStats): RatingDistributionQuery | undefined => {
-    const ratingCandidate = getLatestProfileRatingCandidate(memberStats)
+    const ratingCandidate = getProfileRatingCandidate(memberStats)
 
     if (!ratingCandidate) {
         return undefined
@@ -444,7 +451,7 @@ export const getRatingDistributionQuery = (memberStats?: UserStats): RatingDistr
  * @returns {string} The broad track audience label for the rating card and modal.
  */
 export const getRatingAudienceLabel = (memberStats?: UserStats): string => {
-    const ratingCandidate = getLatestProfileRatingCandidate(memberStats)
+    const ratingCandidate = getProfileRatingCandidate(memberStats)
     const normalizedTrack = normalizeTrackToken(ratingCandidate?.track)
     const normalizedSubTrack = normalizeTrackToken(ratingCandidate?.subTrack)
 


### PR DESCRIPTION
What was broken
The compact profile rating card selected the newest rated track candidate, so a newer lower Data Science rating could appear while a higher AI Engineering rating from stats/maxRating was available.

Root cause (if identifiable)
The profile card treated event date as the primary selector and only used maxRating as a fallback when no track ratings were found.

What was changed
Changed the selector to include API maxRating and all rated tracks, choose the highest rating, and use event date only to break ties. Updated the card to call the renamed getProfileRating helper.

Any added/updated tests
Updated MemberRatingCard.utils tests to cover a higher AI Engineering rating beating a newer lower Data Science rating, and adjusted distribution/audience expectations for highest-rating selection.

Validation run:
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts: passed
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx: passed
- yarn test:no-watch --runInBand src/apps/profiles: passed
- yarn lint: passed
- yarn run build: passed with existing warnings
- yarn test:no-watch --runInBand: failed in unrelated wallet-admin, work, and engagements suites outside this change
