### PR TITLE
PM-5395: Fix rating modal top percentile display

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -86,4 +86,23 @@ describe('MemberRatingInfoModal', () => {
         expect(screen.getByText('Where Emily ranks in the distribution'))
             .toBeInTheDocument()
     })
+
+    it('shows a positive sub-one percentile as top one percent', () => {
+        render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={0.4}
+                profile={baseProfile}
+                rating={3664}
+                ratingDistribution={ratingDistribution}
+            />,
+        )
+
+        expect(screen.getByText(/TOP\s+1%/))
+            .toBeInTheDocument()
+        expect(screen.queryByText(/TOP\s+0%/))
+            .not
+            .toBeInTheDocument()
+    })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { getRatingColor, UserProfile, UserStatsDistributionResponse } from '~/libs/core'
 import { BaseModal } from '~/libs/ui'
 
-import { numberToFixed } from '../../../../lib'
+import { formatTopPercentile } from '../MemberRatingCard.utils'
 
 import styles from './MemberRatingInfoModal.module.scss'
 
@@ -101,7 +101,8 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
 /**
  * Formats percentile values for the rating comparison modal.
  *
- * Used by MemberRatingInfoModal to keep the top percentile text compact.
+ * Used by MemberRatingInfoModal to keep the top percentile text consistent with
+ * the compact rating card, including showing positive sub-1% values as 1%.
  *
  * @param {number | undefined} percentile - The percentile value calculated from the rating distribution.
  * @returns {string} A display-ready percentage or `--` when the percentile is unavailable.
@@ -109,7 +110,7 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
 const formatPercentile = (percentile?: number): string => (
     percentile === undefined || percentile === 0
         ? '--'
-        : numberToFixed(percentile, 0)
+        : formatTopPercentile(percentile)
 )
 
 /**


### PR DESCRIPTION
What was broken

The profile rating info pop-up could show TOP 0% for highly rated members whose calculated top percentile was positive but below one percent.

Root cause

The compact profile card already clamps positive sub-one percentile values to 1%, but the modal used a separate formatter that rounded those values to 0.

What was changed

The rating modal now reuses the compact card percentile formatter so positive sub-one values render as TOP 1% consistently across both surfaces.

Any added/updated tests

Added a MemberRatingInfoModal regression test covering a positive sub-one percentile value so it renders TOP 1% and never TOP 0%.

Validation run:

- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
- source ~/.nvm/nvm.sh && nvm use && yarn lint
- source ~/.nvm/nvm.sh && nvm use && yarn run build
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch

The targeted modal spec, lint, and build passed. The full yarn test:no-watch command still fails on unrelated existing work and wallet-admin specs outside the profiles app, including missing mocked utility exports/module aliases and an engagement schema expectation.
