### PR TITLE
PM-5458: Use placement history for profile win counts

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.tsx
@@ -9,6 +9,8 @@ import {
     UserChallengePointsSummary,
     UserProfile,
     UserStats,
+    UserStatsHistory,
+    useStatsHistory,
 } from '~/libs/core'
 import { IconOutline } from '~/libs/ui'
 
@@ -247,7 +249,8 @@ const MemberStatsBlock: FC<MemberStatsBlockProps> = props => {
     const { statsRoute }: MemberProfileContextValue = useMemberProfileContext()
 
     const memberStats: UserStats | undefined = useMemberStats(props.profile.handle)
-    const activeTracks = useMemo(() => getActiveTracks(memberStats), [memberStats])
+    const statsHistory: UserStatsHistory | undefined = useStatsHistory(props.profile.handle)
+    const activeTracks = useMemo(() => getActiveTracks(memberStats, statsHistory), [memberStats, statsHistory])
     const displayTracks = useMemo(() => sortTracksForDisplay(activeTracks), [activeTracks])
 
     const getTrackRoute = useCallback((trackName: string, subTracks?: MemberStats[]): string => {

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -537,4 +537,60 @@ describe('getSubTrackSummaryStats', () => {
                 wins: 2,
             })
     })
+
+    it('uses placement history when aggregate wins are stale and nonzero', () => {
+        const summaryStats = getSubTrackSummaryStats({
+            challenges: 5,
+            name: 'AI Engineering',
+            submissions: {
+                submissions: 5,
+            },
+            wins: 2,
+        } as MemberStats, [
+            {
+                challengeId: 'ai-1',
+                challengeName: 'AI Challenge 1',
+                newRating: 840,
+                placement: 2,
+                ratingDate: 1781237773026,
+            },
+            {
+                challengeId: 'ai-2',
+                challengeName: 'AI Challenge 2',
+                newRating: 860,
+                placement: 5,
+                ratingDate: 1781237773027,
+            },
+        ])
+
+        expect(summaryStats)
+            .toEqual({
+                submissions: 5,
+                wins: 0,
+            })
+    })
+
+    it('keeps aggregate wins when history rows have no placement data', () => {
+        const summaryStats = getSubTrackSummaryStats({
+            challenges: 2,
+            name: 'Challenge',
+            submissions: {
+                submissions: 2,
+            },
+            wins: 2,
+        } as MemberStats, [
+            {
+                challengeId: 'dev-1',
+                challengeName: 'Development Challenge 1',
+                newRating: 840,
+                ratingDate: 1781237773026,
+            },
+        ])
+
+        expect(summaryStats)
+            .toEqual({
+                submissions: 2,
+                wins: 2,
+            })
+    })
 })

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -118,9 +118,9 @@ export const getSubTrackDisplaySubmissionCount = (subTrack?: MemberStats): numbe
  * Builds the displayed win/submission counts for a subtrack card or summary.
  *
  * Some unified stats rows currently include challenge/rating history while the
- * aggregate win or submission counters are omitted or left at zero. In that
- * case, history placements are used for wins and history/challenge count is
- * used as the minimum visible submission count.
+ * aggregate win or submission counters are stale, omitted, or left at zero. In
+ * that case, placement-bearing history is used for wins and history/challenge
+ * count is used as the minimum visible submission count.
  *
  * @param {MemberStats | undefined} subTrack - The subtrack to summarize.
  * @param {StatsHistory[]} trackHistory - Optional history rows for the same subtrack.
@@ -131,13 +131,15 @@ export const getSubTrackSummaryStats = (
     trackHistory: StatsHistory[] = [],
 ): SubTrackSummaryStats => {
     const statWins = getFiniteNumber(subTrack?.wins) ?? 0
-    const historyWins = trackHistory.filter(history => history.placement === 1).length
+    const historyWithPlacements = trackHistory
+        .filter(history => getFiniteNumber(history.placement) !== undefined)
+    const historyWins = historyWithPlacements.filter(history => history.placement === 1).length
     const displaySubmissions = getSubTrackDisplaySubmissionCount(subTrack) ?? 0
     const historySubmissions = trackHistory.length
 
     return {
         submissions: Math.max(displaySubmissions, historySubmissions),
-        wins: statWins > 0 ? statWins : historyWins,
+        wins: historyWithPlacements.length > 0 ? historyWins : statWins,
     }
 }
 


### PR DESCRIPTION
What was broken
Member profile stats could show stale win totals for Development and AI Engineering when the aggregate win count disagreed with the placement history displayed on the profile.

Root cause
The profiles aggregation helper preferred any nonzero aggregate win count over placement history. When the aggregate was stale, the UI could show second-place finishes as wins or miss additional first-place history rows.

What was changed
Subtrack summaries now use placement-bearing history as the authoritative source for wins and only fall back to aggregate wins when history has no placement data. The compact Member Stats block now passes stats history into the same aggregation path used by detail pages.

Any added/updated tests
Added regression tests for stale nonzero aggregate wins being overridden by placement history and for preserving aggregate wins when legacy history rows have no placement data.

Validation run:
- yarn test:no-watch src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
- yarn test:no-watch src/apps/profiles/src/components/tc-achievements/MemberStatsBlock/MemberStatsBlock.spec.tsx
- yarn lint
- yarn build

Full yarn test:no-watch was also run. The profiles tests passed, but the full repo run still fails in unrelated apps/work suites that are outside this change, including engagement-editor.schema.spec.ts, PaymentFormModal.spec.tsx, and ChallengeEditorForm.spec.tsx.
