### PR TITLE
PM-5433: Fix profile subtrack summary counters

### DIFF
--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -1,6 +1,11 @@
-import type { UserStats } from '~/libs/core'
+import type { MemberStats, UserStats } from '~/libs/core'
 
-import { getActiveTracks, getMemberChallengePoints, MemberStatsTrack } from './useFetchActiveTracks'
+import {
+    getActiveTracks,
+    getMemberChallengePoints,
+    getSubTrackSummaryStats,
+    MemberStatsTrack,
+} from './useFetchActiveTracks'
 
 jest.mock('~/libs/core', () => ({
     useMemberStats: jest.fn(),
@@ -367,5 +372,62 @@ describe('getActiveTracks', () => {
             ])
         expect(activeTracks.map(track => track.name))
             .not.toContain('NO_RATING')
+    })
+})
+
+describe('getSubTrackSummaryStats', () => {
+    it('falls back to challenge count when a subtrack has zero submissions', () => {
+        const summaryStats = getSubTrackSummaryStats({
+            challenges: 3,
+            submissions: {
+                submissions: 0,
+            },
+            wins: 3,
+        } as MemberStats)
+
+        expect(summaryStats)
+            .toEqual({
+                submissions: 3,
+                wins: 3,
+            })
+    })
+
+    it('falls back to history placements for AI Engineering wins and submissions', () => {
+        const summaryStats = getSubTrackSummaryStats({
+            challenges: 6,
+            name: 'AI Engineering',
+            submissions: {
+                submissions: 0,
+            },
+            wins: 0,
+        } as MemberStats, [
+            {
+                challengeId: 'ai-1',
+                challengeName: 'AI Challenge 1',
+                newRating: 840,
+                placement: 1,
+                ratingDate: 1781237773026,
+            },
+            {
+                challengeId: 'ai-2',
+                challengeName: 'AI Challenge 2',
+                newRating: 860,
+                placement: 2,
+                ratingDate: 1781237773027,
+            },
+            {
+                challengeId: 'ai-3',
+                challengeName: 'AI Challenge 3',
+                newRating: 901,
+                placement: 1,
+                ratingDate: 1781237773028,
+            },
+        ])
+
+        expect(summaryStats)
+            .toEqual({
+                submissions: 6,
+                wins: 2,
+            })
     })
 })

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -6,6 +6,7 @@ import {
     MemberStats,
     MemberStatsGroup,
     SRMStats,
+    StatsHistory,
     useMemberStats,
     UserStats,
 } from '~/libs/core'
@@ -57,6 +58,15 @@ export interface MemberStatsTrack {
     isCPTrack?: boolean
 }
 
+export interface SubTrackSummaryStats {
+    submissions: number
+    wins: number
+}
+
+const getFiniteNumber = (value: unknown): number | undefined => (
+    typeof value === 'number' && Number.isFinite(value) ? value : undefined
+)
+
 /**
  * Return the explicit submission count when the stats payload includes one.
  *
@@ -69,6 +79,36 @@ export const getSubTrackSubmissionCount = (subTrack?: MemberStats): number | und
     const submissionCount = subTrack?.submissions?.submissions ?? subTrack?.submissions
 
     return typeof submissionCount === 'number' ? submissionCount : undefined
+}
+
+/**
+ * Builds the displayed win/submission counts for a subtrack card or summary.
+ *
+ * Some unified stats rows currently include challenge/rating history while the
+ * aggregate win or submission counters are omitted or left at zero. In that
+ * case, history placements are used for wins and history/challenge count is
+ * used as the minimum visible submission count.
+ *
+ * @param {MemberStats | undefined} subTrack - The subtrack to summarize.
+ * @param {StatsHistory[]} trackHistory - Optional history rows for the same subtrack.
+ * @returns {SubTrackSummaryStats} Display-safe win and submission counts.
+ */
+export const getSubTrackSummaryStats = (
+    subTrack?: MemberStats,
+    trackHistory: StatsHistory[] = [],
+): SubTrackSummaryStats => {
+    const statWins = getFiniteNumber(subTrack?.wins) ?? 0
+    const historyWins = trackHistory.filter(history => history.placement === 1).length
+    const statSubmissions = getSubTrackSubmissionCount(subTrack) ?? 0
+    const historySubmissions = trackHistory.length
+    const challengeSubmissions = getFiniteNumber(subTrack?.challenges) ?? 0
+
+    return {
+        submissions: statSubmissions > 0
+            ? statSubmissions
+            : Math.max(historySubmissions, challengeSubmissions),
+        wins: statWins > 0 ? statWins : historyWins,
+    }
 }
 
 /**
@@ -162,10 +202,6 @@ const mapSubTracksByName = (
 
         return all
     }, {} as {[key: string]: MemberStats}) ?? {}
-)
-
-const getFiniteNumber = (value: unknown): number | undefined => (
-    typeof value === 'number' && Number.isFinite(value) ? value : undefined
 )
 
 /**

--- a/src/apps/profiles/src/member-profile/tc-achievements/sub-track-view/SubTrackView.tsx
+++ b/src/apps/profiles/src/member-profile/tc-achievements/sub-track-view/SubTrackView.tsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash'
 
 import { MemberStats, UserProfile } from '~/libs/core'
 
-import { useFetchSubTrackData, useTrackHistory } from '../../../hooks'
+import { getSubTrackSummaryStats, useFetchSubTrackData, useTrackHistory } from '../../../hooks'
 import { StatsDetailsLayout } from '../../../components/tc-achievements/StatsDetailsLayout'
 import { DevelopTrackView } from '../../../components/tc-achievements/DevelopTrackView'
 import { SRMView } from '../../../components/tc-achievements/SRMView'
@@ -25,6 +25,18 @@ const SubTrackView: FC<SubTrackViewProps> = props => {
     const subTrackResult = useFetchSubTrackData(props.profile.handle, params.trackType, params.subTrack)
     const { trackData, ...subTrackData }: any = subTrackResult ?? {}
     const trackHistory = useTrackHistory(props.profile.handle, subTrackData as MemberStats | undefined)
+    const summaryTrackData: MemberStats = useMemo(() => {
+        const summaryStats = getSubTrackSummaryStats(subTrackData as MemberStats, trackHistory)
+
+        return {
+            ...subTrackData,
+            submissions: {
+                ...(subTrackData.submissions ?? {}),
+                submissions: summaryStats.submissions,
+            },
+            wins: summaryStats.wins,
+        } as MemberStats
+    }, [subTrackData, trackHistory])
 
     const [backRoute, prevTitle] = useMemo(() => {
         const trackName = trackData?.subTracks?.length === 1 ? '' : trackData?.name ?? ''
@@ -41,7 +53,7 @@ const SubTrackView: FC<SubTrackViewProps> = props => {
                 title={subTrackLabelToHumanName(subTrackData.name)}
                 backAction={backRoute}
                 closeAction={statsRoute(props.profile.handle)}
-                trackData={subTrackData}
+                trackData={summaryTrackData}
             >
                 {subTrackData.name === 'SRM' ? (
                     <SRMView trackData={subTrackData} profile={props.profile} />

--- a/src/apps/profiles/src/member-profile/tc-achievements/track-view/TrackView.tsx
+++ b/src/apps/profiles/src/member-profile/tc-achievements/track-view/TrackView.tsx
@@ -1,10 +1,15 @@
 import { FC, ReactElement, useMemo } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { orderBy } from 'lodash'
+import { orderBy, sumBy } from 'lodash'
 
-import { MemberStats, UserProfile } from '~/libs/core'
+import { MemberStats, UserProfile, UserStatsHistory, useStatsHistory } from '~/libs/core'
 
-import { getSubTrackSubmissionCount, useFetchTrackData } from '../../../hooks'
+import {
+    getSubTrackSummaryStats,
+    getTrackHistoryFromStats,
+    SubTrackSummaryStats,
+    useFetchTrackData,
+} from '../../../hooks'
 import { StatsDetailsLayout } from '../../../components/tc-achievements/StatsDetailsLayout'
 import { SubTrackSummaryCard } from '../../../components/tc-achievements/SubTrackSummaryCard'
 import { MemberProfileContextValue, useMemberProfileContext } from '../../MemberProfile.context'
@@ -16,38 +21,60 @@ interface TrackViewProps {
     renderDefault: () => ReactElement
 }
 
+type SubTrackDisplayStats = [MemberStats, SubTrackSummaryStats]
+
 const TrackView: FC<TrackViewProps> = props => {
     const { statsRoute }: MemberProfileContextValue = useMemberProfileContext()
     const params = useParams()
     const trackData = useFetchTrackData(props.profile.handle, params.trackType)
+    const statsHistory: UserStatsHistory | undefined = useStatsHistory(props.profile.handle)
 
-    const subTracks: MemberStats[] = useMemo(() => orderBy(
-        trackData?.subTracks,
-        ['wins', 'submissions.submissions', 'challenges'],
+    const subTrackStats = useMemo<SubTrackDisplayStats[]>(() => (
+        trackData?.subTracks.map(subTrack => {
+            const trackHistory = getTrackHistoryFromStats(statsHistory, subTrack)
+
+            return [
+                subTrack,
+                getSubTrackSummaryStats(subTrack, trackHistory),
+            ] as SubTrackDisplayStats
+        }) ?? []
+    ), [statsHistory, trackData?.subTracks])
+    const subTracks = useMemo(() => orderBy(
+        subTrackStats,
+        [
+            subTrack => subTrack[1].wins,
+            subTrack => subTrack[1].submissions,
+            subTrack => subTrack[0].challenges,
+        ],
         ['desc', 'desc', 'desc'],
-    ), [trackData?.subTracks])
+    ), [subTrackStats])
+    const displayTrackData = useMemo(() => (trackData ? {
+        ...trackData,
+        submissions: sumBy(subTrackStats, subTrack => subTrack[1].submissions),
+        wins: sumBy(subTrackStats, subTrack => subTrack[1].wins),
+    } : undefined), [subTrackStats, trackData])
 
-    return !trackData ? props.renderDefault() : (
+    return !displayTrackData ? props.renderDefault() : (
         <div className={styles.wrap}>
             <StatsDetailsLayout
                 prevTitle='Member Stats'
-                title={trackData.name}
+                title={displayTrackData.name}
                 backAction={statsRoute(props.profile.handle)}
                 closeAction={statsRoute(props.profile.handle)}
-                trackData={trackData}
+                trackData={displayTrackData}
             >
                 <div className={styles.cardsWrap}>
                     <div className={styles.cardsInner}>
-                        {subTracks.map((subTrack: MemberStats) => (
+                        {subTracks.map(([subTrack, stats]: SubTrackDisplayStats) => (
                             <Link
-                                to={statsRoute(props.profile.handle, trackData.name, subTrack.name)}
+                                to={statsRoute(props.profile.handle, displayTrackData.name, subTrack.name)}
                                 key={subTrack.name}
                             >
                                 <SubTrackSummaryCard
                                     key={subTrack.name}
                                     title={subTrack.name}
-                                    wins={subTrack.wins}
-                                    submissions={getSubTrackSubmissionCount(subTrack) ?? 0}
+                                    wins={stats.wins}
+                                    submissions={stats.submissions}
                                 />
                             </Link>
                         ))}


### PR DESCRIPTION
What was broken
AI Engineering and Data Science subtrack summary cards could show 0 submissions, and AI Engineering detail headers could show 0 wins, even when the profile history showed challenge activity and winning placements.

Root cause
The profiles UI rendered aggregate counters directly from member stats rows. Some unified stats rows expose challenge/rating history while their aggregate win or submission counters are missing or left at zero.

What was changed
Added a shared subtrack summary helper that preserves positive aggregate counters, falls back to history placement wins when aggregate wins are zero, and falls back to history/challenge counts when submission counters are zero. Track and subtrack views now use that helper for cards and detail summaries.

Any added/updated tests
Updated useFetchActiveTracks specs to cover zero-submission fallback and AI Engineering history-derived wins/submissions.

Validation
- yarn test:no-watch src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx passed.
- yarn lint passed.
- yarn run build passed with existing CRA warnings.
- yarn test:no-watch was run for the full suite and failed in unrelated work/wallet specs outside profiles.
