### PR TITLE
PM-5221: show Data Science challenges as Data Science stats

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/DevelopTrackView/DevelopTrackView.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/DevelopTrackView/DevelopTrackView.tsx
@@ -24,13 +24,11 @@ const DevelopTrackView: FC<DevelopTrackViewProps> = props => {
         'First2Finish',
         'DESIGN_FIRST_2_FINISH',
     ].includes(trackName), [trackName])
-    const statsDistributionTrack = props.trackData.statsDistributionTrack ?? props.trackData.parentTrack
-    const statsDistributionSubTrack = props.trackData.statsDistributionSubTrack ?? trackName
 
     const ratingDistribution: UserStatsDistributionResponse | undefined = useStatsDistribution(
         isDesignTrack ? undefined : {
-            subTrack: statsDistributionSubTrack,
-            track: statsDistributionTrack,
+            subTrack: trackName,
+            track: props.trackData.parentTrack,
         },
     )
 

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -74,13 +74,17 @@ describe('getActiveTracks', () => {
             .toEqual(['Challenge', 'Task'])
     })
 
-    it('shows Data Science Challenge stats under the Development Code subtrack', () => {
+    it('includes Data Science Challenge stats in the Data Science track', () => {
         const activeTracks: MemberStatsTrack[] = getActiveTracks({
             DATA_SCIENCE: {
                 Challenge: {
                     challenges: 1,
                     rank: {
+                        percentile: 10,
                         rating: 1499,
+                    },
+                    submissions: {
+                        submissions: 0,
                     },
                     wins: 1,
                 },
@@ -98,34 +102,27 @@ describe('getActiveTracks', () => {
             .find(track => track.name === 'Data Science')
         const developmentTrack: MemberStatsTrack | undefined = activeTracks
             .find(track => track.name === 'Development')
-        const codeSubTrack = developmentTrack?.subTracks
-            .find(track => track.name === 'CODE')
+        const challengeSubTrack = dataScienceTrack?.subTracks
+            .find(track => track.name === 'Challenge')
 
         expect(dataScienceTrack?.challenges)
+            .toEqual(2)
+        expect(dataScienceTrack?.wins)
             .toEqual(1)
         expect(dataScienceTrack?.rating)
-            .toEqual(763)
-        expect(dataScienceTrack?.subTracks.map(track => track.name))
-            .toEqual(['MARATHON_MATCH'])
-        expect(developmentTrack?.challenges)
-            .toEqual(1)
-        expect(developmentTrack?.wins)
-            .toEqual(1)
-        expect(developmentTrack?.subTracks.map(track => track.name))
-            .toEqual(['CODE'])
-        expect(codeSubTrack)
-            .toEqual(expect.objectContaining({
-                historyPaths: ['DATA_SCIENCE.Challenge.history'],
-                name: 'CODE',
-                parentTrack: 'DEVELOP',
-                path: 'DEVELOP.subTracks',
-                statsDistributionSubTrack: 'Challenge',
-                statsDistributionTrack: 'DATA_SCIENCE',
-            }))
-        expect(codeSubTrack?.rank?.rating)
             .toEqual(1499)
-        expect(activeTracks.map(track => track.name))
-            .not.toContain('Challenge')
+        expect(dataScienceTrack?.percentile)
+            .toEqual(10)
+        expect(dataScienceTrack?.subTracks.map(track => track.name))
+            .toEqual(['Challenge', 'MARATHON_MATCH'])
+        expect(challengeSubTrack)
+            .toEqual(expect.objectContaining({
+                name: 'Challenge',
+                parentTrack: 'DATA_SCIENCE',
+                path: 'DATA_SCIENCE',
+            }))
+        expect(developmentTrack)
+            .toBeUndefined()
     })
 
     it('keeps legacy testing subtracks in the testing track', () => {

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -29,8 +29,6 @@ const nativeDataScienceStatsKeys = new Set([
     'wins',
 ])
 
-const dataScienceChallengeCodeHistoryPath = 'DATA_SCIENCE.Challenge.history'
-
 /**
  * The structure of a track for a member.
  */
@@ -68,7 +66,7 @@ export const getSubTrackSubmissionCount = (subTrack?: MemberStats): number | und
 /**
  * Determine whether the subtrack should be considered active.
  *
- * Some rated Code rows can have zero submissions while still having challenge
+ * Some rated rows can have zero submissions while still having challenge
  * history, so challenge count also keeps the subtrack visible.
  *
  * @param {MemberStats | undefined} subTrack - The subtrack to inspect.
@@ -95,30 +93,24 @@ const isTestingSubTrack = (subTrack?: MemberStats): boolean => (
 )
 
 /**
- * Convert a Data Science Challenge stats payload into the legacy Code subtrack
- * shown under Development.
+ * Pick the Data Science subtrack rating used by the summary card.
  *
- * Member-api stores newly rated Data Science Challenge rows under
- * `DATA_SCIENCE.Challenge`, but the profile history UI presents non-MM data
- * science challenges in Development > Code for parity with existing profiles.
+ * Data Science can include Marathon Match and Challenge ratings. The summary
+ * should show the strongest visible rating instead of always using Marathon
+ * Match, otherwise Data Science Challenge ratings are hidden from the profile.
  *
- * @param {UserStats | undefined} memberStats - The raw stats payload for the user.
- * @returns {MemberStats | undefined} Display-ready Code stats when available.
+ * @param {MemberStats[]} subTracks - Active Data Science subtracks.
+ * @returns {MemberStats | undefined} The subtrack with the highest rating.
  */
-const buildDataScienceChallengeCodeSubTrack = (memberStats?: UserStats): MemberStats | undefined => {
-    const challengeStats = memberStats?.DATA_SCIENCE?.Challenge
-
-    return !challengeStats ? undefined : ({
-        ...challengeStats,
-        historyPaths: [dataScienceChallengeCodeHistoryPath],
-        name: 'CODE',
-        parentTrack: 'DEVELOP',
-        path: 'DEVELOP.subTracks',
-        statsDistributionSubTrack: 'Challenge',
-        statsDistributionTrack: 'DATA_SCIENCE',
-        submissions: challengeStats.submissions ?? { submissions: 0 },
-    } as MemberStats)
-}
+const getDataScienceSummarySubTrack = (subTracks: MemberStats[]): MemberStats | undefined => orderBy(
+    subTracks,
+    [
+        subTrack => subTrack.rank?.rating ?? 0,
+        subTrack => subTrack.rank?.percentile ?? 0,
+        subTrack => subTrack.challenges ?? 0,
+    ],
+    ['desc', 'desc', 'desc'],
+)[0]
 
 /**
  * Attach parent track metadata to legacy design/develop subtracks and index them by name.
@@ -145,96 +137,6 @@ const mapSubTracksByName = (
 const getFiniteNumber = (value: unknown): number | undefined => (
     typeof value === 'number' && Number.isFinite(value) ? value : undefined
 )
-
-/**
- * Return the rank object that should represent a merged subtrack.
- *
- * When both streams have ratings, the visible Code stats should keep the
- * stronger rating so a Data Science Challenge rating is not hidden by a lower
- * legacy Development Code rating.
- *
- * @param {MemberStats} currentSubTrack - Existing displayed subtrack stats.
- * @param {MemberStats} additionalSubTrack - Additional stats to merge.
- * @returns {MemberStats['rank']} Rank data for the merged subtrack.
- */
-const getMergedSubTrackRank = (
-    currentSubTrack: MemberStats,
-    additionalSubTrack: MemberStats,
-): MemberStats['rank'] => {
-    const currentRating = getFiniteNumber(currentSubTrack.rank?.rating)
-    const additionalRating = getFiniteNumber(additionalSubTrack.rank?.rating)
-
-    if (currentRating === undefined) {
-        return additionalSubTrack.rank ?? currentSubTrack.rank
-    }
-
-    if (additionalRating === undefined) {
-        return currentSubTrack.rank
-    }
-
-    return additionalRating > currentRating ? additionalSubTrack.rank : currentSubTrack.rank
-}
-
-/**
- * Merge two displayed subtracks with the same name.
- *
- * This keeps Development > Code as one profile bucket when a member has both
- * legacy Code stats and Data Science Challenge stats backed by different API
- * dimensions.
- *
- * @param {MemberStats} currentSubTrack - Existing displayed subtrack stats.
- * @param {MemberStats} additionalSubTrack - Additional stats to merge.
- * @returns {MemberStats} Merged stats for the displayed subtrack.
- */
-const mergeDisplayedSubTrackStats = (
-    currentSubTrack: MemberStats,
-    additionalSubTrack: MemberStats,
-): MemberStats => {
-    const currentSubmissions = getSubTrackSubmissionCount(currentSubTrack)
-    const additionalSubmissions = getSubTrackSubmissionCount(additionalSubTrack)
-    const hasSubmissionCounts = currentSubmissions !== undefined || additionalSubmissions !== undefined
-
-    return {
-        ...currentSubTrack,
-        challenges: (currentSubTrack.challenges ?? 0) + (additionalSubTrack.challenges ?? 0),
-        historyPaths: Array.from(new Set([
-            ...(currentSubTrack.historyPaths ?? []),
-            ...(additionalSubTrack.historyPaths ?? []),
-        ])),
-        rank: getMergedSubTrackRank(currentSubTrack, additionalSubTrack),
-        submissions: hasSubmissionCounts
-            ? { submissions: (currentSubmissions ?? 0) + (additionalSubmissions ?? 0) }
-            : currentSubTrack.submissions,
-        wins: (currentSubTrack.wins ?? 0) + (additionalSubTrack.wins ?? 0),
-    }
-}
-
-/**
- * Adds Data Science Challenge stats to the Development > Code bucket.
- *
- * @param {{[key: string]: MemberStats}} developSubTracks - Existing Development subtracks.
- * @param {UserStats | undefined} memberStats - The raw stats payload for the user.
- * @returns {{[key: string]: MemberStats}} Development subtracks with the Code compatibility mapping.
- */
-const addDataScienceChallengeToDevelopmentCode = (
-    developSubTracks: {[key: string]: MemberStats},
-    memberStats?: UserStats,
-): {[key: string]: MemberStats} => {
-    const dataScienceChallengeCodeSubTrack = buildDataScienceChallengeCodeSubTrack(memberStats)
-
-    if (!dataScienceChallengeCodeSubTrack) {
-        return developSubTracks
-    }
-
-    const codeSubTrack = developSubTracks[dataScienceChallengeCodeSubTrack.name]
-
-    return {
-        ...developSubTracks,
-        [dataScienceChallengeCodeSubTrack.name]: codeSubTrack
-            ? mergeDisplayedSubTrackStats(codeSubTrack, dataScienceChallengeCodeSubTrack)
-            : dataScienceChallengeCodeSubTrack,
-    }
-}
 
 /**
  * Determine whether a DATA_SCIENCE entry is a configured rating path.
@@ -452,6 +354,13 @@ const getDataScienceRatingPathTrackData = (memberStats?: UserStats): MemberStats
 export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => {
     // Create mappings for data science subtracks
     const dataScienceSubTracks: {[key: string]: MemberStats | SRMStats} = {
+        // Map Challenge subtrack
+        Challenge: (memberStats?.DATA_SCIENCE?.Challenge && ({
+            ...memberStats.DATA_SCIENCE.Challenge,
+            name: 'Challenge',
+            parentTrack: 'DATA_SCIENCE',
+            path: 'DATA_SCIENCE',
+        })) as MemberStats,
         // Map MARATHON_MATCH subtrack
         MARATHON_MATCH: (memberStats?.DATA_SCIENCE?.MARATHON_MATCH && ({
             ...memberStats.DATA_SCIENCE.MARATHON_MATCH,
@@ -476,12 +385,9 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
     )
 
     // Create mappings for develop subtracks
-    const developSubTracks: {[key: string]: MemberStats} = addDataScienceChallengeToDevelopmentCode(
-        mapSubTracksByName(
-            'DEVELOP',
-            memberStats?.DEVELOP?.subTracks,
-        ),
-        memberStats,
+    const developSubTracks: {[key: string]: MemberStats} = mapSubTracksByName(
+        'DEVELOP',
+        memberStats?.DEVELOP?.subTracks,
     )
 
     // Build aggregated stats for Design, Development, Testing, and Competitive Programming tracks
@@ -515,17 +421,19 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
 
     // Data science
     const dsSubTracks: MemberStats[] = [
+        dataScienceSubTracks.Challenge,
         dataScienceSubTracks.MARATHON_MATCH,
     ].filter(d => d?.challenges > 0) as MemberStats[]
     const dsTrackData: MemberStatsTrack = buildTrackData('Data Science', dsSubTracks)
+    const dsSummarySubTrack: MemberStats | undefined = getDataScienceSummarySubTrack(dsTrackData.subTracks)
     const dataScienceRatingPathTrackStats: MemberStatsTrack[] = getDataScienceRatingPathTrackData(memberStats)
 
     const dsTrackStats: MemberStatsTrack = {
         ...dsTrackData,
         isDSTrack: true,
         order: -1,
-        percentile: dataScienceSubTracks.MARATHON_MATCH?.rank?.percentile ?? 0,
-        rating: dataScienceSubTracks.MARATHON_MATCH?.rank?.rating ?? 0,
+        percentile: dsSummarySubTrack?.rank?.percentile ?? 0,
+        rating: dsSummarySubTrack?.rank?.rating ?? 0,
     }
 
     // Competitive Programming

--- a/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
@@ -9,12 +9,11 @@ jest.mock('~/libs/core', () => ({
 })
 
 describe('getTrackHistoryFromStats', () => {
-    it('reads compatibility history paths for displayed subtracks', () => {
+    it('reads keyed Data Science Challenge history', () => {
         const trackData = {
-            historyPaths: ['DATA_SCIENCE.Challenge.history'],
-            name: 'CODE',
-            parentTrack: 'DEVELOP',
-            path: 'DEVELOP.subTracks',
+            name: 'Challenge',
+            parentTrack: 'DATA_SCIENCE',
+            path: 'DATA_SCIENCE',
         } as MemberStats
         const history = getTrackHistoryFromStats({
             DATA_SCIENCE: {
@@ -28,9 +27,6 @@ describe('getTrackHistoryFromStats', () => {
                         },
                     ],
                 },
-            },
-            DEVELOP: {
-                subTracks: [],
             },
             groupId: 10,
             handle: 'testcoun',

--- a/src/apps/profiles/src/hooks/useTrackHistory.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.tsx
@@ -1,18 +1,6 @@
-import { find, get, orderBy, uniqBy } from 'lodash'
+import { find, get } from 'lodash'
 
 import { MemberStats, StatsHistory, UserStatsHistory, useStatsHistory } from '~/libs/core'
-
-/**
- * Extracts the history array from an exact stats-history path.
- *
- * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
- * @param {string} historyPath - Exact lodash path to a history array.
- * @returns {StatsHistory[]} History rows at the supplied path.
- */
-const getHistoryFromExactPath = (
-    statsHistory: UserStatsHistory | undefined,
-    historyPath: string,
-): StatsHistory[] => get(statsHistory, historyPath, [])
 
 /**
  * Fetches the default history data for a track using its API path and name.
@@ -37,9 +25,6 @@ const getDefaultTrackHistory = (
 /**
  * Extracts the history rows for a displayed track.
  *
- * Some displayed tracks merge history from compatibility paths, such as
- * Development > Code reading Data Science Challenge history from the API.
- *
  * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
  * @param {MemberStats | undefined} trackData - The track data for which to fetch history.
  * @returns {StatsHistory[]} History rows for the displayed track.
@@ -52,25 +37,7 @@ export const getTrackHistoryFromStats = (
         return []
     }
 
-    const trackHistory = getDefaultTrackHistory(statsHistory, trackData)
-    const compatibilityHistory = (trackData.historyPaths ?? [])
-        .flatMap(historyPath => getHistoryFromExactPath(statsHistory, historyPath))
-
-    if (compatibilityHistory.length === 0) {
-        return trackHistory
-    }
-
-    return orderBy(
-        uniqBy(
-            [
-                ...trackHistory,
-                ...compatibilityHistory,
-            ],
-            history => String(history.challengeId),
-        ),
-        [history => history.ratingDate ?? history.date ?? 0],
-        ['desc'],
-    )
+    return getDefaultTrackHistory(statsHistory, trackData)
 }
 
 /**

--- a/src/libs/core/lib/profile/user-stats.model.ts
+++ b/src/libs/core/lib/profile/user-stats.model.ts
@@ -55,23 +55,6 @@ export type MemberStats = {
     }
     parentTrack?: string
     path?: string
-    /**
-     * Exact stats-history paths to merge into this displayed subtrack.
-     *
-     * Used when a legacy display bucket is backed by stats stored under a newer
-     * API dimension.
-     */
-    historyPaths?: string[]
-    /**
-     * Track key used for rating-distribution lookups when it differs from the
-     * displayed parent track.
-     */
-    statsDistributionTrack?: string
-    /**
-     * Subtrack key used for rating-distribution lookups when it differs from
-     * the displayed subtrack name.
-     */
-    statsDistributionSubTrack?: string
 }
 
 /**


### PR DESCRIPTION
What was broken
The previous follow-up remapped member-api DATA_SCIENCE.Challenge profile stats into Development > Code based on old production behavior. The latest Jira guidance says ratings should follow the current track/type setup, where Data Science is the track and Challenge is the type.

Root cause (if identifiable)
The active-track mapper converted DATA_SCIENCE.Challenge into a synthetic DEVELOP/CODE subtrack and added compatibility history/distribution metadata, so the profile stats card and detail route displayed the rating under Development Code instead of Data Science Challenge.

What was changed
Restored DATA_SCIENCE.Challenge as an active Data Science subtrack, with the Data Science summary using the strongest visible Data Science rating. Removed the Development Code compatibility history/distribution fields while keeping zero-submission challenge activity visible.

Any added/updated tests
Updated getActiveTracks coverage to expect Data Science > Challenge, including a zero-submission challenge stats row. Updated getTrackHistoryFromStats coverage for DATA_SCIENCE.Challenge keyed history.
