### PR TITLE
PM-5401: Align member stats chevrons

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
@@ -151,6 +151,7 @@
 .trackDetails {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     min-width: 136px;
 
     > svg {

--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
@@ -92,4 +92,9 @@ describe('MemberStatsBlock typography styles', () => {
         expect(memberStatsBlockStyles)
             .toMatch(/\.trackName \{[\s\S]*?font-size: 16px;/)
     })
+
+    it('right-aligns track details so member stats chevrons line up', () => {
+        expect(memberStatsBlockStyles)
+            .toMatch(/\.trackDetails \{[\s\S]*?justify-content: flex-end;/)
+    })
 })


### PR DESCRIPTION
What was broken
The previous PM-5401 fix kept member stats text readable in the trip-winner layout, but QA reported that the right-side chevrons still did not align consistently across rows.

Root cause
The track details area had a fixed minimum width, but its internal flex contents were left-aligned. Rows with no winner or rating icon could leave unused space after the chevron, while rows with icons or wider values pushed the chevron farther right.

What was changed
Right-aligned the track details contents so every stats-row chevron sits on the same right edge while preserving the existing card markup, spacing, and typography behavior from the previous fix.

Any added/updated tests
Updated the MemberStatsBlock SCSS test to assert that track details use right alignment for consistent chevron placement.

Validation
- yarn test:no-watch --runInBand src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx passed.
- yarn test:no-watch --runInBand src/apps/profiles/src passed.
- yarn lint passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch --runInBand was run and still fails in unrelated wallet-admin and work suites with existing module/mock/schema failures outside this change.
