### PR TITLE
PM-5394: Left align mobile rating position

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -106,7 +106,7 @@
         flex-wrap: nowrap;
         gap: $sp-4;
         grid-column: 1 / -1;
-        justify-content: center;
+        justify-content: flex-start;
     }
 }
 


### PR DESCRIPTION
## What was broken
Mobile rating comparison modals centered the Position summary after the pyramid graphic was removed.

## Root cause (if identifiable)
The small-screen `.positionMetric` styles still used `justify-content: center`, so the remaining position data stayed centered in the summary row.

## What was changed
Changed the small-screen `.positionMetric` alignment to `justify-content: flex-start` so the Position data lines up with the summary panel padding on mobile.

## Any added/updated tests
No tests were added or updated for this one-line responsive style change.

Validation run:
- `yarn test:no-watch MemberRatingInfoModal --runInBand` passed.
- `yarn lint` passed.
- `yarn run build` passed with existing webpack/CSS order and CRA warnings.
- `yarn test:no-watch --runInBand` was also run. It currently fails in unrelated wallet/work suites on the dev baseline: 145 suites passed and 12 failed, with errors such as undefined Heroicon components in `PaymentAgreementBanner`, missing mocked exports like `fetchAiReviewConfigByChallenge`, and unrelated module resolution failures.
