### PR TITLE
PM-5444: Show top percentile for highest profile ratings

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
@@ -181,6 +181,31 @@ describe('MemberRatingCard', () => {
             .toBeInTheDocument()
     })
 
+    it('shows top one percent when the member rating is above the highest distribution range', () => {
+        mockedUseMemberStats.mockReturnValue({
+            DATA_SCIENCE: {
+                MARATHON_MATCH: {
+                    mostRecentEventDate: 1000,
+                    rank: {
+                        rating: 4051,
+                    },
+                },
+            },
+            maxRating: {
+                rating: 4051,
+            },
+        } as unknown as UserStats)
+
+        render(<MemberRatingCard {...defaultProps} />)
+
+        expect(screen.getByText('4051'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Top 1%'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Data Scientists'))
+            .toBeInTheDocument()
+    })
+
     it('disables the percentile tooltip while the rating modal is open', () => {
         mockedUseMemberStats.mockReturnValue({
             DATA_SCIENCE: {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts
@@ -123,6 +123,11 @@ describe('calculateTopPercentileFromDistribution', () => {
             .toBeCloseTo(55)
     })
 
+    it('returns the top known member percentage when the rating is above the highest range', () => {
+        expect(calculateTopPercentileFromDistribution(distribution, 4051))
+            .toBeCloseTo(0.1)
+    })
+
     it('returns undefined when the rating or distribution cannot be used', () => {
         expect(calculateTopPercentileFromDistribution(distribution, undefined))
             .toBeUndefined()

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.ts
@@ -214,7 +214,9 @@ const getDistributionRanges = (
  *
  * The distribution only gives bucket counts, so when a rating falls inside a
  * bucket this assumes members are evenly distributed across that bucket and
- * counts the proportional share at or above the member rating.
+ * counts the proportional share at or above the member rating. Ratings above
+ * the final bucket are treated as the top known member so the card still shows
+ * the best visible percentile instead of hiding the badge.
  *
  * @param {UserStatsDistributionResponse['distribution'] | undefined} distribution - Raw rating distribution buckets.
  * @param {number | undefined} memberRating - The visible member rating in the same track/subtrack.
@@ -252,6 +254,10 @@ export const calculateTopPercentileFromDistribution = (
 
         return total + (range.value * (ratingAndAboveSize / rangeSize))
     }, 0)
+
+    if (membersAtOrAboveRating <= 0 && rating > ranges[ranges.length - 1].end) {
+        return 100 / totalMembers
+    }
 
     if (membersAtOrAboveRating <= 0) {
         return undefined


### PR DESCRIPTION
What was broken
Profiles with a positive rating above the highest returned rating distribution bucket showed the rating value but omitted the Top X% percentile badge.

Root cause
The percentile calculation returned undefined when no distribution bucket contained or exceeded the member rating. For outlier ratings above the final bucket, that suppressed the badge even though the member should still be shown as a top-ranked member.

What was changed
Treat ratings above the final distribution bucket as the top known member percentage so the existing formatter renders a visible Top 1% badge instead of hiding the percentile details.

Any added/updated tests
Added utility coverage for ratings above the highest distribution range and component coverage for rendering Top 1% with a 4051 profile rating.

Validation run:
- PASS yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.utils.spec.ts src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingCard.spec.tsx
- PASS yarn lint
- PASS yarn run build, with existing CSS order and lint warning output from unrelated modules
- FAIL yarn test:no-watch: existing unrelated failures in src/apps/work specs, including engagement-editor schema validation, ReviewersField missing mocked fetchAiReviewConfigByChallenge, and ChallengeEditorForm launch expectations
