### PR TITLE
PM-5401: Reserve member stats chevron column

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.module.scss
@@ -149,29 +149,27 @@
 }
 
 .trackDetails {
-    display: flex;
+    display: grid;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: end;
+    grid-template-columns: $sp-6 $sp-3 minmax(58px, max-content) $sp-4 $sp-4;
     min-width: 136px;
-
-    > svg {
-        flex: 0 0 auto;
-    }
 }
 
 .rightArrowIcon {
-    margin-left: $sp-4;
     color: rgba($tc-white, 0.9);
+    grid-column: 5;
 }
 
 .winnerIcon {
     color: #F2C900;
-    margin-right: $sp-3;
+    grid-column: 1;
 }
 
 .trackStats {
     display: flex;
     flex-direction: column;
+    grid-column: 3;
     text-align: right;
     min-width: 58px;
 
@@ -197,7 +195,7 @@
 
     background: currentColor;
     border-radius: 50%;
-    margin-right: $sp-3;
+    grid-column: 1;
 }
 
 .trackName {
@@ -238,6 +236,7 @@
     }
 
     .trackDetails {
+        grid-template-columns: $sp-4 $sp-1 minmax(42px, max-content) $sp-1 $sp-3;
         min-width: 96px;
     }
 
@@ -262,16 +261,13 @@
 
     .icon {
         @include icon-lg;
-        margin-right: $sp-1;
     }
 
     .winnerIcon {
         @include icon-lg;
-        margin-right: $sp-1;
     }
 
     .rightArrowIcon {
         @include icon-md;
-        margin-left: $sp-1;
     }
 }

--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
@@ -9,6 +9,10 @@ import type { UserProfile } from '~/libs/core'
 import { MemberChallengePointsBar } from './MemberStatsBlock'
 
 const memberStatsBlockStyles = readFileSync(`${__dirname}/MemberStatsBlock.module.scss`, 'utf8')
+const trackDetailsGridTemplatePattern = [
+    '\\.trackDetails \\{[\\s\\S]*?grid-template-columns: ',
+    '\\$sp-6 \\$sp-3 minmax\\(58px, max-content\\) \\$sp-4 \\$sp-4;',
+].join('')
 
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(() => '#000000'),
@@ -93,8 +97,18 @@ describe('MemberStatsBlock typography styles', () => {
             .toMatch(/\.trackName \{[\s\S]*?font-size: 16px;/)
     })
 
-    it('right-aligns track details so member stats chevrons line up', () => {
+    it('reserves track details columns so member stats chevrons line up', () => {
         expect(memberStatsBlockStyles)
-            .toMatch(/\.trackDetails \{[\s\S]*?justify-content: flex-end;/)
+            .toMatch(/\.trackDetails \{[\s\S]*?display: grid;/)
+        expect(memberStatsBlockStyles)
+            .toMatch(new RegExp(trackDetailsGridTemplatePattern))
+        expect(memberStatsBlockStyles)
+            .toMatch(/\.trackStats \{[\s\S]*?grid-column: 3;/)
+        expect(memberStatsBlockStyles)
+            .toMatch(/\.rightArrowIcon \{[\s\S]*?grid-column: 5;/)
+        expect(memberStatsBlockStyles)
+            .toMatch(/\.icon \{[\s\S]*?grid-column: 1;/)
+        expect(memberStatsBlockStyles)
+            .toMatch(/\.winnerIcon \{[\s\S]*?grid-column: 1;/)
     })
 })


### PR DESCRIPTION
What was broken
The previous PM-5401 fixes kept member stats text readable in the trip-winner layout and right-aligned the details group, but rows with different optional indicator icons could still derive their right-side spacing from different child combinations.

Root cause
The stats row details area was still a flex row containing optional winner/rating icons, stat text, and the chevron. Optional children changed the internal column spacing, so the chevron alignment was not structurally reserved for every row.

What was changed
Converted the details area to a compact CSS grid with dedicated columns for the optional indicator, stat text, and chevron at normal and compact widths. The chevron now occupies the same rightmost column for every row while preserving the existing typography and responsive breakpoints from the prior fixes.

Any added/updated tests
Updated the MemberStatsBlock SCSS regression test to assert that the details area reserves grid columns for the indicator, stats, and chevron alignment.

Validation
- yarn test:no-watch --runInBand src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx passed.
- yarn test:no-watch --runInBand src/apps/profiles/src passed.
- yarn lint passed.
- yarn run build passed with existing warnings.
- yarn test:no-watch --runInBand was run and still fails in unrelated work, engagements, and wallet-admin suites with existing module/mock/schema failures outside this change.
