### PR TITLE
PM-5446: Restore persisted active schedules

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -105,6 +105,9 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
   challenge-api-v6 fetch instead of reusing stale cached detail data, and the editor form
   reapplies that refreshed same-id snapshot once it arrives.
 - Save create/update/delete: `createChallenge`, `patchChallenge`, `deleteChallenge`.
+- Manual saves for active scheduled challenges refetch the persisted challenge after `patchChallenge`
+  before resetting or navigating, so an API-rejected active-phase shortening is restored immediately
+  and the user sees a partial-save warning instead of a misleading success-only state.
 - Initial create refresh: after `createChallenge`, the form fetches full challenge details with `fetchChallenge` to avoid round-type regressions from sparse create responses and to surface the generated forum link for challenge types that provision a discussion on create.
 - Skills search: `searchSkills`.
 - Tracks fetch: `fetchChallengeTracks`.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -64,6 +64,34 @@ let mockMaximumSubmissionsDeferDirtyValues: boolean[] = []
 jest.mock('../../../../lib/components/form', () => ({
     FormCheckboxField: () => <></>,
 }))
+jest.mock('../../../../lib/components', () => ({
+    ConfirmationModal: (props: {
+        cancelText?: string
+        children?: React.ReactNode
+        confirmDisabled?: boolean
+        confirmText?: string
+        message: string
+        onCancel: () => void
+        onConfirm: () => void
+        title: string
+    }) => (
+        <div aria-modal='true' role='dialog'>
+            <h4>{props.title}</h4>
+            <p>{props.message}</p>
+            {props.children}
+            <button onClick={props.onCancel} type='button'>
+                {props.cancelText || 'Cancel'}
+            </button>
+            <button
+                disabled={props.confirmDisabled}
+                onClick={props.onConfirm}
+                type='button'
+            >
+                {props.confirmText || 'Confirm'}
+            </button>
+        </div>
+    ),
+}))
 jest.mock('../../../../lib/hooks', () => ({
     useAutosave: jest.fn(),
     useFetchChallengeTracks: jest.fn(),
@@ -90,6 +118,19 @@ jest.mock('../../../../lib/services', () => ({
     searchProfilesByUserIds: jest.fn(),
 }))
 jest.mock('../../../../lib/utils', () => ({
+    checkCanEditProjectDetails: (
+        userRoles?: string[],
+        userId?: number,
+        project?: {
+            members?: Array<{
+                role?: string
+                userId?: number
+            }>
+        },
+    ): boolean => (userRoles || []).includes('manager')
+        && (project?.members || []).some(member => (
+            member.userId === userId && member.role === 'manager'
+        )),
     formatLastSaved: () => '',
     showErrorToast: jest.fn(),
     showSuccessToast: jest.fn(),
@@ -216,6 +257,23 @@ jest.mock('~/config', () => ({
         TC_FINANCE_API: 'https://example.com/finance',
         TOPCODER_URL: 'https://example.com/topcoder',
     },
+}), {
+    virtual: true,
+})
+jest.mock('~/libs/core', () => ({
+    xhrCreateInstance: jest.fn(() => ({
+        defaults: {
+            headers: {
+                common: {},
+            },
+        },
+    })),
+    xhrDeleteAsync: jest.fn(),
+    xhrGetAsync: jest.fn(),
+    xhrGetPaginatedAsync: jest.fn(),
+    xhrPatchAsync: jest.fn(),
+    xhrPostAsync: jest.fn(),
+    xhrPutAsync: jest.fn(),
 }), {
     virtual: true,
 })
@@ -673,6 +731,9 @@ const LocationDisplay = (): JSX.Element => {
 
     return <div data-testid='location-display'>{location.pathname}</div>
 }
+
+const activePhaseShorteningRejectionTestName = 'restores the persisted schedule when active phase shortening '
+    + 'is rejected after saving other edits'
 
 describe('ChallengeEditorForm', () => {
     const copilotContextValue: WorkAppContextModel = {
@@ -3115,6 +3176,66 @@ describe('ChallengeEditorForm', () => {
             expect(screen.getByTestId('location-display'))
                 .toHaveTextContent('/projects/100578/challenges/12345/view')
         })
+    })
+
+    it(activePhaseShorteningRejectionTestName, async () => {
+        const user = userEvent.setup()
+        const activeChallenge = {
+            ...validDraftChallenge,
+            legacy: {
+                reviewType: 'INTERNAL',
+                useSchedulingAPI: true,
+            },
+            phases: [{
+                duration: 1440,
+                isOpen: true,
+                name: 'Submission',
+                phaseId: 'submission-phase-id',
+                scheduledEndDate: '2026-04-19T04:58:51.000Z',
+                scheduledStartDate: '2026-04-11T04:58:51.000Z',
+            }],
+            startDate: '2026-04-11T04:58:51.000Z',
+            status: 'ACTIVE',
+        } as Challenge
+        const rejectedShortenedSchedule = {
+            ...activeChallenge,
+            name: 'Active challenge updated',
+            phases: [{
+                ...activeChallenge.phases?.[0],
+                duration: 1440,
+                scheduledEndDate: '2026-04-18T04:58:51.000Z',
+            }],
+        } as Challenge
+
+        mockedPatchChallenge.mockResolvedValue(rejectedShortenedSchedule)
+        mockedFetchChallenge.mockResolvedValue(activeChallenge)
+
+        render(
+            <MemoryRouter initialEntries={['/projects/100578/challenges/12345/edit']}>
+                <LocationDisplay />
+                <ChallengeEditorForm
+                    challenge={activeChallenge}
+                    projectId='100578'
+                />
+            </MemoryRouter>,
+        )
+
+        await user.click(screen.getByTestId('mock-dirty-phase-end'))
+        await user.type(screen.getByLabelText('Challenge Name'), ' updated')
+        await user.click(screen.getByRole('button', { name: 'Update Challenge' }))
+
+        await waitFor(() => {
+            expect(mockedFetchChallenge)
+                .toHaveBeenCalledWith('12345')
+            expect(screen.getByTestId('challenge-schedule-section'))
+                .toHaveAttribute('data-first-phase-end', '2026-04-19T04:58:51.000Z')
+            expect(screen.getByTestId('location-display'))
+                .toHaveTextContent('/projects/100578/challenges/12345/view')
+        })
+        expect(mockedShowErrorToast)
+            .toHaveBeenCalledWith('Active phase shortening cannot be saved. Other challenge changes were saved.')
+        expect(mockedShowSuccessToast)
+            .not.toHaveBeenCalledWith('Challenge saved successfully')
     })
 
     it('blocks saving when an assigned AI workflow has been disabled', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -286,6 +286,8 @@ const DISABLED_AI_WORKFLOW_FOR_CHALLENGE_ACTION_MESSAGE
 const DISABLED_AI_TEMPLATE_FOR_CHALLENGE_ACTION_MESSAGE
     = 'The saved AI review template was disabled. '
     + 'Update the AI template selection before saving or launching this challenge.'
+const ACTIVE_PHASE_SHORTENING_NOT_SAVED_MESSAGE
+    = 'Active phase shortening cannot be saved. Other challenge changes were saved.'
 const CHALLENGE_TYPE_CHALLENGE_ABBREVIATION = 'CH'
 const CHALLENGE_TYPE_CHALLENGE_NAME = 'CHALLENGE'
 const CHALLENGE_TYPE_FIRST_2_FINISH_ABBREVIATION = 'F2F'
@@ -1389,6 +1391,115 @@ function getSaveSuccessMessage(
     return isSaveAsDraft
         ? 'Challenge saved as draft successfully'
         : 'Challenge saved successfully'
+}
+
+/**
+ * Returns whether the saved challenge should be refetched before the form baseline is reset.
+ *
+ * @param formData form state that was just submitted to challenge-api.
+ * @returns `true` when an active challenge uses the scheduling API and has schedule phases.
+ */
+function shouldVerifyPersistedScheduleAfterSave(
+    formData: ChallengeEditorFormData,
+): boolean {
+    return normalizeStatus(formData.status) === CHALLENGE_STATUS.ACTIVE
+        && formData.legacy?.useSchedulingAPI !== false
+        && Array.isArray(formData.phases)
+        && formData.phases.length > 0
+}
+
+/**
+ * Converts a phase date value to milliseconds for stable comparisons.
+ *
+ * @param value phase date value from form or API state.
+ * @returns the timestamp in milliseconds, or `undefined` when invalid.
+ */
+function getPhaseDateTime(value: Date | string | undefined): number | undefined {
+    if (!value) {
+        return undefined
+    }
+
+    const parsedDate = value instanceof Date
+        ? value
+        : new Date(value)
+
+    return Number.isNaN(parsedDate.getTime())
+        ? undefined
+        : parsedDate.getTime()
+}
+
+/**
+ * Resolves a stable phase identity for comparing submitted and persisted schedules.
+ *
+ * @param phase challenge phase from form or API state.
+ * @returns phase id token when available.
+ */
+function getPhaseIdentity(phase: ChallengePhase | undefined): string | undefined {
+    return normalizeTextValue(phase?.id)
+        || normalizeTextValue(phase?.phaseId)
+        || undefined
+}
+
+/**
+ * Returns whether a phase should be treated as the currently open phase.
+ *
+ * @param phase challenge phase from form or API state.
+ * @returns `true` when the phase is explicitly open.
+ */
+function isOpenPhase(phase: ChallengePhase | undefined): boolean {
+    return phase?.isOpen === true
+        || normalizeTextValue(phase?.status)
+            .toUpperCase() === 'OPEN'
+}
+
+/**
+ * Detects an active phase end date that the API did not shorten.
+ *
+ * @param submittedPhases schedule phases submitted with the save request.
+ * @param persistedPhases schedule phases fetched after the save completed.
+ * @returns `true` when an open phase still ends later in persisted data than in submitted data.
+ */
+function hasRejectedActivePhaseShortening(
+    submittedPhases: ChallengeEditorFormData['phases'],
+    persistedPhases: ChallengeEditorFormData['phases'],
+): boolean {
+    if (!Array.isArray(submittedPhases) || !Array.isArray(persistedPhases)) {
+        return false
+    }
+
+    const persistedPhasesByIdentity = new Map<string, ChallengePhase>()
+    persistedPhases.forEach(phase => {
+        const phaseIdentity = getPhaseIdentity(phase)
+        if (phaseIdentity) {
+            persistedPhasesByIdentity.set(phaseIdentity, phase)
+        }
+    })
+
+    return submittedPhases.some((submittedPhase, index) => {
+        const phaseIdentity = getPhaseIdentity(submittedPhase)
+        const persistedPhase = phaseIdentity
+            ? persistedPhasesByIdentity.get(phaseIdentity)
+            : persistedPhases[index]
+
+        if (!persistedPhase) {
+            return false
+        }
+
+        if (
+            (!isOpenPhase(submittedPhase) && !isOpenPhase(persistedPhase))
+            || submittedPhase.actualEndDate
+            || persistedPhase.actualEndDate
+        ) {
+            return false
+        }
+
+        const submittedEndTime = getPhaseDateTime(submittedPhase.scheduledEndDate)
+        const persistedEndTime = getPhaseDateTime(persistedPhase.scheduledEndDate)
+
+        return submittedEndTime !== undefined
+            && persistedEndTime !== undefined
+            && submittedEndTime < persistedEndTime
+    })
 }
 
 function getApprovalStatusText(approvalStatus: string | undefined): string {
@@ -2948,10 +3059,27 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                 })
                 const savedChallenge = await patchChallenge(currentChallengeId, payload)
                 await syncDraftSingleAssignments(currentChallengeId, formDataWithProjectBilling)
+                const shouldVerifyPersistedSchedule
+                    = shouldVerifyPersistedScheduleAfterSave(formDataWithProjectBilling)
+                let savedChallengeSnapshot = savedChallenge
+
+                if (shouldVerifyPersistedSchedule) {
+                    try {
+                        savedChallengeSnapshot = await fetchChallenge(currentChallengeId)
+                    } catch {
+                        savedChallengeSnapshot = savedChallenge
+                    }
+                }
+
                 const persistedFormData = applyProjectBillingToChallengeFormData(
-                    transformChallengeToFormData(savedChallenge),
+                    transformChallengeToFormData(savedChallengeSnapshot),
                     resolvedProjectBillingAccount,
                 )
+                const wasActivePhaseShorteningRejected = shouldVerifyPersistedSchedule
+                    && hasRejectedActivePhaseShortening(
+                        formDataWithProjectBilling.phases,
+                        persistedFormData.phases,
+                    )
 
                 const nextValues = applySingleAssignmentFieldValues(
                     await hydratePersistedSavedFormData(
@@ -2984,7 +3112,11 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                 onChallengeStatusChange?.(normalizeStatus(nextValues.status))
 
                 if (!options.isAutosave) {
-                    showSuccessToast(getSaveSuccessMessage(isSaveAsDraft, options))
+                    if (wasActivePhaseShorteningRejected) {
+                        showErrorToast(ACTIVE_PHASE_SHORTENING_NOT_SAVED_MESSAGE)
+                    } else {
+                        showSuccessToast(getSaveSuccessMessage(isSaveAsDraft, options))
+                    }
                 }
 
                 const postSaveNavigationPath = resolvePostSaveNavigationPath({


### PR DESCRIPTION
What was broken
- Active challenge saves could show a success-only state after an attempted active phase shortening, even when challenge-api kept the original timeline.
- The view page could temporarily show the shortened timeline until a refresh restored the persisted schedule.

Root cause
- The editor reset and navigated with the patch response, which could echo submitted phase dates instead of the persisted schedule state.

What was changed
- Active scheduled challenge saves now refetch the persisted challenge before resetting or navigating.
- Rejected active-phase shortening is detected from the fresh schedule and shown as a partial-save warning while other saved fields remain saved.
- Challenge editor docs were updated for the post-save schedule verification behavior.

Any added/updated tests
- Added a ChallengeEditorForm regression test for a patch response that echoes shortened phase dates while the persisted timeline remains unchanged.
- Validation run: focused PM-5446 test passed; lint passed; build passed with existing warnings. Full yarn test:no-watch --runInBand still fails on unrelated existing wallet-admin alias/icon issues and pre-existing launch approval expectations.
