### PR TITLE
PM-5221: show Data Science challenges as Code stats

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/DevelopTrackView/DevelopTrackView.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/DevelopTrackView/DevelopTrackView.tsx
@@ -24,11 +24,13 @@ const DevelopTrackView: FC<DevelopTrackViewProps> = props => {
         'First2Finish',
         'DESIGN_FIRST_2_FINISH',
     ].includes(trackName), [trackName])
+    const statsDistributionTrack = props.trackData.statsDistributionTrack ?? props.trackData.parentTrack
+    const statsDistributionSubTrack = props.trackData.statsDistributionSubTrack ?? trackName
 
     const ratingDistribution: UserStatsDistributionResponse | undefined = useStatsDistribution(
         isDesignTrack ? undefined : {
-            subTrack: trackName,
-            track: props.trackData.parentTrack,
+            subTrack: statsDistributionSubTrack,
+            track: statsDistributionTrack,
         },
     )
 

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -74,7 +74,7 @@ describe('getActiveTracks', () => {
             .toEqual(['Challenge', 'Task'])
     })
 
-    it('includes Data Science Challenge stats in the Data Science track', () => {
+    it('shows Data Science Challenge stats under the Development Code subtrack', () => {
         const activeTracks: MemberStatsTrack[] = getActiveTracks({
             DATA_SCIENCE: {
                 Challenge: {
@@ -96,15 +96,34 @@ describe('getActiveTracks', () => {
         } as UserStats)
         const dataScienceTrack: MemberStatsTrack | undefined = activeTracks
             .find(track => track.name === 'Data Science')
+        const developmentTrack: MemberStatsTrack | undefined = activeTracks
+            .find(track => track.name === 'Development')
+        const codeSubTrack = developmentTrack?.subTracks
+            .find(track => track.name === 'CODE')
 
         expect(dataScienceTrack?.challenges)
-            .toEqual(2)
-        expect(dataScienceTrack?.wins)
             .toEqual(1)
         expect(dataScienceTrack?.rating)
-            .toEqual(1499)
+            .toEqual(763)
         expect(dataScienceTrack?.subTracks.map(track => track.name))
-            .toEqual(['Challenge', 'MARATHON_MATCH'])
+            .toEqual(['MARATHON_MATCH'])
+        expect(developmentTrack?.challenges)
+            .toEqual(1)
+        expect(developmentTrack?.wins)
+            .toEqual(1)
+        expect(developmentTrack?.subTracks.map(track => track.name))
+            .toEqual(['CODE'])
+        expect(codeSubTrack)
+            .toEqual(expect.objectContaining({
+                historyPaths: ['DATA_SCIENCE.Challenge.history'],
+                name: 'CODE',
+                parentTrack: 'DEVELOP',
+                path: 'DEVELOP.subTracks',
+                statsDistributionSubTrack: 'Challenge',
+                statsDistributionTrack: 'DATA_SCIENCE',
+            }))
+        expect(codeSubTrack?.rank?.rating)
+            .toEqual(1499)
         expect(activeTracks.map(track => track.name))
             .not.toContain('Challenge')
     })

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -29,6 +29,8 @@ const nativeDataScienceStatsKeys = new Set([
     'wins',
 ])
 
+const dataScienceChallengeCodeHistoryPath = 'DATA_SCIENCE.Challenge.history'
+
 /**
  * The structure of a track for a member.
  */
@@ -66,9 +68,8 @@ export const getSubTrackSubmissionCount = (subTrack?: MemberStats): number | und
 /**
  * Determine whether the subtrack should be considered active.
  *
- * Unified member stats do not currently include legacy submission counters for
- * development/design rows, so fall back to the challenge count when the
- * submission count is unavailable.
+ * Some rated Code rows can have zero submissions while still having challenge
+ * history, so challenge count also keeps the subtrack visible.
  *
  * @param {MemberStats | undefined} subTrack - The subtrack to inspect.
  * @returns {boolean} Whether the subtrack has activity worth rendering.
@@ -76,7 +77,7 @@ export const getSubTrackSubmissionCount = (subTrack?: MemberStats): number | und
 const isActiveSubTrack = (subTrack?: MemberStats): boolean => {
     const submissionCount = getSubTrackSubmissionCount(subTrack)
 
-    return (submissionCount ?? subTrack?.challenges ?? 0) > 0
+    return (submissionCount ?? 0) > 0 || (subTrack?.challenges ?? 0) > 0
 }
 
 /**
@@ -94,24 +95,30 @@ const isTestingSubTrack = (subTrack?: MemberStats): boolean => (
 )
 
 /**
- * Pick the Data Science subtrack rating used by the summary card.
+ * Convert a Data Science Challenge stats payload into the legacy Code subtrack
+ * shown under Development.
  *
- * Data Science can include Marathon Match and challenge ratings. The summary
- * should show the strongest visible rating instead of always using Marathon
- * Match, otherwise Data Science Challenge ratings are hidden from the profile.
+ * Member-api stores newly rated Data Science Challenge rows under
+ * `DATA_SCIENCE.Challenge`, but the profile history UI presents non-MM data
+ * science challenges in Development > Code for parity with existing profiles.
  *
- * @param {MemberStats[]} subTracks - Active Data Science subtracks.
- * @returns {MemberStats | undefined} The subtrack with the highest rating.
+ * @param {UserStats | undefined} memberStats - The raw stats payload for the user.
+ * @returns {MemberStats | undefined} Display-ready Code stats when available.
  */
-const getDataScienceSummarySubTrack = (subTracks: MemberStats[]): MemberStats | undefined => orderBy(
-    subTracks,
-    [
-        subTrack => subTrack.rank?.rating ?? 0,
-        subTrack => subTrack.rank?.percentile ?? 0,
-        subTrack => subTrack.challenges ?? 0,
-    ],
-    ['desc', 'desc', 'desc'],
-)[0]
+const buildDataScienceChallengeCodeSubTrack = (memberStats?: UserStats): MemberStats | undefined => {
+    const challengeStats = memberStats?.DATA_SCIENCE?.Challenge
+
+    return !challengeStats ? undefined : ({
+        ...challengeStats,
+        historyPaths: [dataScienceChallengeCodeHistoryPath],
+        name: 'CODE',
+        parentTrack: 'DEVELOP',
+        path: 'DEVELOP.subTracks',
+        statsDistributionSubTrack: 'Challenge',
+        statsDistributionTrack: 'DATA_SCIENCE',
+        submissions: challengeStats.submissions ?? { submissions: 0 },
+    } as MemberStats)
+}
 
 /**
  * Attach parent track metadata to legacy design/develop subtracks and index them by name.
@@ -138,6 +145,96 @@ const mapSubTracksByName = (
 const getFiniteNumber = (value: unknown): number | undefined => (
     typeof value === 'number' && Number.isFinite(value) ? value : undefined
 )
+
+/**
+ * Return the rank object that should represent a merged subtrack.
+ *
+ * When both streams have ratings, the visible Code stats should keep the
+ * stronger rating so a Data Science Challenge rating is not hidden by a lower
+ * legacy Development Code rating.
+ *
+ * @param {MemberStats} currentSubTrack - Existing displayed subtrack stats.
+ * @param {MemberStats} additionalSubTrack - Additional stats to merge.
+ * @returns {MemberStats['rank']} Rank data for the merged subtrack.
+ */
+const getMergedSubTrackRank = (
+    currentSubTrack: MemberStats,
+    additionalSubTrack: MemberStats,
+): MemberStats['rank'] => {
+    const currentRating = getFiniteNumber(currentSubTrack.rank?.rating)
+    const additionalRating = getFiniteNumber(additionalSubTrack.rank?.rating)
+
+    if (currentRating === undefined) {
+        return additionalSubTrack.rank ?? currentSubTrack.rank
+    }
+
+    if (additionalRating === undefined) {
+        return currentSubTrack.rank
+    }
+
+    return additionalRating > currentRating ? additionalSubTrack.rank : currentSubTrack.rank
+}
+
+/**
+ * Merge two displayed subtracks with the same name.
+ *
+ * This keeps Development > Code as one profile bucket when a member has both
+ * legacy Code stats and Data Science Challenge stats backed by different API
+ * dimensions.
+ *
+ * @param {MemberStats} currentSubTrack - Existing displayed subtrack stats.
+ * @param {MemberStats} additionalSubTrack - Additional stats to merge.
+ * @returns {MemberStats} Merged stats for the displayed subtrack.
+ */
+const mergeDisplayedSubTrackStats = (
+    currentSubTrack: MemberStats,
+    additionalSubTrack: MemberStats,
+): MemberStats => {
+    const currentSubmissions = getSubTrackSubmissionCount(currentSubTrack)
+    const additionalSubmissions = getSubTrackSubmissionCount(additionalSubTrack)
+    const hasSubmissionCounts = currentSubmissions !== undefined || additionalSubmissions !== undefined
+
+    return {
+        ...currentSubTrack,
+        challenges: (currentSubTrack.challenges ?? 0) + (additionalSubTrack.challenges ?? 0),
+        historyPaths: Array.from(new Set([
+            ...(currentSubTrack.historyPaths ?? []),
+            ...(additionalSubTrack.historyPaths ?? []),
+        ])),
+        rank: getMergedSubTrackRank(currentSubTrack, additionalSubTrack),
+        submissions: hasSubmissionCounts
+            ? { submissions: (currentSubmissions ?? 0) + (additionalSubmissions ?? 0) }
+            : currentSubTrack.submissions,
+        wins: (currentSubTrack.wins ?? 0) + (additionalSubTrack.wins ?? 0),
+    }
+}
+
+/**
+ * Adds Data Science Challenge stats to the Development > Code bucket.
+ *
+ * @param {{[key: string]: MemberStats}} developSubTracks - Existing Development subtracks.
+ * @param {UserStats | undefined} memberStats - The raw stats payload for the user.
+ * @returns {{[key: string]: MemberStats}} Development subtracks with the Code compatibility mapping.
+ */
+const addDataScienceChallengeToDevelopmentCode = (
+    developSubTracks: {[key: string]: MemberStats},
+    memberStats?: UserStats,
+): {[key: string]: MemberStats} => {
+    const dataScienceChallengeCodeSubTrack = buildDataScienceChallengeCodeSubTrack(memberStats)
+
+    if (!dataScienceChallengeCodeSubTrack) {
+        return developSubTracks
+    }
+
+    const codeSubTrack = developSubTracks[dataScienceChallengeCodeSubTrack.name]
+
+    return {
+        ...developSubTracks,
+        [dataScienceChallengeCodeSubTrack.name]: codeSubTrack
+            ? mergeDisplayedSubTrackStats(codeSubTrack, dataScienceChallengeCodeSubTrack)
+            : dataScienceChallengeCodeSubTrack,
+    }
+}
 
 /**
  * Determine whether a DATA_SCIENCE entry is a configured rating path.
@@ -355,13 +452,6 @@ const getDataScienceRatingPathTrackData = (memberStats?: UserStats): MemberStats
 export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => {
     // Create mappings for data science subtracks
     const dataScienceSubTracks: {[key: string]: MemberStats | SRMStats} = {
-        // Map Challenge subtrack
-        Challenge: (memberStats?.DATA_SCIENCE?.Challenge && ({
-            ...memberStats.DATA_SCIENCE.Challenge,
-            name: 'Challenge',
-            parentTrack: 'DATA_SCIENCE',
-            path: 'DATA_SCIENCE',
-        })) as MemberStats,
         // Map MARATHON_MATCH subtrack
         MARATHON_MATCH: (memberStats?.DATA_SCIENCE?.MARATHON_MATCH && ({
             ...memberStats.DATA_SCIENCE.MARATHON_MATCH,
@@ -386,9 +476,12 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
     )
 
     // Create mappings for develop subtracks
-    const developSubTracks: {[key: string]: MemberStats} = mapSubTracksByName(
-        'DEVELOP',
-        memberStats?.DEVELOP?.subTracks,
+    const developSubTracks: {[key: string]: MemberStats} = addDataScienceChallengeToDevelopmentCode(
+        mapSubTracksByName(
+            'DEVELOP',
+            memberStats?.DEVELOP?.subTracks,
+        ),
+        memberStats,
     )
 
     // Build aggregated stats for Design, Development, Testing, and Competitive Programming tracks
@@ -422,19 +515,17 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
 
     // Data science
     const dsSubTracks: MemberStats[] = [
-        dataScienceSubTracks.Challenge,
         dataScienceSubTracks.MARATHON_MATCH,
     ].filter(d => d?.challenges > 0) as MemberStats[]
     const dsTrackData: MemberStatsTrack = buildTrackData('Data Science', dsSubTracks)
-    const dsSummarySubTrack: MemberStats | undefined = getDataScienceSummarySubTrack(dsTrackData.subTracks)
     const dataScienceRatingPathTrackStats: MemberStatsTrack[] = getDataScienceRatingPathTrackData(memberStats)
 
     const dsTrackStats: MemberStatsTrack = {
         ...dsTrackData,
         isDSTrack: true,
         order: -1,
-        percentile: dsSummarySubTrack?.rank?.percentile ?? 0,
-        rating: dsSummarySubTrack?.rank?.rating ?? 0,
+        percentile: dataScienceSubTracks.MARATHON_MATCH?.rank?.percentile ?? 0,
+        rating: dataScienceSubTracks.MARATHON_MATCH?.rank?.rating ?? 0,
     }
 
     // Competitive Programming

--- a/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
@@ -1,0 +1,49 @@
+import type { MemberStats, UserStatsHistory } from '~/libs/core'
+
+import { getTrackHistoryFromStats } from './useTrackHistory'
+
+jest.mock('~/libs/core', () => ({
+    useStatsHistory: jest.fn(),
+}), {
+    virtual: true,
+})
+
+describe('getTrackHistoryFromStats', () => {
+    it('reads compatibility history paths for displayed subtracks', () => {
+        const trackData = {
+            historyPaths: ['DATA_SCIENCE.Challenge.history'],
+            name: 'CODE',
+            parentTrack: 'DEVELOP',
+            path: 'DEVELOP.subTracks',
+        } as MemberStats
+        const history = getTrackHistoryFromStats({
+            DATA_SCIENCE: {
+                Challenge: {
+                    history: [
+                        {
+                            challengeId: 'ds-challenge',
+                            challengeName: 'Data Science Challenge',
+                            newRating: 1499,
+                            ratingDate: 1781237773026,
+                        },
+                    ],
+                },
+            },
+            DEVELOP: {
+                subTracks: [],
+            },
+            groupId: 10,
+            handle: 'testcoun',
+            handleLower: 'testcoun',
+            userId: 89770325,
+        } as UserStatsHistory, trackData)
+
+        expect(history)
+            .toEqual([
+                expect.objectContaining({
+                    challengeId: 'ds-challenge',
+                    newRating: 1499,
+                }),
+            ])
+    })
+})

--- a/src/apps/profiles/src/hooks/useTrackHistory.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.tsx
@@ -1,29 +1,87 @@
-import { find, get } from 'lodash'
+import { find, get, orderBy, uniqBy } from 'lodash'
 
 import { MemberStats, StatsHistory, UserStatsHistory, useStatsHistory } from '~/libs/core'
 
 /**
- * Fetches the user stats history and extracts the history data for the specified track
- * @param userHandle - User's handle
- * @param trackData - The track data for which we want to fetch the history
- * @returns
+ * Extracts the history array from an exact stats-history path.
+ *
+ * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
+ * @param {string} historyPath - Exact lodash path to a history array.
+ * @returns {StatsHistory[]} History rows at the supplied path.
  */
-export const useTrackHistory = (userHandle?: string, trackData?: MemberStats): StatsHistory[] => {
-    const statsHistory: UserStatsHistory | undefined = useStatsHistory(userHandle)
+const getHistoryFromExactPath = (
+    statsHistory: UserStatsHistory | undefined,
+    historyPath: string,
+): StatsHistory[] => get(statsHistory, historyPath, [])
 
-    if (!trackData) {
-        return []
-    }
-
-    const trackHistory: StatsHistory[] = get(
-        find(get(statsHistory, `${trackData.path}`, []), { name: trackData.name }),
-        'history',
-    )
-    // marathon match has a different structure for the stats history
+/**
+ * Fetches the default history data for a track using its API path and name.
+ *
+ * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
+ * @param {MemberStats} trackData - The track data for which to fetch history.
+ * @returns {StatsHistory[]} History rows for the displayed track.
+ */
+const getDefaultTrackHistory = (
+    statsHistory: UserStatsHistory | undefined,
+    trackData: MemberStats,
+): StatsHistory[] => get(
+    find(get(statsHistory, `${trackData.path}`, []), { name: trackData.name }),
+    'history',
+)
+    // marathon match and some unified stats dimensions have a keyed history structure
     || get(
         statsHistory,
         `${trackData.path}.${trackData.name}.history`,
     ) || []
 
-    return trackHistory
+/**
+ * Extracts the history rows for a displayed track.
+ *
+ * Some displayed tracks merge history from compatibility paths, such as
+ * Development > Code reading Data Science Challenge history from the API.
+ *
+ * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
+ * @param {MemberStats | undefined} trackData - The track data for which to fetch history.
+ * @returns {StatsHistory[]} History rows for the displayed track.
+ */
+export const getTrackHistoryFromStats = (
+    statsHistory: UserStatsHistory | undefined,
+    trackData?: MemberStats,
+): StatsHistory[] => {
+    if (!trackData) {
+        return []
+    }
+
+    const trackHistory = getDefaultTrackHistory(statsHistory, trackData)
+    const compatibilityHistory = (trackData.historyPaths ?? [])
+        .flatMap(historyPath => getHistoryFromExactPath(statsHistory, historyPath))
+
+    if (compatibilityHistory.length === 0) {
+        return trackHistory
+    }
+
+    return orderBy(
+        uniqBy(
+            [
+                ...trackHistory,
+                ...compatibilityHistory,
+            ],
+            history => String(history.challengeId),
+        ),
+        [history => history.ratingDate ?? history.date ?? 0],
+        ['desc'],
+    )
+}
+
+/**
+ * Fetches the user stats history and extracts the history data for the specified track.
+ *
+ * @param {string | undefined} userHandle - User's handle.
+ * @param {MemberStats | undefined} trackData - The track data for which to fetch history.
+ * @returns {StatsHistory[]} History rows for the specified track.
+ */
+export const useTrackHistory = (userHandle?: string, trackData?: MemberStats): StatsHistory[] => {
+    const statsHistory: UserStatsHistory | undefined = useStatsHistory(userHandle)
+
+    return getTrackHistoryFromStats(statsHistory, trackData)
 }

--- a/src/libs/core/lib/profile/user-stats.model.ts
+++ b/src/libs/core/lib/profile/user-stats.model.ts
@@ -55,6 +55,23 @@ export type MemberStats = {
     }
     parentTrack?: string
     path?: string
+    /**
+     * Exact stats-history paths to merge into this displayed subtrack.
+     *
+     * Used when a legacy display bucket is backed by stats stored under a newer
+     * API dimension.
+     */
+    historyPaths?: string[]
+    /**
+     * Track key used for rating-distribution lookups when it differs from the
+     * displayed parent track.
+     */
+    statsDistributionTrack?: string
+    /**
+     * Subtrack key used for rating-distribution lookups when it differs from
+     * the displayed subtrack name.
+     */
+    statsDistributionSubTrack?: string
 }
 
 /**


### PR DESCRIPTION
What was broken
The previous platform-ui fix displayed member-api DATA_SCIENCE.Challenge ratings and history as a Data Science > Challenge subtrack. QA confirmed the backend now returns the history, but production profile behavior shows non-Marathon-Match Data Science challenges under Development > Code.

Root cause (if identifiable)
The profile active-track mapper treated DATA_SCIENCE.Challenge as a native Data Science display subtrack, so the achievements card and drill-down route disagreed with the existing production bucket for these challenge ratings.

What was changed
Remapped DATA_SCIENCE.Challenge into the Development Code subtrack while keeping explicit history and distribution lookup paths pointed at DATA_SCIENCE.Challenge. Data Science now uses Marathon Match for its summary again, and Code rows with zero submissions remain visible when they have challenge history.

Any added/updated tests
Updated getActiveTracks coverage to assert Data Science Challenge stats display under Development > Code, and added getTrackHistoryFromStats coverage for compatibility history paths.

Validation
- yarn test:no-watch src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx src/apps/profiles/src/hooks/useTrackHistory.spec.tsx: passed.
- yarn lint: passed.
- yarn run build: passed with existing unrelated CSS-order and React build warnings.
- yarn test:no-watch --runInBand: ran full suite; failed on unrelated existing wallet-admin/work specs and module alias issues while the PM-5221 targeted profile specs passed.
