### PR TITLE
PM-5447: Preserve immediate phase durations

### DIFF
--- a/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
@@ -242,6 +242,26 @@ describe('challenge-editor utils submission count mapping', () => {
 })
 
 describe('challenge-editor utils schedule mapping', () => {
+    it('rounds API phase durations with leftover seconds up to a whole minute', () => {
+        const result = transformChallengeToFormData({
+            description: 'Public specification',
+            name: 'Immediate challenge',
+            phases: [{
+                duration: 1295994,
+                isOpen: true,
+                name: 'Submission',
+                phaseId: 'submission-phase',
+                scheduledEndDate: '2026-07-10T05:26:25.000Z',
+                scheduledStartDate: '2026-06-25T05:26:30.201Z',
+            }],
+            trackId: 'track-id',
+            typeId: 'type-id',
+        })
+
+        expect(result.phases?.[0]?.duration)
+            .toBe(21600)
+    })
+
     it('serializes scheduled phase end dates to the API payload', () => {
         const formData: Record<string, unknown> = {
             description: 'Public specification',

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.ts
@@ -835,7 +835,7 @@ function normalizePhaseDurationMinutes(duration: unknown): number {
         return maxMinutesDuration
     }
 
-    return Math.max(1, Math.trunc(parsedDuration))
+    return Math.max(1, Math.ceil(parsedDuration))
 }
 
 function normalizePhasesForForm(phases: unknown): ChallengePhase[] {


### PR DESCRIPTION
What was broken
After an active development challenge was changed from a scheduled launch to immediately, the save could still show the non-Design phase-shortening error even though the immediate schedule had already persisted.

Root cause (if identifiable)
Immediate saves can persist phase durations with leftover seconds because the backend records current seconds and milliseconds. The Work app converted API durations from seconds to whole minutes by truncating, so the next save could send a phase up to 59 seconds shorter and trigger the backend shortening guard.

What was changed
Round partial API phase durations up to the next whole minute when hydrating the challenge editor form. This preserves or slightly extends the saved phase window instead of submitting a shorter duration on the next save.

Any added/updated tests
Added a challenge editor schedule mapping regression test for API phase durations with leftover seconds.

Validation
Focused regression passed: yarn test:no-watch --runTestsByPath src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
Lint passed: yarn lint
Build passed: yarn run build, with existing CSS/order and lint-style build warnings
Full suite attempted: yarn test:no-watch, but existing unrelated tests fail, including PaymentFormModal.spec.tsx with getAssignmentPaymentCycle is not a function and several ChallengeEditorForm launch-flow specs blocked by budget approval gating.
