### PR TITLE
PM-5223: show QA stats in Testing

### DIFF
--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -166,6 +166,48 @@ describe('getActiveTracks', () => {
             .toEqual(['BUG_HUNT'])
     })
 
+    it('shows QA Challenge stats in the testing track', () => {
+        const activeTracks: MemberStatsTrack[] = getActiveTracks({
+            QA: {
+                challenges: 1,
+                mostRecentEventDate: 1781237773026,
+                mostRecentSubmission: 1781237773026,
+                subTracks: [
+                    {
+                        challenges: 1,
+                        name: 'Challenge',
+                        rank: {
+                            rating: 1490,
+                        },
+                        submissions: {
+                            submissions: 1,
+                        },
+                        wins: 1,
+                    },
+                ],
+                wins: 1,
+            },
+        } as UserStats)
+        const testingTrack: MemberStatsTrack | undefined = activeTracks
+            .find(track => track.name === 'Testing')
+        const qaChallengeSubTrack = testingTrack?.subTracks
+            .find(track => track.name === 'Challenge')
+
+        expect(testingTrack)
+            .toEqual(expect.objectContaining({
+                challenges: 1,
+                wins: 1,
+            }))
+        expect(qaChallengeSubTrack)
+            .toEqual(expect.objectContaining({
+                name: 'Challenge',
+                parentTrack: 'QA',
+                path: 'QA.subTracks',
+            }))
+        expect(qaChallengeSubTrack?.rank?.rating)
+            .toEqual(1490)
+    })
+
     it('keeps AI engineering stats visible when the API returns them', () => {
         const memberStats = {
             AI_ENGINEERING: {

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -484,6 +484,11 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
         memberStats,
     )
 
+    const qaSubTracks: {[key: string]: MemberStats} = mapSubTracksByName(
+        'QA',
+        memberStats?.QA?.subTracks,
+    )
+
     // Build aggregated stats for Design, Development, Testing, and Competitive Programming tracks
     // AI Engineering
     const aiEngineeringTrackStats: MemberStatsTrack = buildAIEngineeringTrackData(memberStats)
@@ -508,8 +513,11 @@ export const getActiveTracks = (memberStats?: UserStats): MemberStatsTrack[] => 
     const testingTrackStats: MemberStatsTrack = (
         buildTrackData(
             'Testing',
-            Object.values(developSubTracks)
-                .filter(isTestingSubTrack),
+            [
+                ...Object.values(developSubTracks)
+                    .filter(isTestingSubTrack),
+                ...Object.values(qaSubTracks),
+            ],
         )
     )
 

--- a/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
@@ -46,4 +46,41 @@ describe('getTrackHistoryFromStats', () => {
                 }),
             ])
     })
+
+    it('reads QA subtrack history paths', () => {
+        const trackData = {
+            name: 'Challenge',
+            parentTrack: 'QA',
+            path: 'QA.subTracks',
+        } as MemberStats
+        const history = getTrackHistoryFromStats({
+            groupId: 10,
+            handle: 'testmfa6',
+            handleLower: 'testmfa6',
+            QA: {
+                subTracks: [
+                    {
+                        history: [
+                            {
+                                challengeId: 'qa-challenge',
+                                challengeName: 'QA Challenge',
+                                newRating: 1490,
+                                ratingDate: 1781237773026,
+                            },
+                        ],
+                        name: 'Challenge',
+                    },
+                ],
+            },
+            userId: 89770374,
+        } as UserStatsHistory, trackData)
+
+        expect(history)
+            .toEqual([
+                expect.objectContaining({
+                    challengeId: 'qa-challenge',
+                    newRating: 1490,
+                }),
+            ])
+    })
 })

--- a/src/libs/core/lib/profile/user-profile.model.ts
+++ b/src/libs/core/lib/profile/user-profile.model.ts
@@ -1,6 +1,6 @@
 import { UserSkill } from './user-skill.model'
 
-export type TC_TRACKS = 'DEVELOP' | 'DESIGN' | 'DATA_SCIENCE'
+export type TC_TRACKS = 'DEVELOP' | 'DESIGN' | 'DATA_SCIENCE' | 'QA'
 
 export enum NamesAndHandleAppearance {
     both = 'namesAndHandle',

--- a/src/libs/core/lib/profile/user-stats.model.ts
+++ b/src/libs/core/lib/profile/user-stats.model.ts
@@ -149,6 +149,13 @@ export type UserStats = {
         subTracks: Array<MemberStats>
         wins: number
     }
+    QA?: {
+        challenges: number
+        mostRecentEventDate: number
+        mostRecentSubmission: number
+        subTracks: Array<MemberStats>
+        wins: number
+    }
     AI?: MemberStatsGroup
     AI_ENGINEER?: MemberStatsGroup
     AI_ENGINEERING?: MemberStatsGroup
@@ -188,6 +195,12 @@ export type UserStatsHistory = {
         }
     }
     DEVELOP?: {
+        subTracks: Array<{
+            name: string
+            history: Array<StatsHistory>
+        }>
+    }
+    QA?: {
         subTracks: Array<{
             name: string
             history: Array<StatsHistory>


### PR DESCRIPTION
What was broken
The profile app only typed and read DEVELOP, DESIGN, and DATA_SCIENCE stats. Once the API emits first-class QA stats for QA Challenge ratings, those stats would not appear in the profile's Testing section.

Root cause
The profile stats models and active-track builder did not include a QA stats/history group or map QA Challenge subtracks into the displayed Testing track.

What was changed
Added QA to the profile stats/history types and active track model, then merged QA subtracks into the visible Testing track while preserving QA history paths for the stats history drawer.

Any added/updated tests
Added profile hook coverage for rendering QA Challenge stats under Testing and reading QA subtrack history from QA.subTracks.
