### PR TITLE
PM-5402: Stack high rating marker sooner

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -28,6 +28,17 @@ const ratingDistribution = {
     updatedBy: 'test',
 }
 
+const wideRatingDistribution = {
+    ...ratingDistribution,
+    distribution: {
+        ratingRange0To899: 10,
+        ratingRange900To1199: 20,
+        ratingRange1200To1499: 30,
+        ratingRange1500To2199: 40,
+        ratingRange2200To4499: 1,
+    },
+}
+
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(() => '#616BD5'),
 }), {
@@ -95,7 +106,7 @@ describe('MemberRatingInfoModal', () => {
                 percentile={0.4}
                 profile={baseProfile}
                 rating={3664}
-                ratingDistribution={ratingDistribution}
+                ratingDistribution={wideRatingDistribution}
             />,
         )
 

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -98,7 +98,9 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
     value: 2200,
 }]
 
-const stackedMarkerPositionThreshold = 90
+// The inline avatar and score need room to the right of the marker, so stack
+// before the marker reaches the final segment of the chart.
+const stackedMarkerPositionThreshold = 80
 
 /**
  * Formats percentile values for the rating comparison modal.


### PR DESCRIPTION
What was broken
The prior PM-5402 fix only stacked the rating label after the marker reached 90% of the chart. QA still saw the tourist rating rendered inline and clipped at the right edge.

Root cause
The inline avatar and score need horizontal room to the right of the marker, so a percentage threshold that close to the edge was too conservative. The previous regression test used a shortened distribution that clamped 3664 to the chart end, so it did not cover a high score that sits before the final tenth of the rendered chart.

What was changed
Lowered the right-edge stacking threshold to 80% so high ratings switch to the stacked avatar-over-score layout before the inline badge can run out of space.

Any added/updated tests
Updated the MemberRatingInfoModal regression fixture so the 3664 score is tested against a wider distribution range and still applies the stacked marker layout.

Validation
Passed: yarn lint
Passed: yarn run build (completed with existing CRA build warnings)
Passed: yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
Not passed: yarn test:no-watch currently fails in unrelated work, engagements, and wallet-admin suites on dev-era issues outside this profiles change.
