### PR TITLE
PM-5407: Show preferred roles without rating

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
@@ -6,6 +6,8 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import type { UserProfile, UserStats, UserStatsDistributionResponse } from '~/libs/core'
 import { useMemberStats, useStatsDistribution } from '~/libs/core'
 
+import { getPreferredRolesText } from '../../../lib'
+
 import MemberRatingCard from './MemberRatingCard'
 
 const mockTooltip = jest.fn((props: PropsWithChildren<{ disableTooltip?: boolean }>) => <>{props.children}</>)
@@ -29,7 +31,7 @@ jest.mock('../../../components', () => ({
 }))
 
 jest.mock('../../../lib', () => ({
-    getPreferredRolesText: jest.fn(() => undefined),
+    getPreferredRolesText: jest.fn(() => ''),
 }))
 
 jest.mock('./MemberRatingInfoModal', () => ({
@@ -46,6 +48,7 @@ jest.mock('./ModifyPreferredRolesModal', () => ({
 
 const mockedUseMemberStats = useMemberStats as jest.MockedFunction<typeof useMemberStats>
 const mockedUseStatsDistribution = useStatsDistribution as jest.MockedFunction<typeof useStatsDistribution>
+const mockedGetPreferredRolesText = getPreferredRolesText as jest.MockedFunction<typeof getPreferredRolesText>
 const profile = { handle: 'dave' } as UserProfile
 const ratingDistribution: UserStatsDistributionResponse = {
     createdAt: '2026-06-15T00:00:00.000Z',
@@ -86,6 +89,37 @@ describe('MemberRatingCard', () => {
             <>{props.children}</>
         ))
         mockedUseStatsDistribution.mockReturnValue(ratingDistribution)
+        mockedGetPreferredRolesText.mockReturnValue('')
+    })
+
+    it('shows preferred roles when rating data is unavailable', () => {
+        mockedUseMemberStats.mockReturnValue(undefined)
+        mockedGetPreferredRolesText.mockReturnValue('Designer\nFront-End Developer')
+
+        render(<MemberRatingCard {...defaultProps} />)
+
+        expect(screen.queryByText('Rating'))
+            .not
+            .toBeInTheDocument()
+        expect(screen.queryByText('What is this?'))
+            .not
+            .toBeInTheDocument()
+        expect(screen.getByText('Designer'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Front-End Developer'))
+            .toBeInTheDocument()
+    })
+
+    it('shows the preferred roles edit action for the profile owner when rating data is unavailable', () => {
+        mockedUseMemberStats.mockReturnValue(undefined)
+
+        render(<MemberRatingCard {...defaultProps} authProfile={profile} />)
+
+        expect(screen.queryByText('Rating'))
+            .not
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Edit' }))
+            .toBeInTheDocument()
     })
 
     it('hides percentile details when the member rating is zero', () => {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.tsx
@@ -79,6 +79,9 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
         () => getPreferredRolesDisplay(preferredRoles, arePreferredRolesExpanded),
         [arePreferredRolesExpanded, preferredRoles],
     )
+    const hasRating: boolean = rating !== undefined
+    const shouldRenderPreferredRoles: boolean = preferredRoles.length > 0 || canEditPreferredRoles
+    const shouldRenderCard: boolean = hasRating || shouldRenderPreferredRoles
 
     function handleInfoModalClose(): void {
         setIsInfoModalOpen(false)
@@ -142,53 +145,55 @@ const MemberRatingCard: FC<MemberRatingCardProps> = (props: MemberRatingCardProp
         )
     }
 
-    return rating !== undefined ? (
+    return shouldRenderCard ? (
         <div className={styles.container}>
-            <div className={styles.innerWrap}>
-                <button type='button' className={styles.valueWrap} onClick={handleInfoModalOpen}>
-                    <p className={styles.value} style={{ color: compactRatingColor }}>
-                        {rating}
-                    </p>
-                    <p className={styles.name}>Rating</p>
-                </button>
-                {
-                    percentileLabel ? (
-                        <Tooltip
-                            className={styles.ratingTooltip}
-                            content={(
-                                <span className={styles.tooltipContent}>
-                                    {percentileLabel}
-                                    {' '}
-                                    of
-                                    <br />
-                                    2M
-                                    {' '}
-                                    {audienceLabel.toLowerCase()}
-                                </span>
-                            )}
-                            disableTooltip={isInfoModalOpen}
-                            place='top'
-                        >
-                            <button
-                                type='button'
-                                className={classNames(styles.valueWrap, styles.percentileWrap)}
-                                onClick={handleInfoModalOpen}
+            {hasRating && (
+                <div className={styles.innerWrap}>
+                    <button type='button' className={styles.valueWrap} onClick={handleInfoModalOpen}>
+                        <p className={styles.value} style={{ color: compactRatingColor }}>
+                            {rating}
+                        </p>
+                        <p className={styles.name}>Rating</p>
+                    </button>
+                    {
+                        percentileLabel ? (
+                            <Tooltip
+                                className={styles.ratingTooltip}
+                                content={(
+                                    <span className={styles.tooltipContent}>
+                                        {percentileLabel}
+                                        {' '}
+                                        of
+                                        <br />
+                                        2M
+                                        {' '}
+                                        {audienceLabel.toLowerCase()}
+                                    </span>
+                                )}
+                                disableTooltip={isInfoModalOpen}
+                                place='top'
                             >
-                                <p
-                                    className={classNames(styles.value, styles.percentileValue)}
+                                <button
+                                    type='button'
+                                    className={classNames(styles.valueWrap, styles.percentileWrap)}
+                                    onClick={handleInfoModalOpen}
                                 >
-                                    {percentileLabel}
-                                </p>
-                                <p className={styles.name}>{audienceLabel}</p>
-                            </button>
-                        </Tooltip>
-                    ) : undefined
-                }
-                <button type='button' className={styles.link} onClick={handleInfoModalOpen}>What is this?</button>
-            </div>
+                                    <p
+                                        className={classNames(styles.value, styles.percentileValue)}
+                                    >
+                                        {percentileLabel}
+                                    </p>
+                                    <p className={styles.name}>{audienceLabel}</p>
+                                </button>
+                            </Tooltip>
+                        ) : undefined
+                    }
+                    <button type='button' className={styles.link} onClick={handleInfoModalOpen}>What is this?</button>
+                </div>
+            )}
 
             {
-                isInfoModalOpen && (
+                isInfoModalOpen && hasRating && (
                     <MemberRatingInfoModal
                         onClose={handleInfoModalClose}
                         percentile={visiblePercentile}


### PR DESCRIPTION
What was broken
Preferred roles lived inside the profile rating card, and the entire card was hidden when the stats API did not return a usable rating.

Root cause (if identifiable)
MemberRatingCard returned an empty fragment whenever getProfileRating(memberStats) was undefined, so both saved roles and the owner edit action were skipped for unrated members.

What was changed
Decoupled card visibility from rating availability. The rating summary still renders only when a rating exists, while the preferred roles list and owner edit action render independently.

Any added/updated tests
Updated MemberRatingCard specs to cover saved preferred roles and the owner edit action when rating data is unavailable.

Validation run:
yarn lint passed.
yarn run build passed with existing project warnings.
yarn test:no-watch MemberRatingCard.spec.tsx --runInBand passed.
yarn test:no-watch src/apps/profiles/src --runInBand passed.
yarn test:no-watch --runInBand was run and currently fails in unrelated wallet/work suites, including PaymentAgreementBanner icon rendering, assignment payment helper mocks, engagement assignment detail validation, and existing module-resolution failures outside Profiles.
