### PR TITLE
PM-5406: Close rating tooltip with info modal

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
 import type { PropsWithChildren } from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import type { UserProfile, UserStats, UserStatsDistributionResponse } from '~/libs/core'
 import { useMemberStats, useStatsDistribution } from '~/libs/core'
 
 import MemberRatingCard from './MemberRatingCard'
+
+const mockTooltip = jest.fn((props: PropsWithChildren<{ disableTooltip?: boolean }>) => <>{props.children}</>)
 
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(() => '#616BD5'),
@@ -17,7 +19,7 @@ jest.mock('~/libs/core', () => ({
 })
 
 jest.mock('~/libs/ui', () => ({
-    Tooltip: (props: PropsWithChildren) => <>{props.children}</>,
+    Tooltip: (props: PropsWithChildren<{ disableTooltip?: boolean }>) => mockTooltip(props),
 }), {
     virtual: true,
 })
@@ -31,7 +33,11 @@ jest.mock('../../../lib', () => ({
 }))
 
 jest.mock('./MemberRatingInfoModal', () => ({
-    MemberRatingInfoModal: () => <div />,
+    MemberRatingInfoModal: (props: { onClose: () => void }) => (
+        <div role='dialog'>
+            <button type='button' onClick={props.onClose}>Close rating modal</button>
+        </div>
+    ),
 }))
 
 jest.mock('./ModifyPreferredRolesModal', () => ({
@@ -61,9 +67,24 @@ const defaultProps = {
     profile,
 }
 
+/**
+ * Returns the props from the latest mocked Tooltip render.
+ * Used to verify the rating card disables its percentile tooltip while the rating modal is open.
+ *
+ * @returns The most recent Tooltip props captured by the mock.
+ */
+function getLastTooltipProps(): PropsWithChildren<{ disableTooltip?: boolean }> {
+    const lastTooltipCall = mockTooltip.mock.calls[mockTooltip.mock.calls.length - 1]
+
+    return lastTooltipCall[0]
+}
+
 describe('MemberRatingCard', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockTooltip.mockImplementation((props: PropsWithChildren<{ disableTooltip?: boolean }>) => (
+            <>{props.children}</>
+        ))
         mockedUseStatsDistribution.mockReturnValue(ratingDistribution)
     })
 
@@ -124,5 +145,42 @@ describe('MemberRatingCard', () => {
             .toHaveAttribute('style')
         expect(screen.getByText('Data Scientists'))
             .toBeInTheDocument()
+    })
+
+    it('disables the percentile tooltip while the rating modal is open', () => {
+        mockedUseMemberStats.mockReturnValue({
+            DATA_SCIENCE: {
+                MARATHON_MATCH: {
+                    mostRecentEventDate: 1000,
+                    rank: {
+                        percentile: 42,
+                        rating: 1200,
+                    },
+                },
+            },
+            maxRating: {
+                rating: 1200,
+            },
+        } as unknown as UserStats)
+
+        render(<MemberRatingCard {...defaultProps} />)
+
+        expect(getLastTooltipProps().disableTooltip)
+            .toBe(false)
+
+        fireEvent.click(screen.getByRole('button', { name: /Top 70% Data Scientists/i }))
+
+        expect(screen.getByRole('dialog'))
+            .toBeInTheDocument()
+        expect(getLastTooltipProps().disableTooltip)
+            .toBe(true)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close rating modal' }))
+
+        expect(screen.queryByRole('dialog'))
+            .not
+            .toBeInTheDocument()
+        expect(getLastTooltipProps().disableTooltip)
+            .toBe(false)
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -166,6 +166,7 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
                                     {audienceLabel.toLowerCase()}
                                 </span>
                             )}
+                            disableTooltip={isInfoModalOpen}
                             place='top'
                         >
                             <button


### PR DESCRIPTION
What was broken
The profile rating percentile tooltip could remain visible after opening the rating information modal and then closing it.

Root cause
The percentile tooltip was uncontrolled and stayed mounted while the rating modal was open, so its hover state could survive the modal overlay lifecycle.

What was changed
Disable the percentile tooltip whenever the rating information modal is open, which unmounts the tooltip until the modal closes.

Any added/updated tests
Updated MemberRatingCard tests to assert the percentile tooltip is disabled while the rating modal is open and restored after closing.

Validation:
- yarn test:no-watch src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
- yarn lint
- yarn run build
- yarn test:no-watch (attempted; existing unrelated failures in work, engagements, and wallet-admin specs)
