### PR TITLE
PM-5374: Fix blank Filestack env fallback

### DIFF
--- a/src/config/environments/react-env.spec.ts
+++ b/src/config/environments/react-env.spec.ts
@@ -1,0 +1,33 @@
+import { getReactEnv } from './react-env'
+
+const originalEnv = process.env
+
+describe('getReactEnv', () => {
+    beforeEach(() => {
+        process.env = { ...originalEnv }
+        delete process.env.REACT_APP_FILESTACK_REGION
+        delete process.env.REACT_APP_FEATURE_FLAG
+        delete process.env.REACT_APP_RETRY_COUNT
+    })
+
+    afterAll(() => {
+        process.env = originalEnv
+    })
+
+    it('uses the provided default when an env value is blank', () => {
+        process.env.REACT_APP_FILESTACK_REGION = ''
+
+        expect(getReactEnv<string>('FILESTACK_REGION', 'us-east-1'))
+            .toBe('us-east-1')
+    })
+
+    it('keeps parsing boolean and numeric env values', () => {
+        process.env.REACT_APP_FEATURE_FLAG = 'true'
+        process.env.REACT_APP_RETRY_COUNT = '2'
+
+        expect(getReactEnv<boolean>('FEATURE_FLAG', false))
+            .toBe(true)
+        expect(getReactEnv<number>('RETRY_COUNT', 0))
+            .toBe(2)
+    })
+})

--- a/src/config/environments/react-env.ts
+++ b/src/config/environments/react-env.ts
@@ -4,14 +4,20 @@
 export function getReactEnv<T>(varName: string, defaultValue?: string | boolean | number): T {
     const hasDefaultValue: boolean = arguments.length > 1
 
-    let value = process.env[`REACT_APP_${varName}`] as unknown as T
+    const rawValue = process.env[`REACT_APP_${varName}`]
 
-    if (value === undefined && !hasDefaultValue) {
+    if (rawValue === undefined && !hasDefaultValue) {
         throw new Error(`${varName} is not defined in process.env!`)
     }
 
+    if (rawValue?.trim() === '' && hasDefaultValue) {
+        return defaultValue as T
+    }
+
+    let value = rawValue as unknown as T
+
     // convert to number
-    if (!Number.isNaN(Number(value))) {
+    if (rawValue?.trim() !== '' && !Number.isNaN(Number(value))) {
         value = Number(value as unknown) as T
     }
 


### PR DESCRIPTION
What was broken
Production markdown uploads could pass an invalid Filestack store config when a string env override, such as REACT_APP_FILESTACK_REGION, was present but blank. That caused MM example solution uploads to fail with "Invalid store upload params" before the uploaded file link was inserted into the specification editor.

Root cause (if identifiable)
getReactEnv converted blank strings with Number("") before applying defaults, so blank env values became numeric 0 instead of falling back to defaults like us-east-1.

What was changed
Blank env values now use the provided default when one exists, while non-blank numeric and boolean env values keep the existing parsing behavior.

Any added/updated tests
Added src/config/environments/react-env.spec.ts to cover blank default fallback and existing boolean/numeric parsing.
