### PR TITLE
PM-5231: Show failed validation scores

### DIFF
--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
@@ -441,4 +441,47 @@ describe('SubmissionsTable', () => {
         expect(screen.getByRole('img', { name: 'Test status: SUCCESS' }))
             .toBeTruthy()
     })
+
+    it('renders failed example validation scores for marathon submissions', () => {
+        render(
+            <SubmissionsTable
+                canDownloadSubmissions
+                challengeId='challenge-123'
+                onDownloadSubmission={jest.fn()}
+                onOpenArtifacts={jest.fn()}
+                onSort={jest.fn()}
+                showMarathonMatchTestProgress
+                sortBy='createdAt'
+                sortOrder='desc'
+                submissions={[
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-1',
+                        id: 'submission-1',
+                        reviewSummation: [
+                            {
+                                aggregateScore: -1,
+                                isExample: true,
+                                metadata: {
+                                    testProgress: 1,
+                                    testStatus: 'FAILED',
+                                    testType: 'example',
+                                },
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                ]}
+            />,
+        )
+
+        expect(screen.getByRole('link', { name: '-1.00 / -' }))
+            .toBeTruthy()
+        expect(screen.getByText('Example'))
+            .toBeTruthy()
+        expect(screen.getByText('100%'))
+            .toBeTruthy()
+        expect(screen.getByRole('img', { name: 'Test status: FAILED' }))
+            .toBeTruthy()
+    })
 })

--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
@@ -168,7 +168,7 @@ function formatTestProcess(process?: string): string {
  * Selects the marathon score shown in the left side of the score column.
  * @param submission Submission row with review summation data.
  * @param process Current marathon test process from progress metadata.
- * @returns Example score when Example is current; otherwise the provisional score.
+ * @returns Example score when Example is current; otherwise the provisional score, including MM failure scores.
  * Used by `SubmissionsTable` for marathon score display.
  */
 function getMarathonInitialScore(
@@ -183,7 +183,7 @@ function getMarathonInitialScore(
         }
     }
 
-    return getSubmissionProvisionalScore(submission)
+    return getSubmissionProvisionalScore(submission, true)
 }
 
 function getSortIndicator(
@@ -379,7 +379,7 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                             ? getMarathonInitialScore(submission, testProgress?.process)
                             : getSubmissionInitialScore(submission)
                         const finalScoreValue = props.showMarathonMatchTestProgress
-                            ? getSubmissionSystemScore(submission)
+                            ? getSubmissionSystemScore(submission, true)
                             : getSubmissionFinalScore(submission)
                         const emptyScoreValue = props.showMarathonMatchTestProgress
                             ? '-'

--- a/src/apps/work/src/lib/utils/challenge.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.spec.ts
@@ -76,6 +76,22 @@ describe('challenge utils', () => {
             }))
                 .toBe(15.25)
         })
+
+        it('returns failed example scorer scores', () => {
+            expect(getSubmissionExampleScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: -1,
+                        isExample: true,
+                        metadata: {
+                            testStatus: 'FAILED',
+                            testType: 'example',
+                        },
+                    },
+                ],
+            }))
+                .toBe(-1)
+        })
     })
 
     describe('getSubmissionTestProgress', () => {
@@ -192,6 +208,22 @@ describe('challenge utils', () => {
             }))
                 .toBeUndefined()
         })
+
+        it('returns failed provisional scorer scores when requested', () => {
+            expect(getSubmissionProvisionalScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: -1,
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                            testStatus: 'FAILED',
+                        },
+                    },
+                ],
+            }, true))
+                .toBe(-1)
+        })
     })
 
     describe('getSubmissionSystemScore', () => {
@@ -287,6 +319,22 @@ describe('challenge utils', () => {
                 ],
             }))
                 .toBeUndefined()
+        })
+
+        it('returns failed system scorer scores when requested', () => {
+            expect(getSubmissionSystemScore({
+                reviewSummation: [
+                    {
+                        aggregateScore: -1,
+                        isFinal: true,
+                        metadata: {
+                            testProcess: 'system',
+                            testStatus: 'FAILED',
+                        },
+                    },
+                ],
+            }, true))
+                .toBe(-1)
         })
     })
 })

--- a/src/apps/work/src/lib/utils/challenge.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.ts
@@ -106,6 +106,14 @@ function toValidScore(value: unknown): number | undefined {
         : undefined
 }
 
+function toFiniteScore(value: unknown): number | undefined {
+    const score = Number(value)
+
+    return Number.isFinite(score)
+        ? score
+        : undefined
+}
+
 function getAverageScore(scores: Array<number | undefined>): number | undefined {
     const validScores = scores
         .filter((score): score is number => score !== undefined)
@@ -141,12 +149,14 @@ function getReviewSummationScoreTimestamp(entry: ReviewSummation): number {
  * Returns the latest valid score from matching Review API summations.
  * @param reviewSummation Review summations attached to a submission.
  * @param matcher Predicate that selects the requested Marathon Match score phase.
+ * @param allowNegativeScore Whether failed Marathon Match scorer scores like -1 should be retained.
  * @returns Latest valid aggregate score, or `undefined` when no matching score exists.
  * Used by marathon score display so relative-score rewrites replace stale raw scores.
  */
 function getScoreFromSummation(
     reviewSummation: ReviewSummation[] | undefined,
     matcher: (entry: ReviewSummation) => boolean,
+    allowNegativeScore: boolean = false,
 ): number | undefined {
     if (!Array.isArray(reviewSummation) || !reviewSummation.length) {
         return undefined
@@ -156,7 +166,9 @@ function getScoreFromSummation(
         .map((entry, index) => ({
             entry,
             index,
-            score: toValidScore(entry.aggregateScore),
+            score: allowNegativeScore
+                ? toFiniteScore(entry.aggregateScore)
+                : toValidScore(entry.aggregateScore),
             timestamp: getReviewSummationScoreTimestamp(entry),
         }))
         .filter(item => item.score !== undefined && matcher(item.entry))
@@ -504,6 +516,7 @@ export function getSubmissionExampleScore(
     return getScoreFromSummation(
         submission.reviewSummation,
         item => getReviewSummationTestProcess(item) === 'example',
+        true,
     )
 }
 
@@ -514,15 +527,18 @@ export function getProvisionalScore(submission: ScoredSubmissionLike): number {
 /**
  * Returns only the provisional marathon score for a submission.
  * @param submission Submission-like object containing legacy phase scores or Review API summations.
+ * @param allowNegativeScore Whether failed Marathon Match scorer scores like -1 should be retained.
  * @returns Provisional score, or `undefined` when provisional scoring has not produced a valid score.
  * Used by marathon submission score display to prefer latest relative summations over stale raw scores.
  */
 export function getSubmissionProvisionalScore(
     submission: ScoredSubmissionLike,
+    allowNegativeScore: boolean = false,
 ): number | undefined {
     const provisionalSummationScore = getScoreFromSummation(
         submission.reviewSummation,
         item => getReviewSummationTestProcess(item) === 'provisional',
+        allowNegativeScore,
     )
     if (provisionalSummationScore !== undefined) {
         return provisionalSummationScore
@@ -572,15 +588,18 @@ export function getFinalScore(submission: ScoredSubmissionLike): number {
 /**
  * Returns only the system marathon score for a submission.
  * @param submission Submission-like object containing legacy phase scores or Review API summations.
+ * @param allowNegativeScore Whether failed Marathon Match scorer scores like -1 should be retained.
  * @returns System score, or `undefined` when system scoring has not produced a valid score.
  * Used by marathon submission score display to prefer latest relative summations over stale raw scores.
  */
 export function getSubmissionSystemScore(
     submission: ScoredSubmissionLike,
+    allowNegativeScore: boolean = false,
 ): number | undefined {
     const systemSummationScore = getScoreFromSummation(
         submission.reviewSummation,
         item => getReviewSummationTestProcess(item) === 'system',
+        allowNegativeScore,
     )
     if (systemSummationScore !== undefined) {
         return systemSummationScore


### PR DESCRIPTION
What was broken
The Work Manager Submissions tab could still display a blank score for Marathon Match validation uploads when the scorer completed with a failed aggregate score such as -1.

Root cause (if identifiable)
The previous PM-5231 UI follow-up added Example phase display support, but the shared review-summation score helper still rejected all negative aggregate scores. Marathon Match uses -1 as the failed scorer result, so failed Example, Provisional, or System validation scores were filtered out before the table rendered them.

What was changed
Kept the default non-negative score behavior for standard score paths, and added an explicit Marathon Match validation display path that retains finite negative scorer results. The submissions table now opts into that behavior for Marathon Match Provisional/System display, while Example scores retain the failed result as well.

Any added/updated tests
Added utility coverage for failed Example, Provisional, and System validation scores, plus table coverage that renders a failed Example score as -1.00 with the Example process and failed status.

Validation
- yarn test:no-watch src/apps/work/src/lib/utils/challenge.utils.spec.ts src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx --runInBand
- yarn lint
- yarn run build

Note: yarn test:no-watch --runInBand was also run and still fails in unrelated existing suites outside this PM-5231 path, including wallet-admin icon/module resolution, Work reviewer service mocks, engagement assignment helper mocks, and billing alias resolution.
