### PR TITLE
PM-5442: Match rating marker line color

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -206,7 +206,7 @@
     z-index: 2;
 
     &::after {
-        background: #F2C900;
+        background: currentColor;
         bottom: 0;
         content: '';
         display: block;

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from 'react'
 import { render, screen, within } from '@testing-library/react'
 
 import type { UserProfile } from '~/libs/core'
+import { getRatingColor } from '~/libs/core'
 
 import MemberRatingInfoModal from './MemberRatingInfoModal'
 
@@ -53,7 +54,7 @@ const expandedTailRatingDistribution = {
 }
 
 jest.mock('~/libs/core', () => ({
-    getRatingColor: jest.fn(() => '#616BD5'),
+    getRatingColor: jest.fn(),
 }), {
     virtual: true,
 })
@@ -79,7 +80,13 @@ jest.mock('../../../../lib', () => ({
         .toFixed(digits),
 }))
 
+const mockedGetRatingColor = getRatingColor as jest.MockedFunction<typeof getRatingColor>
+
 describe('MemberRatingInfoModal', () => {
+    beforeEach(() => {
+        mockedGetRatingColor.mockReturnValue('#616BD5')
+    })
+
     it('renders the position summary without the pyramid graphic', () => {
         render(
             <MemberRatingInfoModal
@@ -144,6 +151,8 @@ describe('MemberRatingInfoModal', () => {
 
         const marker = screen.getByTestId('rating-member-marker')
 
+        expect(marker)
+            .toHaveStyle('color: #616BD5')
         expect(parseFloat(marker.style.left))
             .toBeLessThan(80)
         expect(marker)

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -265,6 +265,7 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const displayName: string = getMemberDisplayName(props.profile)
     const titleDisplayName: string = displayName
         .toUpperCase()
+    const ratingColor: string = getRatingColor(props.rating)
     const selectedRatingTier: RatingTier = getRatingTier(props.rating)
     const distributionRanges: RatingDistributionRange[] = useMemo(() => (
         getDistributionRanges(props.ratingDistribution?.distribution)
@@ -311,7 +312,7 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                 <div className={styles.summaryPanel}>
                     <div className={styles.summaryMetric}>
                         <span className={styles.summaryLabel}>Overall Rating</span>
-                        <span className={styles.ratingValue} style={{ color: getRatingColor(props.rating) }}>
+                        <span className={styles.ratingValue} style={{ color: ratingColor }}>
                             {props.rating ?? '--'}
                         </span>
                         <span className={styles.summaryMeta}>{getRatingTierName(props.rating)}</span>
@@ -370,7 +371,10 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                                         shouldStackMarkerRating && styles.memberMarkerStacked,
                                     )}
                                     data-testid='rating-member-marker'
-                                    style={{ left: `${markerPosition}%` }}
+                                    style={{
+                                        color: ratingColor,
+                                        left: `${markerPosition}%`,
+                                    }}
                                 >
                                     <div className={styles.markerBadge}>
                                         <span className={styles.markerAvatar}>
@@ -382,10 +386,7 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                                                 </span>
                                             )}
                                         </span>
-                                        <span
-                                            className={styles.markerRating}
-                                            style={{ color: getRatingColor(props.rating) }}
-                                        >
+                                        <span className={styles.markerRating}>
                                             {props.rating}
                                         </span>
                                     </div>


### PR DESCRIPTION
What was broken
The rating distribution marker line in the member profile rating modal was always yellow, even when the member rating color was red, blue, green, or gray.

Root cause
The marker line is rendered by a CSS pseudo-element with a hardcoded yellow background, while the nearby rating values already use getRatingColor.

What was changed
The modal now computes the rating color once and applies it to the marker element. The marker line uses currentColor so it stays in sync with the displayed rating color.

Any added/updated tests
Updated MemberRatingInfoModal.spec.tsx to assert the marker receives the mocked rating color.

Validation run:
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx: passed
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch: failed in unrelated work and wallet-admin suites outside this change
- source ~/.nvm/nvm.sh && nvm use && yarn lint: passed
- source ~/.nvm/nvm.sh && nvm use && yarn run build: passed with existing warnings
