### PR TITLE
PM-5402: Stack extreme rating markers

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -39,6 +39,19 @@ const wideRatingDistribution = {
     },
 }
 
+const expandedTailRatingDistribution = {
+    ...ratingDistribution,
+    distribution: {
+        ratingRange0To899: 10,
+        ratingRange900To1199: 20,
+        ratingRange1200To1499: 30,
+        ratingRange1500To2199: 40,
+        ratingRange2200To2999: 5,
+        ratingRange3000To3999: 2,
+        ratingRange4000To4999: 0,
+    },
+}
+
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(() => '#616BD5'),
 }), {
@@ -117,7 +130,7 @@ describe('MemberRatingInfoModal', () => {
             .toBeInTheDocument()
     })
 
-    it('stacks the marker rating for high ratings near the right edge of the chart', () => {
+    it('stacks the marker rating for extreme ratings before the right-edge threshold', () => {
         render(
             <MemberRatingInfoModal
                 audienceLabel='developers'
@@ -125,11 +138,15 @@ describe('MemberRatingInfoModal', () => {
                 percentile={0.4}
                 profile={baseProfile}
                 rating={3664}
-                ratingDistribution={ratingDistribution}
+                ratingDistribution={expandedTailRatingDistribution}
             />,
         )
 
-        expect(screen.getByTestId('rating-member-marker'))
+        const marker = screen.getByTestId('rating-member-marker')
+
+        expect(parseFloat(marker.style.left))
+            .toBeLessThan(80)
+        expect(marker)
             .toHaveClass('memberMarkerStacked')
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -101,6 +101,9 @@ const chartAxisLabels: Array<{ label: string, value: number }> = [{
 // The inline avatar and score need room to the right of the marker, so stack
 // before the marker reaches the final segment of the chart.
 const stackedMarkerPositionThreshold = 80
+// Extreme ratings can still crowd the right edge when the distribution has a
+// wider tail range, especially on compact screens.
+const stackedMarkerRatingThreshold = 3000
 
 /**
  * Formats percentile values for the rating comparison modal.
@@ -273,7 +276,10 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const markerPosition: number = props.rating !== undefined
         ? getChartPosition(props.rating, distributionRanges)
         : 0
-    const shouldStackMarkerRating: boolean = markerPosition >= stackedMarkerPositionThreshold
+    const shouldStackMarkerRating: boolean = props.rating !== undefined && (
+        markerPosition >= stackedMarkerPositionThreshold
+        || props.rating >= stackedMarkerRatingThreshold
+    )
     const percentileLabel: string = formatPercentile(props.percentile)
 
     return (


### PR DESCRIPTION
What was broken
The earlier PM-5402 follow-ups stacked the marker only after it crossed a chart-position threshold. QA had already shown the 3664 tourist score staying inline and clipped after the first threshold-based fix, and the regression coverage still only proved a clamped right-edge case.

Root cause
The inline avatar-and-score badge can run out of room for extreme ratings when the distribution tail or compact viewport leaves less horizontal space than a percentage threshold assumes. The existing test did not exercise a high rating before that threshold.

What was changed
Stack marker labels for extreme ratings in addition to the existing right-edge threshold, so very high scores move below the avatar before the inline badge can crowd the chart edge.

Any added/updated tests
Updated the MemberRatingInfoModal regression test with an expanded-tail distribution that places rating 3664 before the 80% threshold and verifies the marker still uses the stacked layout.

Validation
Passed: yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
Passed: yarn lint
Passed: yarn run build, with existing CRA build warnings
Not passed: yarn test:no-watch still fails in unrelated work and wallet-admin suites outside this profiles change.
