### PR TITLE
PM-5516: Restore URL F2F iterative review actions

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentIterativeReview.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentIterativeReview.tsx
@@ -28,6 +28,7 @@ import { hasSubmitterPassedThreshold } from '../../utils/reviewScoring'
 
 import {
     filterIterativeReviewRows,
+    getIterativeReviewSubmissionPriority,
     limitFirst2FinishIterativeRows,
 } from './iterativeReviewFiltering'
 
@@ -42,30 +43,6 @@ interface Props {
     columnLabel?: string
     phaseIdFilter?: string
     aiReviewers?: { aiWorkflowId: string }[]
-}
-
-const getSubmissionPriority = (submission: SubmissionInfo): number => {
-    const review = submission.review
-    if (!review) {
-        return 0
-    }
-
-    const hasReviewId = Boolean(review.id)
-    const status = (review.status ?? '').toUpperCase()
-
-    if (hasReviewId && (status === 'COMPLETED' || status === 'SUBMITTED')) {
-        return 4
-    }
-
-    if (hasReviewId && review.reviewProgress) {
-        return 3
-    }
-
-    if (hasReviewId) {
-        return 2
-    }
-
-    return 1
 }
 
 export const TabContentIterativeReview: FC<Props> = (props: Props) => {
@@ -86,6 +63,10 @@ export const TabContentIterativeReview: FC<Props> = (props: Props) => {
 
     const myMemberIds = useMemo<Set<string>>(
         () => new Set((myResources ?? []).map(resource => resource.memberId)),
+        [myResources],
+    )
+    const myResourceIds = useMemo<Set<string>>(
+        () => new Set((myResources ?? []).map(resource => resource.id)),
         [myResources],
     )
 
@@ -183,13 +164,16 @@ export const TabContentIterativeReview: FC<Props> = (props: Props) => {
                 return
             }
 
-            if (getSubmissionPriority(submission) > getSubmissionPriority(existing)) {
+            if (
+                getIterativeReviewSubmissionPriority(submission, myResourceIds)
+                > getIterativeReviewSubmissionPriority(existing, myResourceIds)
+            ) {
                 map.set(submission.id, submission)
             }
         })
 
         return Array.from(map.values())
-    }, [filteredRows])
+    }, [filteredRows, myResourceIds])
     const first2FinishReviewRows = useMemo<SubmissionInfo[]>(
         () => {
             if (isPostMortemPhase || !isFirst2FinishChallenge) {

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts
@@ -6,6 +6,7 @@ import {
 
 import {
     filterIterativeReviewRows,
+    getIterativeReviewSubmissionPriority,
     limitFirst2FinishIterativeRows,
 } from './iterativeReviewFiltering'
 
@@ -308,6 +309,32 @@ describe('filterIterativeReviewRows', () => {
         expect(results[0].id)
             .toBe('synthetic-row-1')
     })
+
+    it('keeps a URL submission row when the F2F limiter matches its legacy submission id', () => {
+        const iterativeReviewer = createResource('iterative-resource-1', 'Iterative Reviewer')
+        const urlSubmissionRow = {
+            ...createSubmission(iterativeReviewer.id),
+            id: 'url-submission-row',
+            isFileSubmission: false,
+            legacySubmissionId: 'canonical-submission-id',
+        }
+        const otherRow = {
+            ...createSubmission('other-reviewer'),
+            id: 'other-submission-row',
+            legacySubmissionId: 'other-canonical-id',
+        }
+
+        const results = limitFirst2FinishIterativeRows(
+            [otherRow, urlSubmissionRow],
+            ['canonical-submission-id'],
+            { forceSingleRow: true },
+        )
+
+        expect(results)
+            .toHaveLength(1)
+        expect(results[0].id)
+            .toBe('url-submission-row')
+    })
 })
 
 describe('limitFirst2FinishIterativeRows', () => {
@@ -346,5 +373,33 @@ describe('limitFirst2FinishIterativeRows', () => {
             .toHaveLength(1)
         expect(results[0].id)
             .toBe('submission-earlier')
+    })
+})
+
+describe('getIterativeReviewSubmissionPriority', () => {
+    it('prefers the logged-in reviewer row when duplicate F2F rows share a submission id', () => {
+        const currentReviewerResourceIds = new Set(['current-reviewer-resource'])
+        const currentReviewerRow = createSubmission('current-reviewer-resource')
+        const otherReviewerCompletedRow = createSubmission('other-reviewer-resource')
+        currentReviewerRow.review!.id = 'review-current'
+        otherReviewerCompletedRow.review!.id = 'review-other'
+        otherReviewerCompletedRow.review!.status = 'COMPLETED'
+
+        expect(getIterativeReviewSubmissionPriority(currentReviewerRow, currentReviewerResourceIds))
+            .toBeGreaterThan(
+                getIterativeReviewSubmissionPriority(otherReviewerCompletedRow, currentReviewerResourceIds),
+            )
+    })
+
+    it('keeps the completed-review preference when no row belongs to the logged-in reviewer', () => {
+        const currentReviewerResourceIds = new Set(['current-reviewer-resource'])
+        const pendingRow = createSubmission('pending-reviewer-resource')
+        const completedRow = createSubmission('completed-reviewer-resource')
+        pendingRow.review!.id = 'review-pending'
+        completedRow.review!.id = 'review-completed'
+        completedRow.review!.status = 'COMPLETED'
+
+        expect(getIterativeReviewSubmissionPriority(completedRow, currentReviewerResourceIds))
+            .toBeGreaterThan(getIterativeReviewSubmissionPriority(pendingRow, currentReviewerResourceIds))
     })
 })

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
@@ -79,6 +79,63 @@ function normalizeIdentifier(value: unknown): string | undefined {
 }
 
 /**
+ * Collect submission identifiers that can refer to the same visible row.
+ *
+ * @param submission - Candidate iterative-review row from review data.
+ * @returns Normalized row, legacy, and review submission ids for matching.
+ * Used by F2F limiting because URL submissions can be keyed by legacy ids.
+ */
+function collectSubmissionCandidateIds(submission: SubmissionInfo): Set<string> {
+    return new Set(
+        [
+            submission.id,
+            submission.legacySubmissionId,
+            submission.review?.submissionId,
+        ]
+            .map(id => normalizeIdentifier(id))
+            .filter((id): id is string => Boolean(id)),
+    )
+}
+
+/**
+ * Rank duplicate iterative-review rows for the same submission.
+ *
+ * @param submission - Candidate row built from a submission/reviewer pair.
+ * @param currentResourceIds - Resource ids assigned to the logged-in reviewer.
+ * @returns Numeric priority; larger values win during duplicate collapse.
+ * Used so reviewers see their own pending action when URL/F2F rows share ids.
+ */
+export function getIterativeReviewSubmissionPriority(
+    submission: SubmissionInfo,
+    currentResourceIds: Set<string> = new Set<string>(),
+): number {
+    const review = submission.review
+    if (!review) {
+        return 0
+    }
+
+    const hasReviewId = Boolean(review.id)
+    const status = (review.status ?? '').toUpperCase()
+    const resourcePriority = review.resourceId && currentResourceIds.has(review.resourceId)
+        ? 10
+        : 0
+
+    if (hasReviewId && (status === 'COMPLETED' || status === 'SUBMITTED')) {
+        return 4 + resourcePriority
+    }
+
+    if (hasReviewId && review.reviewProgress) {
+        return 3 + resourcePriority
+    }
+
+    if (hasReviewId) {
+        return 2 + resourcePriority
+    }
+
+    return 1
+}
+
+/**
  * Parse sortable date inputs from submission and review payloads.
  *
  * @param value - Raw date-like value supplied by the UI model.
@@ -376,11 +433,9 @@ export function limitFirst2FinishIterativeRows(
     }
 
     const matchingRows = rows.filter(submission => {
-        const submissionId = normalizeIdentifier(submission.id)
-        const reviewSubmissionId = normalizeIdentifier(submission.review?.submissionId)
-
-        return (submissionId ? submissionIds.has(submissionId) : false)
-            || (reviewSubmissionId ? submissionIds.has(reviewSubmissionId) : false)
+        const candidateIds = collectSubmissionCandidateIds(submission)
+        return Array.from(candidateIds)
+            .some(submissionId => submissionIds.has(submissionId))
     })
 
     if (matchingRows.length) {


### PR DESCRIPTION
What was broken
URL First2Finish challenges could render the Iterative Review tab without the logged-in reviewer's action when the row selected for display was keyed differently from the canonical submission.

Root cause (if identifiable)
The F2F limiter only matched row ids and review submission ids, but URL submissions can carry the canonical submission id in legacySubmissionId. Duplicate rows for the same submission also preferred completed reviews even when the pending row belonged to the current reviewer.

What was changed
Iterative-review row limiting now matches all known submission aliases, including legacySubmissionId. Duplicate row selection now adds priority for rows assigned to the current reviewer's resource ids before rendering the action column.

Any added/updated tests
Added iterative-review filtering coverage for URL legacy submission id matching and current-reviewer duplicate row priority.

Validation
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.spec.ts passed.
- source ~/.nvm/nvm.sh && nvm use && yarn lint passed.
- source ~/.nvm/nvm.sh && nvm use && yarn run build passed with existing CSS-order and unrelated warning output.
- source ~/.nvm/nvm.sh && nvm use && yarn test:no-watch was attempted but still fails on unrelated baseline wallet-admin module-resolution failures and existing Work challenge launch expectations outside this diff.
