### PR TITLE
PM-5585: Update Flexi Talent bucket note

### DIFF
--- a/src/apps/customer-portal/src/pages/flexi-talent/components/EngagementsView/EngagementsView.tsx
+++ b/src/apps/customer-portal/src/pages/flexi-talent/components/EngagementsView/EngagementsView.tsx
@@ -549,7 +549,7 @@ export const EngagementsView: FC = () => {
                 </div>
 
                 <p className={styles.summaryNote}>
-                    Total includes On Hold engagements. Active is the default bucket.
+                    Total includes only Active and Closed engagements. Active is the default bucket.
                 </p>
             </aside>
 


### PR DESCRIPTION
What was broken
The Flexi Talent engagement summary note still said Total included On Hold engagements, which conflicts with the Active and Closed-only bucket behavior.

Root cause
The summary note was static UI copy left over from the previous bucket semantics.

What was changed
Updated the Engagement Buckets note to state that Total includes only Active and Closed engagements while preserving the Active default bucket guidance.

Any added/updated tests
No UI tests were added for this copy-only change. Related-test lookup for the touched Flexi Talent view found no matching tests.

Validation: yarn lint passed. yarn run build passed with existing broader app warnings. yarn test:no-watch --findRelatedTests src/apps/customer-portal/src/pages/flexi-talent/components/EngagementsView/EngagementsView.tsx passed with no tests found. Full yarn test:no-watch was run and failed in unrelated wallet-admin/work suites outside this change: wallet-admin module resolution errors for existing imports and Work ChallengeEditorForm launch expectation failures.
