### PR TITLE
PM-5403: Reduce profile section spacing

### DIFF
--- a/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
+++ b/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
@@ -160,7 +160,7 @@
         .expirenceWrap {
             display: grid;
             grid-template-columns: 1fr;
-            gap: 40px;
+            gap: 0;
 
             @include ltelg {
                 grid-template-columns: 1fr;


### PR DESCRIPTION
What was broken
The profile Experience and Education and Certifications cards had a larger vertical gap than the updated design.

Root cause
The Experience/Education wrapper added a 40px grid gap on top of the existing section card margin.

What was changed
Removed the extra grid gap from the profile Experience/Education wrapper so the stack relies on the standard section spacing.

Any added/updated tests
No tests were added because this is a CSS-only spacing change.

Validation run:
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch --runInBand --testPathPattern=src/apps/profiles/src/member-profile: passed, 6 suites and 32 tests.
- source ~/.nvm/nvm.sh && nvm use && yarn lint: passed.
- source ~/.nvm/nvm.sh && nvm use && yarn run build: passed with existing warnings.
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch --runInBand: failed in unrelated wallet-admin and work specs outside this change.
