### PR TITLE
PM-5506: Link exact missing terms in save errors

### DIFF
--- a/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
+++ b/src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.tsx
@@ -351,6 +351,25 @@ function getFinancePaymentSplit(payment: AssignmentPayment): EngagementPaymentSp
 }
 
 /**
+ * Converts a finance payment into a candidate billing-account row match.
+ *
+ * @param payment Finance payment row.
+ * @returns Payment and split pair when the finance amount can be read.
+ */
+function getFinancePaymentSplitMatch(
+    payment: AssignmentPayment,
+): EngagementPaymentSplitMatch | undefined {
+    const split = getFinancePaymentSplit(payment)
+
+    return split
+        ? {
+            payment,
+            split,
+        }
+        : undefined
+}
+
+/**
  * Resolves the finance payment date used to match one billing ledger row.
  *
  * @param payment Finance payment row.
@@ -392,6 +411,41 @@ function getAggregatePaymentSplit(
             (total, split) => total + split.paymentAmount,
             0,
         )),
+    }
+}
+
+/**
+ * Resolves a single finance split that exactly matches a billing-account row.
+ *
+ * @param item Billing-account engagement row.
+ * @param matches Finance payment candidates for the row assignment.
+ * @returns Matching split plus the number of amount matches considered.
+ * @remarks Date matching disambiguates repeated assignment payments that have
+ * the same amount but represent different consumed ledger rows.
+ */
+function getLineItemMatchingPaymentSplit(
+    item: BillingAccountLineItem,
+    matches: EngagementPaymentSplitMatch[],
+): EngagementPaymentSplitMatchResult {
+    const amountMatches = matches.filter(match => (
+        match.split.challengeFee !== undefined
+        && currencyAmountsMatch(
+            match.split.paymentAmount + match.split.challengeFee,
+            item.amount,
+        )
+    ))
+    const dateMatches = amountMatches.filter(match => (
+        paymentDateMatchesLineItem(match.payment, item)
+    ))
+    const selectedMatches = dateMatches.length > 0
+        ? dateMatches
+        : amountMatches
+
+    return {
+        matchCount: amountMatches.length,
+        split: selectedMatches.length === 1
+            ? selectedMatches[0].split
+            : undefined,
     }
 }
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -1337,6 +1337,9 @@ describe('ChallengeEditorForm', () => {
             isError: false,
             isLoading: false,
             terms: [{
+                id: 'standard-terms',
+                title: 'Standard Terms',
+            }, {
                 id: 'standard-terms-2026',
                 title: 'Standard Terms 2026',
             }],
@@ -1348,7 +1351,10 @@ describe('ChallengeEditorForm', () => {
                 <ChallengeEditorForm
                     challenge={{
                         ...validDraftChallenge,
-                        terms: ['standard-terms-2026'],
+                        terms: [
+                            'standard-terms',
+                            'standard-terms-2026',
+                        ],
                     }}
                 />
             </MemoryRouter>,
@@ -1364,6 +1370,9 @@ describe('ChallengeEditorForm', () => {
                 'href',
                 'https://example.com/topcoder/challenges/terms/detail/standard-terms-2026',
             )
+        expect(screen.queryByRole('link', { name: 'Standard Terms' }))
+            .not
+            .toBeInTheDocument()
     })
 
     it('preserves project billing markup when fetched draft data resets the form', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -506,6 +506,30 @@ function getTermDetailUrl(termId: string): string {
 }
 
 /**
+ * Extracts the term titles named by the Resource API missing-terms save error.
+ *
+ * Resource API returns missing term titles in a bracketed, comma-delimited list. Parsing that
+ * list lets the editor link exact missing terms without also linking selected terms whose titles
+ * are substrings of another missing term.
+ *
+ * @param errorMessage Save error message returned by the API.
+ * @returns Normalized term titles named in the missing-terms error.
+ * @throws Does not throw.
+ */
+function extractMissingTermTitlesFromSaveError(errorMessage: string): string[] {
+    const termsListMatch = errorMessage.match(/\[([^\]]+)\]/)
+
+    if (!termsListMatch) {
+        return []
+    }
+
+    return termsListMatch[1]
+        .split(',')
+        .map(normalizeTextValue)
+        .filter(Boolean)
+}
+
+/**
  * Finds selected challenge terms referenced by a save error.
  *
  * API errors for member assignment failures currently include only the human-readable term title.
@@ -536,6 +560,19 @@ function getTermsForSaveError(
 
     const selectedTermIdSet = new Set(selectedTermIds)
     const normalizedErrorMessageLower = normalizedErrorMessage.toLowerCase()
+    const missingTermTitles = new Set(
+        extractMissingTermTitlesFromSaveError(normalizedErrorMessage)
+            .map(title => title.toLowerCase()),
+    )
+    const exactMatchedTerms = terms
+        .filter(term => (
+            selectedTermIdSet.has(term.id)
+            && missingTermTitles.has(term.title.toLowerCase())
+        ))
+
+    if (exactMatchedTerms.length > 0) {
+        return exactMatchedTerms
+    }
 
     return terms
         .filter(term => (


### PR DESCRIPTION
What was broken
The work challenge editor already showed terms links for missing member agreements, but it matched selected terms by searching the whole API error message. That could link a selected term whose title was only a substring of the actual missing term.

Root cause
The save-error link resolver did not parse the Resource API missing-terms list before matching selected challenge terms. The current dev base also had billing modal finance split call sites without their helper definitions, which broke the required lint command until those helpers were restored.

What was changed
The challenge editor now parses the bracketed missing-terms list returned by the API and exact-matches selected terms before falling back to the older text search behavior. The billing account line-items modal has its missing finance split helper definitions restored so the required project lint passes.

Any added/updated tests
Updated the ChallengeEditorForm missing-terms regression to ensure a selected substring term is not linked when only the longer term is missing.

Validation run:
yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx -t "renders selected terms as links" - passed
yarn test:no-watch --runTestsByPath src/apps/work/src/lib/components/BillingAccountLineItemsModal/BillingAccountLineItemsModal.spec.tsx - passed
yarn lint - passed
yarn run build - passed with existing warnings
yarn test:no-watch - failed in unrelated existing areas: wallet-admin module alias resolution and existing ChallengeEditorForm launch approval-status expectations
