### PR TITLE
PM-5384: Tune profile photo name spacing

### DIFF
--- a/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
+++ b/src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss
@@ -118,7 +118,7 @@
             .profileInfoLeft {
                 display: flex;
                 flex-direction: column;
-                margin-top: -140px;
+                margin-top: -120px;
 
                 @include ltelg {
                     margin-top: 0;


### PR DESCRIPTION
What was broken

The previous PM-5384 fix moved the desktop About Me greeting closer to the profile picture, but QA reported that the result was now a bit too close and needed more breathing room.

Root cause

The prior desktop left-column offset changed from -60px to -140px, which corrected the original oversized gap but slightly overcorrected the spacing under the avatar.

What was changed

Reduced the desktop left profile column offset from -140px to -120px so the greeting sits lower while still remaining much closer to the profile picture than the original layout. Tablet and mobile offsets remain unchanged.

Any added/updated tests

No tests were added because this is a CSS-only spacing adjustment.

Validation:
- `yarn lint` passed.
- `yarn run build` passed, with existing CRA/webpack warnings.
- `yarn test:no-watch src/apps/profiles/src/member-profile` passed: 6 suites, 33 tests.
- `yarn test:no-watch --findRelatedTests src/apps/profiles/src/member-profile/page-layout/ProfilePageLayout.module.scss` found no related tests and exited successfully.
- Full `yarn test:no-watch` was attempted but currently fails in unrelated `work`, `engagements`, and `wallet-admin` suites outside this CSS-only profiles change.
