### PR TITLE
PM-5397: Show AI Engineering challenge history

### DIFF
--- a/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.spec.tsx
@@ -79,4 +79,41 @@ describe('getTrackHistoryFromStats', () => {
                 }),
             ])
     })
+
+    it('reads AI Engineering challenge history from Data Science aliases', () => {
+        const trackData = {
+            name: 'AI Engineering',
+            parentTrack: 'DEVELOP',
+            path: 'DEVELOP.subTracks',
+        } as MemberStats
+        const history = getTrackHistoryFromStats({
+            DATA_SCIENCE: {
+                AI: {
+                    history: [
+                        {
+                            challengeId: 'ai-challenge',
+                            challengeName: 'AI Challenge',
+                            newRating: 840,
+                            ratingDate: 1781237773026,
+                        },
+                    ],
+                },
+            },
+            DEVELOP: {
+                subTracks: [],
+            },
+            groupId: 10,
+            handle: 'aimember',
+            handleLower: 'aimember',
+            userId: 89770399,
+        } as unknown as UserStatsHistory, trackData)
+
+        expect(history)
+            .toEqual([
+                expect.objectContaining({
+                    challengeId: 'ai-challenge',
+                    newRating: 840,
+                }),
+            ])
+    })
 })

--- a/src/apps/profiles/src/hooks/useTrackHistory.tsx
+++ b/src/apps/profiles/src/hooks/useTrackHistory.tsx
@@ -2,6 +2,98 @@ import { find, get } from 'lodash'
 
 import { MemberStats, StatsHistory, UserStatsHistory, useStatsHistory } from '~/libs/core'
 
+const AI_ENGINEERING_HISTORY_NAMES = [
+    'AI Engineering',
+    'AI',
+    'AI_ENGINEER',
+    'AI_ENGINEERING',
+]
+
+const AI_ENGINEERING_TRACK_TOKENS = new Set([
+    'AI',
+    'AI_ENGINEER',
+    'AI_ENGINEERING',
+])
+
+const AI_ENGINEERING_HISTORY_PATHS = [
+    'DATA_SCIENCE',
+    'DEVELOP.subTracks',
+    'AI_ENGINEERING',
+    'AI',
+    'AI_ENGINEER',
+]
+
+/**
+ * Normalizes a track or rating path name for alias comparison.
+ *
+ * @param {string | undefined} value - Raw track, subtrack, or configured rating path name.
+ * @returns {string} Uppercase underscore-delimited token.
+ */
+const normalizeTrackToken = (value?: string): string => (
+    value?.trim()
+        .toUpperCase()
+        .replace(/[\s-]+/g, '_') ?? ''
+)
+
+/**
+ * Checks whether a displayed stats subtrack represents AI Engineering.
+ *
+ * @param {MemberStats} trackData - Displayed subtrack data from the member stats payload.
+ * @returns {boolean} Whether the subtrack should use AI Engineering history aliases.
+ */
+const isAIEngineeringTrackData = (trackData: MemberStats): boolean => (
+    AI_ENGINEERING_TRACK_TOKENS.has(normalizeTrackToken(trackData.name))
+    || AI_ENGINEERING_TRACK_TOKENS.has(normalizeTrackToken(trackData.parentTrack))
+)
+
+/**
+ * Returns a history array only when it contains challenge rows.
+ *
+ * @param {StatsHistory[] | undefined} history - Candidate history rows.
+ * @returns {StatsHistory[] | undefined} Non-empty history rows, otherwise undefined.
+ */
+const getNonEmptyHistory = (history?: StatsHistory[]): StatsHistory[] | undefined => (
+    Array.isArray(history) && history.length > 0 ? history : undefined
+)
+
+/**
+ * Reads the first non-empty history array from keyed or subtrack-based paths.
+ *
+ * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
+ * @param {string[]} paths - Candidate API paths that may contain history.
+ * @param {string[]} trackNames - Candidate subtrack or rating path names.
+ * @returns {StatsHistory[] | undefined} First matching history rows.
+ */
+const getFirstMatchingHistory = (
+    statsHistory: UserStatsHistory | undefined,
+    paths: string[],
+    trackNames: string[],
+): StatsHistory[] | undefined => {
+    for (const path of paths) {
+        const subTracks = get(statsHistory, path)
+
+        if (Array.isArray(subTracks)) {
+            const history = getNonEmptyHistory(
+                find(subTracks, subTrack => trackNames.includes(subTrack.name))?.history,
+            )
+
+            if (history) {
+                return history
+            }
+        }
+
+        for (const trackName of trackNames) {
+            const history = getNonEmptyHistory(get(statsHistory, `${path}.${trackName}.history`))
+
+            if (history) {
+                return history
+            }
+        }
+    }
+
+    return undefined
+}
+
 /**
  * Fetches the default history data for a track using its API path and name.
  *
@@ -12,15 +104,31 @@ import { MemberStats, StatsHistory, UserStatsHistory, useStatsHistory } from '~/
 const getDefaultTrackHistory = (
     statsHistory: UserStatsHistory | undefined,
     trackData: MemberStats,
-): StatsHistory[] => get(
-    find(get(statsHistory, `${trackData.path}`, []), { name: trackData.name }),
-    'history',
+): StatsHistory[] => (
+    getFirstMatchingHistory(statsHistory, [trackData.path ?? ''], [trackData.name]) ?? []
 )
-    // marathon match and some unified stats dimensions have a keyed history structure
-    || get(
+
+/**
+ * Reads AI Engineering history across the API aliases used before and after
+ * the profile hierarchy moved AI Engineering under Development.
+ *
+ * @param {UserStatsHistory | undefined} statsHistory - Raw stats-history payload.
+ * @param {MemberStats} trackData - Displayed AI Engineering subtrack data.
+ * @returns {StatsHistory[]} AI Engineering challenge history rows.
+ */
+const getAIEngineeringTrackHistory = (
+    statsHistory: UserStatsHistory | undefined,
+    trackData: MemberStats,
+): StatsHistory[] => (
+    getFirstMatchingHistory(
         statsHistory,
-        `${trackData.path}.${trackData.name}.history`,
-    ) || []
+        [
+            trackData.path,
+            ...AI_ENGINEERING_HISTORY_PATHS,
+        ].filter((path): path is string => !!path),
+        AI_ENGINEERING_HISTORY_NAMES,
+    ) ?? []
+)
 
 /**
  * Extracts the history rows for a displayed track.
@@ -37,7 +145,11 @@ export const getTrackHistoryFromStats = (
         return []
     }
 
-    return getDefaultTrackHistory(statsHistory, trackData)
+    const defaultHistory = getDefaultTrackHistory(statsHistory, trackData)
+
+    return defaultHistory.length > 0 || !isAIEngineeringTrackData(trackData)
+        ? defaultHistory
+        : getAIEngineeringTrackHistory(statsHistory, trackData)
 }
 
 /**


### PR DESCRIPTION
What was broken
AI Engineering could show challenge counts on the profile stats page while the Challenges Details view was empty.

Root cause
The profile history lookup used only the displayed subtrack name and current API path. After AI Engineering was normalized under Development, the history response could still be keyed by Data Science AI aliases such as DATA_SCIENCE.AI, so no challenge history rows were found.

What was changed
Added AI Engineering history alias fallback logic that keeps the exact history lookup first, then checks the known AI Engineering aliases across Data Science, Development, and top-level AI paths.

Any added/updated tests
Added a useTrackHistory regression test for a Development AI Engineering subtrack reading challenge history from the DATA_SCIENCE.AI alias.

Validation
- yarn lint: passed
- yarn test:no-watch --runTestsByPath src/apps/profiles/src/hooks/useTrackHistory.spec.tsx: passed
- yarn run build: passed with existing warnings
- yarn test:no-watch: failed in unrelated Work and Wallet suites on the origin/dev-based branch; the new profile history spec passed in the full run.
