### PR TITLE
PM-5412: Disable closed phase start dates

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx
@@ -512,7 +512,7 @@ describe('ChallengeScheduleSection component', () => {
             .toEqual(expect.objectContaining({
                 isDurationEditable: false,
                 isEndDateEditable: false,
-                isStartDateEditable: true,
+                isStartDateEditable: false,
             }))
         expect(checkpointReviewRow)
             .toEqual(expect.objectContaining({

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.spec.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.spec.ts
@@ -30,6 +30,20 @@ describe('ChallengeScheduleSection helpers', () => {
             expect(result)
                 .toBe(true)
         })
+
+        it('does not allow editing completed submission phase start time', () => {
+            const result = canEditPhaseStartDate(
+                buildPhase({
+                    actualEndDate: '2026-04-09T12:51:00.000Z',
+                    name: 'Submission',
+                }),
+                1,
+                false,
+            )
+
+            expect(result)
+                .toBe(false)
+        })
     })
 
     describe('recalculatePhases', () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.utils.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.utils.ts
@@ -92,6 +92,10 @@ export function canEditPhaseStartDate(
     index: number,
     isTwoRoundDesignChallenge: boolean,
 ): boolean {
+    if (phase.actualEndDate) {
+        return false
+    }
+
     const normalizedPhaseName = normalizePhaseName(phase.name)
     const isRegistrationPhase = normalizedPhaseName === 'registration'
     const isStandardSubmissionPhase = normalizedPhaseName === 'submission'


### PR DESCRIPTION
What was broken
Registration and submission phase start date fields stayed editable after those phases had completed, while the matching end date and duration controls were already locked.

Root cause
The schedule start-date editability helper only checked phase type and sequencing rules. It did not apply the completed-phase lock condition based on actualEndDate.

What was changed
Closed phases with an actual end date are no longer considered start-date editable. This disables completed registration and submission row start date fields through the existing PhaseEditorRow props.

Any added/updated tests
Updated ChallengeScheduleSection component coverage to expect a completed registration start date to be disabled.

Added helper coverage to ensure a completed submission phase cannot edit its start date.

Validation run:
Passed: export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use && yarn test:no-watch src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.spec.ts src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx

Passed: export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use && yarn lint

Passed: export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use && yarn run build

Full suite note: export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use && yarn test:no-watch fails in 12 suites outside this change area, including engagement payment, reviewer field, challenge prizes, wallet-admin, and assignment schema specs.
