### PR TITLE
PM-5384: Reduce profile photo username gap

### DIFF
--- a/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
+++ b/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
@@ -118,7 +118,7 @@
             .profileInfoLeft {
                 display: flex;
                 flex-direction: column;
-                margin-top: -60px;
+                margin-top: -140px;
 
                 @include ltelg {
                     margin-top: 0;


### PR DESCRIPTION
What was broken

The member profile summary sat too far below the desktop profile picture, leaving an oversized gap before the "Hello, I'm ..." greeting shown in the left column.

Root cause

The desktop left profile column only moved up by 60px even though the profile photo overlaps farther into the white content area after the current header layout.

What was changed

Adjusted the desktop left profile column offset so the About Me greeting sits closer to the profile photo. The tablet and mobile stacked layout keeps its existing zero offset.

Any added/updated tests

No tests were added because this is a CSS-only spacing adjustment.

Validation:
- `yarn lint` passed.
- `yarn run build` passed, with existing CRA/webpack warnings.
- `yarn test:no-watch --findRelatedTests src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss` found no related tests and exited successfully.
- `yarn test:no-watch src/apps/profiles/src/member-profile` passed.
- Full `yarn test:no-watch` was attempted but currently fails in unrelated `work` and `wallet-admin` suites, including missing mocked utility/module exports and existing engagement schema expectations outside the profiles area.
