### PR TITLE
PM-5231: Show example validation scoring in submissions

### DIFF
--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
@@ -22,6 +22,13 @@ jest.mock('../../constants', () => ({
 jest.mock('../../utils', () => ({
     formatDateTime: (value: string) => value,
     getRatingLevel: () => 'gray',
+    getSubmissionExampleScore: (
+        submission: { reviewSummation?: Array<{ aggregateScore?: number, isExample?: boolean }> },
+    ) => (
+        submission.reviewSummation
+            ?.find(item => item.isExample === true)
+            ?.aggregateScore
+    ),
     getSubmissionFinalScore: (submission: { review?: Array<{ finalScore?: number }> }) => (
         submission.review?.[0]?.finalScore ?? 0
     ),
@@ -46,9 +53,10 @@ jest.mock('../../utils', () => ({
         submission: {
             reviewSummation?: Array<{
                 metadata?: {
-                    testProcess?: 'provisional' | 'system'
+                    testProcess?: 'example' | 'provisional' | 'system'
                     testProgress?: number
                     testStatus?: 'FAILED' | 'IN PROGRESS' | 'SUCCESS'
+                    testType?: 'example' | 'provisional' | 'system'
                 }
             }>
         },
@@ -57,7 +65,7 @@ jest.mock('../../utils', () => ({
         const progress = metadata?.testProgress
 
         return {
-            process: metadata?.testProcess,
+            process: metadata?.testProcess ?? metadata?.testType,
             progressPercent: typeof progress === 'number'
                 ? `${Math.round(progress * 100)}%`
                 : undefined,
@@ -389,5 +397,48 @@ describe('SubmissionsTable', () => {
             .toBeNull()
         expect(screen.queryByRole('link', { name: '80.00 / 85.00' }))
             .toBeNull()
+    })
+
+    it('renders example validation process and score for marathon submissions', () => {
+        render(
+            <SubmissionsTable
+                canDownloadSubmissions
+                challengeId='challenge-123'
+                onDownloadSubmission={jest.fn()}
+                onOpenArtifacts={jest.fn()}
+                onSort={jest.fn()}
+                showMarathonMatchTestProgress
+                sortBy='createdAt'
+                sortOrder='desc'
+                submissions={[
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-1',
+                        id: 'submission-1',
+                        reviewSummation: [
+                            {
+                                aggregateScore: 15.25,
+                                isExample: true,
+                                metadata: {
+                                    testProgress: 1,
+                                    testStatus: 'SUCCESS',
+                                    testType: 'example',
+                                },
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                ]}
+            />,
+        )
+
+        expect(screen.getByRole('link', { name: '15.25 / -' }))
+            .toBeTruthy()
+        expect(screen.getByText('Example'))
+            .toBeTruthy()
+        expect(screen.getByText('100%'))
+            .toBeTruthy()
+        expect(screen.getByRole('img', { name: 'Test status: SUCCESS' }))
+            .toBeTruthy()
     })
 })

--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
@@ -19,6 +19,7 @@ import { Submission } from '../../models'
 import {
     formatDateTime,
     getRatingLevel,
+    getSubmissionExampleScore,
     getSubmissionFinalScore,
     getSubmissionInitialScore,
     getSubmissionProvisionalScore,
@@ -139,6 +140,50 @@ function formatScore(value?: number, emptyValue: string = 'N/A'): string {
     }
 
     return value.toFixed(2)
+}
+
+/**
+ * Converts normalized marathon test process metadata into a table display label.
+ * @param process Current marathon test process from review summation metadata.
+ * @returns Human-readable process label, or an empty string when absent.
+ * Used by `SubmissionsTable` for the Current tests process column.
+ */
+function formatTestProcess(process?: string): string {
+    if (process === 'example') {
+        return 'Example'
+    }
+
+    if (process === 'provisional') {
+        return 'Provisional'
+    }
+
+    if (process === 'system') {
+        return 'System'
+    }
+
+    return ''
+}
+
+/**
+ * Selects the marathon score shown in the left side of the score column.
+ * @param submission Submission row with review summation data.
+ * @param process Current marathon test process from progress metadata.
+ * @returns Example score when Example is current; otherwise the provisional score.
+ * Used by `SubmissionsTable` for marathon score display.
+ */
+function getMarathonInitialScore(
+    submission: Submission,
+    process?: string,
+): number | undefined {
+    if (process === 'example') {
+        const exampleScore = getSubmissionExampleScore(submission)
+
+        if (exampleScore !== undefined) {
+            return exampleScore
+        }
+    }
+
+    return getSubmissionProvisionalScore(submission)
 }
 
 function getSortIndicator(
@@ -327,8 +372,11 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                         const handleDisplay = getHandleDisplay(submission, !!props.isLoadingMembers)
                         const emailDisplay = getEmailDisplay(submission, !!props.isLoadingMembers)
                         const submissionDate = formatDateTime(getCreatedAt(submission))
+                        const testProgress = props.showMarathonMatchTestProgress
+                            ? getSubmissionTestProgress(submission)
+                            : undefined
                         const initialScoreValue = props.showMarathonMatchTestProgress
-                            ? getSubmissionProvisionalScore(submission)
+                            ? getMarathonInitialScore(submission, testProgress?.process)
                             : getSubmissionInitialScore(submission)
                         const finalScoreValue = props.showMarathonMatchTestProgress
                             ? getSubmissionSystemScore(submission)
@@ -338,9 +386,6 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                             : 'N/A'
                         const initialScore = formatScore(initialScoreValue, emptyScoreValue)
                         const finalScore = formatScore(finalScoreValue, emptyScoreValue)
-                        const testProgress = props.showMarathonMatchTestProgress
-                            ? getSubmissionTestProgress(submission)
-                            : undefined
                         const reviewTab = submission.type === 'CHECKPOINT_SUBMISSION'
                             ? 'checkpoint-submission'
                             : 'submission'
@@ -396,7 +441,7 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                                     ? (
                                         <>
                                             <td>
-                                                <span>{testProgress?.process || ''}</span>
+                                                <span>{formatTestProcess(testProgress?.process)}</span>
                                             </td>
 
                                             <td className={styles.testStatusCell}>

--- a/src/apps/work/src/lib/utils/challenge.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.spec.ts
@@ -1,6 +1,8 @@
 import {
+    getSubmissionExampleScore,
     getSubmissionProvisionalScore,
     getSubmissionSystemScore,
+    getSubmissionTestProgress,
     isMarathonMatchChallenge,
 } from './challenge.utils'
 
@@ -31,6 +33,71 @@ describe('challenge utils', () => {
                 typeId: '927abff4-7af9-4145-8ba1-577c16e64e2e',
             }))
                 .toBe(false)
+        })
+    })
+
+    describe('getSubmissionExampleScore', () => {
+        it('returns only example marathon scores', () => {
+            expect(getSubmissionExampleScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: 10,
+                        isExample: true,
+                        metadata: {
+                            testType: 'example',
+                        },
+                    },
+                    {
+                        aggregateScore: 12,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                        },
+                    },
+                ],
+            }))
+                .toBe(10)
+        })
+
+        it('returns the latest example summation', () => {
+            expect(getSubmissionExampleScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: 10,
+                        isExample: true,
+                        updatedAt: '2026-06-17T01:00:00.000Z',
+                    },
+                    {
+                        aggregateScore: 15.25,
+                        isExample: true,
+                        updatedAt: '2026-06-17T02:00:00.000Z',
+                    },
+                ],
+            }))
+                .toBe(15.25)
+        })
+    })
+
+    describe('getSubmissionTestProgress', () => {
+        it('returns example progress from marathon metadata test type', () => {
+            expect(getSubmissionTestProgress({
+                reviewSummation: [
+                    {
+                        aggregateScore: 10,
+                        isExample: true,
+                        metadata: {
+                            testProgress: 1,
+                            testStatus: 'SUCCESS',
+                            testType: 'example',
+                        },
+                    },
+                ],
+            }))
+                .toEqual({
+                    process: 'example',
+                    progressPercent: '100%',
+                    status: 'SUCCESS',
+                })
         })
     })
 

--- a/src/apps/work/src/lib/utils/challenge.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.ts
@@ -14,6 +14,8 @@ interface SubmissionScore {
     provisionalScore?: number
 }
 
+type MarathonMatchScoreProcess = 'example' | 'provisional' | 'system'
+
 interface ScoredSubmissionLike {
     review?: Array<{
         initialScore?: number
@@ -30,7 +32,7 @@ interface ScoredSubmissionLike {
  * Display metadata for marathon test progress columns.
  */
 export interface SubmissionTestProgressDisplay {
-    process?: 'provisional' | 'system'
+    process?: MarathonMatchScoreProcess
     progressPercent?: string
     status?: 'FAILED' | 'IN PROGRESS' | 'SUCCESS'
 }
@@ -169,12 +171,12 @@ function getScoreFromSummation(
 /**
  * Resolves the marathon scoring phase represented by a review summation.
  * @param entry Review summation returned by Review API.
- * @returns `provisional`, `system`, or `undefined` when the summation is not a scored marathon phase.
+ * @returns `example`, `provisional`, `system`, or `undefined` when the summation is not a scored marathon phase.
  * Used by strict marathon score helpers so progress/example reviews do not leak into score display.
  */
 function getReviewSummationTestProcess(
     entry: ReviewSummation,
-): 'provisional' | 'system' | undefined {
+): MarathonMatchScoreProcess | undefined {
     const metadataProcess = normalizeTestProcess(
         entry.metadata?.testProcess
         ?? entry.metadata?.testType,
@@ -193,6 +195,10 @@ function getReviewSummationTestProcess(
         return 'system'
     }
 
+    if (entry.isExample === true) {
+        return 'example'
+    }
+
     if (entry.isFinal === true) {
         return 'system'
     }
@@ -201,7 +207,7 @@ function getReviewSummationTestProcess(
         return 'provisional'
     }
 
-    if (entry.isFinal === false && entry.isExample !== true) {
+    if (entry.isFinal === false) {
         return 'provisional'
     }
 
@@ -223,14 +229,18 @@ function getChallengeTypeName(type: string | ChallengeTypeRef | undefined): stri
 /**
  * Normalizes review summation metadata test process aliases for marathon display.
  * @param value Metadata process or legacy test type value from Review API.
- * @returns `provisional` or `system` when the value identifies a tracked process.
- * Used by `getSubmissionTestProgress` to avoid showing example-test metadata.
+ * @returns `example`, `provisional`, or `system` when the value identifies a tracked process.
+ * Used by `getSubmissionTestProgress` to display the active marathon validation phase.
  */
-function normalizeTestProcess(value: unknown): 'provisional' | 'system' | undefined {
+function normalizeTestProcess(value: unknown): MarathonMatchScoreProcess | undefined {
     const normalized = typeof value === 'string'
         ? value.trim()
             .toLowerCase()
         : ''
+
+    if (normalized === 'example') {
+        return 'example'
+    }
 
     if (normalized === 'system' || normalized === 'final') {
         return 'system'
@@ -278,6 +288,24 @@ function normalizeTestProgress(value: unknown): number | undefined {
     }
 
     return Math.min(Math.max(progress, 0), 1)
+}
+
+/**
+ * Assigns a stable ordering weight for marathon test processes.
+ * @param process Normalized marathon test process.
+ * @returns Numeric priority used to break ties between progress records.
+ * Used by `toSubmissionTestProgressCandidate` after timestamp and status ordering.
+ */
+function getTestProcessPriority(process: MarathonMatchScoreProcess | undefined): number {
+    if (process === 'system') {
+        return 2
+    }
+
+    if (process === 'provisional') {
+        return 1
+    }
+
+    return 0
 }
 
 /**
@@ -330,9 +358,7 @@ function toSubmissionTestProgressCandidate(
             ? 1
             : 0,
         process,
-        processPriority: process === 'system'
-            ? 1
-            : 0,
+        processPriority: getTestProcessPriority(process),
         progress,
         progressPercent: progress === undefined
             ? undefined
@@ -464,6 +490,21 @@ export function getChallengeTypeAbbr(
 
 export function is2RoundsChallenge(challenge: Pick<Challenge, 'phases'>): boolean {
     return !!challenge.phases?.find(phase => phase.name === 'Checkpoint Submission')
+}
+
+/**
+ * Returns only the example marathon score for a submission.
+ * @param submission Submission-like object containing Review API summations.
+ * @returns Example score, or `undefined` when example scoring has not produced a valid score.
+ * Used by marathon submission table display when the current validation process is Example.
+ */
+export function getSubmissionExampleScore(
+    submission: ScoredSubmissionLike,
+): number | undefined {
+    return getScoreFromSummation(
+        submission.reviewSummation,
+        item => getReviewSummationTestProcess(item) === 'example',
+    )
 }
 
 export function getProvisionalScore(submission: ScoredSubmissionLike): number {


### PR DESCRIPTION
What was broken
The Marathon Match validation upload flow could queue and score the Example phase, but the Work Manager Submissions tab did not show Example as the current test process or display its validation score.

Root cause (if identifiable)
The Work submissions table only normalized Provisional and System marathon test processes for progress display, and marathon score display only read Provisional and System summations. Example summations from the scorer callback were intentionally ignored by those helpers, leaving validation-only Example rows blank.

What was changed
Added explicit Example process normalization and an Example score helper for marathon review summations. The submissions table now renders human-readable marathon process labels and uses the Example score when Example is the current validation process, while preserving existing Provisional/System score handling.

Any added/updated tests
Added utility coverage for Example progress and score extraction, plus table coverage for rendering the Example process, status, progress, and score.

Validation run:
- `yarn test:no-watch src/apps/work/src/lib/utils/challenge.utils.spec.ts src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx --runInBand` passed.
- `yarn lint` passed.
- `yarn build` passed with existing CRA CSS-order and lint warnings.
- `yarn test:no-watch --runInBand` still fails in unrelated existing platform-ui suites, including Work/Wallet module alias or mock resolution failures and engagement/payment assertion failures outside this PM-5231 path.
