### PR TITLE
PM-5402: Stack high rating marker label

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -225,6 +225,18 @@
     z-index: 1;
 }
 
+.memberMarkerStacked {
+    &::after {
+        top: $sp-14;
+    }
+
+    .markerBadge {
+        flex-direction: column;
+        gap: $sp-1;
+        transform: translateX(0);
+    }
+}
+
 .markerAvatar {
     align-items: center;
     background: $tc-white;

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -105,4 +105,20 @@ describe('MemberRatingInfoModal', () => {
             .not
             .toBeInTheDocument()
     })
+
+    it('stacks the marker rating for high ratings near the right edge of the chart', () => {
+        render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={0.4}
+                profile={baseProfile}
+                rating={3664}
+                ratingDistribution={ratingDistribution}
+            />,
+        )
+
+        expect(screen.getByTestId('rating-member-marker'))
+            .toHaveClass('memberMarkerStacked')
+    })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -98,6 +98,8 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
     value: 2200,
 }]
 
+const stackedMarkerPositionThreshold = 90
+
 /**
  * Formats percentile values for the rating comparison modal.
  *
@@ -269,6 +271,7 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const markerPosition: number = props.rating !== undefined
         ? getChartPosition(props.rating, distributionRanges)
         : 0
+    const shouldStackMarkerRating: boolean = markerPosition >= stackedMarkerPositionThreshold
     const percentileLabel: string = formatPercentile(props.percentile)
 
     return (
@@ -354,7 +357,11 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
 
                             {props.rating !== undefined && (
                                 <div
-                                    className={styles.memberMarker}
+                                    className={classNames(
+                                        styles.memberMarker,
+                                        shouldStackMarkerRating && styles.memberMarkerStacked,
+                                    )}
+                                    data-testid='rating-member-marker'
                                     style={{ left: `${markerPosition}%` }}
                                 >
                                     <div className={styles.markerBadge}>


### PR DESCRIPTION
What was broken
High member ratings near the right edge of the rating distribution chart kept the avatar and rating inline, which could push the numeric rating partly outside the chart.

Root cause
The marker badge always translated the avatar and rating to the right of the marker, leaving no alternate layout for right-edge positions.

What was changed
Added a right-edge marker layout that stacks the rating below the avatar when the marker is at least 90% across the chart, keeping the value visible while preserving the existing inline layout elsewhere.

Any added/updated tests
Added a MemberRatingInfoModal regression test for a 3664 rating that verifies the stacked marker layout is applied.

Validation:
- Passed: yarn lint
- Passed: yarn run build (completed with existing CRA build warnings)
- Passed: yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
- Not passed: yarn test:no-watch and yarn test:no-watch --runInBand currently fail in unrelated work/wallet suites on dev.
