### PR TITLE
PM-5519: Fix achievements card padding

### DIFF
--- a/src/apps/profiles/src/member-profile/tc-achievements/MemberTCAchievements.module.scss
+++ b/src/apps/profiles/src/member-profile/tc-achievements/MemberTCAchievements.module.scss
@@ -5,7 +5,7 @@
     flex-direction: column;
     margin-bottom: $sp-8;
     background-color: $tc-white;
-    padding: $sp-8 $sp-8 $sp-2;
+    padding: $sp-8;
     border-radius: 16px;
 
     @include ltelg {

--- a/src/apps/profiles/src/member-profile/tc-achievements/MemberTCAchievements.spec.tsx
+++ b/src/apps/profiles/src/member-profile/tc-achievements/MemberTCAchievements.spec.tsx
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs'
+
+const memberTCAchievementsStyles = readFileSync(`${__dirname}/MemberTCAchievements.module.scss`, 'utf8')
+
+describe('MemberTCAchievements styles', () => {
+    it('keeps the desktop card padding even at the top and bottom', () => {
+        expect(memberTCAchievementsStyles)
+            .toMatch(/\.container \{[\s\S]*?padding: \$sp-8;/)
+    })
+})


### PR DESCRIPTION
What was broken

The desktop Achievements card had less bottom spacing than top spacing, making the bottom of the profile card look too tight.

Root cause (if identifiable)

MemberTCAchievements.module.scss used $sp-8 $sp-8 $sp-2 for desktop padding, so the bottom padding was smaller than the top and side padding.

What was changed

Changed the desktop Achievements card to use $sp-8 padding on all sides while preserving the existing mobile padding override.

Any added/updated tests

Added MemberTCAchievements.spec.tsx to assert that the desktop Achievements card uses even padding.

Validation:

- yarn test:no-watch --runTestsByPath src/apps/profiles/src/member-profile/tc-achievements/MemberTCAchievements.spec.tsx passed.
- yarn lint passed.
- yarn run build passed, with existing production build warnings.
- yarn test:no-watch was run and failed in unrelated suites outside profiles: 10 suites / 27 tests failed, while 158 suites / 782 tests passed.
