### PR TITLE
PM-5401: Keep member stats text readable with TCO banner

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
@@ -210,7 +210,7 @@
     white-space: nowrap;
 }
 
-@container (max-width: 520px) {
+@container (max-width: 420px) {
     .container {
         padding: $sp-4;
 


### PR DESCRIPTION
What was broken
Member stats reused the same narrow-card breakpoint for both the one-column layout and compact mobile typography. When the TCO trip-winner banner made the stats card narrow on desktop, the card switched to noticeably smaller text.

Root cause
The compact typography rules were tied to the 520px layout breakpoint instead of a narrower phone-width breakpoint.

What was changed
Moved the compact member-stats typography, icon, and padding container query from 520px to 420px. The stats list can still switch to one column at 520px, but desktop-sized text remains at the side-by-side TCO card width.

Any added/updated tests
No tests were added because this is a CSS container-query adjustment and the repo has no browser visual test harness for this card.

Validation
- yarn test:no-watch --runInBand src/apps/profiles/src passed.
- yarn test:no-watch --runInBand src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing CSS-order and bundle-size warnings.
- yarn test:no-watch --runInBand was run and failed in unrelated work, engagements, and wallet suites on existing baseline issues.
