### PR TITLE
PM-5504: Allow blank private member slots

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -351,6 +351,25 @@ function getFinancePaymentSplit(payment: AssignmentPayment): EngagementPaymentSp
 }
 
 /**
+ * Converts a finance payment into a candidate billing-account row match.
+ *
+ * @param payment Finance payment row.
+ * @returns Payment and split pair when the finance amount can be read.
+ */
+function getFinancePaymentSplitMatch(
+    payment: AssignmentPayment,
+): EngagementPaymentSplitMatch | undefined {
+    const split = getFinancePaymentSplit(payment)
+
+    return split
+        ? {
+            payment,
+            split,
+        }
+        : undefined
+}
+
+/**
  * Resolves the finance payment date used to match one billing ledger row.
  *
  * @param payment Finance payment row.
@@ -392,6 +411,41 @@ function getAggregatePaymentSplit(
             (total, split) => total + split.paymentAmount,
             0,
         )),
+    }
+}
+
+/**
+ * Resolves a single finance split that exactly matches a billing-account row.
+ *
+ * @param item Billing-account engagement row.
+ * @param matches Finance payment candidates for the row assignment.
+ * @returns Matching split plus the number of amount matches considered.
+ * @remarks Date matching disambiguates repeated assignment payments that have
+ * the same amount but represent different consumed ledger rows.
+ */
+function getLineItemMatchingPaymentSplit(
+    item: BillingAccountLineItem,
+    matches: EngagementPaymentSplitMatch[],
+): EngagementPaymentSplitMatchResult {
+    const amountMatches = matches.filter(match => (
+        match.split.challengeFee !== undefined
+        && currencyAmountsMatch(
+            match.split.paymentAmount + match.split.challengeFee,
+            item.amount,
+        )
+    ))
+    const dateMatches = amountMatches.filter(match => (
+        paymentDateMatchesLineItem(match.payment, item)
+    ))
+    const selectedMatches = dateMatches.length > 0
+        ? dateMatches
+        : amountMatches
+
+    return {
+        matchCount: amountMatches.length,
+        split: selectedMatches.length === 1
+            ? selectedMatches[0].split
+            : undefined,
     }
 }
 

--- a/src/apps/work/src/lib/schemas/engagement-editor.schema.spec.ts
+++ b/src/apps/work/src/lib/schemas/engagement-editor.schema.spec.ts
@@ -94,6 +94,21 @@ describe('engagementEditorSchema', () => {
         })
     })
 
+    it('accepts private engagements with registered blank member slots', async () => {
+        await expect(engagementEditorSchema.validate({
+            ...createValidFormValues(),
+            assignedMemberHandles: [undefined, undefined] as unknown as string[],
+            assignmentDetails: [],
+            isPrivate: true,
+            requiredMemberCount: 2,
+        }, {
+            abortEarly: false,
+        })).resolves.toMatchObject({
+            assignedMemberHandles: ['', ''],
+            isPrivate: true,
+        })
+    })
+
     it('accepts private engagements with complete assignment details for assigned members', async () => {
         await expect(engagementEditorSchema.validate({
             ...createValidFormValues(),

--- a/src/apps/work/src/lib/schemas/engagement-editor.schema.ts
+++ b/src/apps/work/src/lib/schemas/engagement-editor.schema.ts
@@ -35,6 +35,22 @@ function emptyStringToUndefined(value: unknown, originalValue: unknown): unknown
 }
 
 /**
+ * Converts registered empty member autocomplete slots into blank strings so
+ * optional private-assignment slots do not fail Yup's defined array-item check.
+ *
+ * @param value cast schema value for a member handle.
+ * @param originalValue raw form value from react-hook-form.
+ * @returns blank string for nullish slots, otherwise the cast schema value.
+ */
+function emptyMemberHandleToString(value: unknown, originalValue: unknown): unknown {
+    if (originalValue === undefined || originalValue === null) {
+        return ''
+    }
+
+    return value
+}
+
+/**
  * Normalizes a member handle from the form so private-assignment validation
  * consistently compares trimmed values.
  *
@@ -135,6 +151,8 @@ export const engagementEditorSchema: yup.ObjectSchema<EngagementEditorSchemaData
     assignedMemberHandles: yup
         .array()
         .of(yup.string()
+            .transform(emptyMemberHandleToString)
+            .default('')
             .defined())
         .optional(),
     assignmentDetails: yup


### PR DESCRIPTION
What was broken
QA still hit assignedMemberHandles[0]/[1] required validation errors when saving a private engagement after all assignments were completed. The previous platform-ui fix covered an empty assignedMemberHandles array, but not blank private member fields registered as undefined array entries.

Root cause
The Yup schema still ran a defined item check for each assignedMemberHandles array entry before optional private member slots were normalized. Current dev also contained merged PM-5507 billing modal call sites with missing finance split helper implementations, which blocked the required lint/build validation until those helper references were completed.

What was changed
Normalized null or undefined private member slots to blank strings before Yup validates assignedMemberHandles items, so optional blank private slots no longer raise indexed required errors. Added the missing billing modal finance split helper implementations needed by current dev's existing call sites.

Any added/updated tests
Added schema coverage for private engagements with registered blank member slots. Re-ran the focused engagement editor schema/form/private-section test suite.

Validation
- yarn lint passed.
- Focused engagement editor tests passed.
- yarn run build passed with existing warnings.
- Full yarn test:no-watch still fails in unrelated suites: wallet-admin module resolution failures and existing ChallengeEditorForm launch expectation failures.
