### PR TITLE
PM-5603: Allow active schedules to extend from current end

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
+import { useEffect } from 'react'
 import {
     act,
     render,
@@ -204,6 +205,7 @@ jest.mock('../TimelineVisualization', () => ({
 
 interface TestHarnessProps {
     disabled?: boolean
+    hydratedPhases?: ChallengeEditorFormData['phases']
     metadata?: ChallengeEditorFormData['metadata']
     phases?: ChallengeEditorFormData['phases']
     startDate?: ChallengeEditorFormData['startDate']
@@ -246,6 +248,29 @@ const StartDateModeValue = (): JSX.Element => {
     )
 }
 
+const HydratedPhases = (props: {
+    phases?: ChallengeEditorFormData['phases']
+}): JSX.Element => {
+    const formContext = useFormContext<ChallengeEditorFormData>()
+    const setValue = formContext.setValue
+
+    useEffect(() => {
+        if (!props.phases) {
+            return
+        }
+
+        setValue('phases', props.phases, {
+            shouldDirty: false,
+            shouldValidate: true,
+        })
+    }, [
+        props.phases,
+        setValue,
+    ])
+
+    return <></>
+}
+
 const TestHarness = (props: TestHarnessProps): JSX.Element => {
     const formMethods = useForm<ChallengeEditorFormData>({
         defaultValues: {
@@ -264,6 +289,7 @@ const TestHarness = (props: TestHarnessProps): JSX.Element => {
     return (
         <FormProvider {...formMethods}>
             <ChallengeScheduleSection disabled={props.disabled} />
+            <HydratedPhases phases={props.hydratedPhases} />
             <StartDateValue />
             <StartDateModeValue />
         </FormProvider>
@@ -722,6 +748,99 @@ describe('ChallengeScheduleSection component', () => {
 
         expect(reviewRow?.minEndDate?.toISOString())
             .toBe('2026-04-02T12:34:00.000Z')
+    })
+
+    it('does not keep stale default dates as the minimum when shorter active schedules hydrate', async () => {
+        mockUseFetchChallengeTracks.mockReturnValue({
+            tracks: [{
+                id: 'development-track',
+                name: 'Development',
+                track: 'DEVELOPMENT',
+            }],
+        })
+
+        const defaultPhase = {
+            duration: 7200,
+            id: 'phase-1',
+            isOpen: true,
+            name: 'Review',
+            phaseId: 'review-phase',
+            scheduledEndDate: '2026-04-04T12:34:00.000Z',
+            scheduledStartDate: '2026-03-30T12:34:00.000Z',
+        }
+        const defaultPhases: ChallengeEditorFormData['phases'] = [defaultPhase]
+        const persistedPhases: ChallengeEditorFormData['phases'] = [{
+            ...defaultPhase,
+            duration: 4320,
+            scheduledEndDate: '2026-04-02T12:34:00.000Z',
+        }]
+        const renderResult = render(
+            <TestHarness
+                phases={defaultPhases}
+                startDate='2026-03-30T12:34:00.000Z'
+                status='ACTIVE'
+                trackId='development-track'
+            />,
+        )
+
+        renderResult.rerender(
+            <TestHarness
+                hydratedPhases={persistedPhases}
+                phases={defaultPhases}
+                startDate='2026-03-30T12:34:00.000Z'
+                status='ACTIVE'
+                trackId='development-track'
+            />,
+        )
+
+        let hydratedReviewRow: {
+            index: number
+            minEndDate?: Date
+            onEndDateChange: (index: number, date: Date | null) => void
+            phase?: {
+                name?: string
+            }
+        } | undefined
+
+        await waitFor(() => {
+            hydratedReviewRow = [...mockPhaseEditorRow.mock.calls]
+                .map(([props]) => props as {
+                    index: number
+                    minEndDate?: Date
+                    onEndDateChange: (index: number, date: Date | null) => void
+                    phase?: {
+                        name?: string
+                    }
+                })
+                .reverse()
+                .find(props => props.phase?.name === 'Review')
+
+            expect(hydratedReviewRow?.minEndDate?.toISOString())
+                .toBe('2026-04-02T12:34:00.000Z')
+        })
+
+        const reviewRowToUpdate = hydratedReviewRow as NonNullable<typeof hydratedReviewRow>
+        act(() => {
+            reviewRowToUpdate.onEndDateChange(
+                reviewRowToUpdate.index,
+                new Date('2026-04-03T12:34:00.000Z'),
+            )
+        })
+
+        await waitFor(() => {
+            const updatedReviewRow = [...mockPhaseEditorRow.mock.calls]
+                .map(([props]) => props as {
+                    minEndDate?: Date
+                    phase?: {
+                        name?: string
+                    }
+                })
+                .reverse()
+                .find(props => props.phase?.name === 'Review')
+
+            expect(updatedReviewRow?.minEndDate?.toISOString())
+                .toBe('2026-04-02T12:34:00.000Z')
+        })
     })
 
     it('keeps the active non-Design end-date minimum at the persisted end date after extending', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.tsx
@@ -122,6 +122,26 @@ function getLatestDate(dates: Array<Date | undefined>): Date | undefined {
 }
 
 /**
+ * Returns the earliest valid date from a candidate list.
+ *
+ * @param dates candidate date values.
+ * @returns the earliest date, or `undefined` when no valid date is provided.
+ */
+function getEarliestDate(dates: Array<Date | undefined>): Date | undefined {
+    return dates.reduce<Date | undefined>((earliestDate, date) => {
+        if (!date) {
+            return earliestDate
+        }
+
+        if (!earliestDate || date.getTime() < earliestDate.getTime()) {
+            return date
+        }
+
+        return earliestDate
+    }, undefined)
+}
+
+/**
  * Returns the earliest valid scheduled phase start from the current schedule.
  *
  * @param phases phase rows currently stored in the challenge form.
@@ -163,8 +183,10 @@ function getMinimumPhaseEndDate(
     isActiveChallenge: boolean,
 ): Date | undefined {
     if ((phase.isOpen || isActiveChallenge) && !phase.actualEndDate) {
-        const currentEndDate = toDate(persistedScheduledEndDate)
-            || toDate(phase.scheduledEndDate)
+        const currentEndDate = getEarliestDate([
+            toDate(persistedScheduledEndDate),
+            toDate(phase.scheduledEndDate),
+        ])
 
         return getLatestDate(
             isDesignTrackChallenge
@@ -359,12 +381,18 @@ export const ChallengeScheduleSection: FC<ChallengeScheduleSectionProps> = (
     useEffect(() => {
         phases.forEach((phase, index) => {
             const phaseKey = getPhaseKey(phase, index)
-            if (initialPhaseEndDatesRef.current.has(phaseKey)) {
-                return
-            }
-
             const scheduledEndDate = toDate(phase.scheduledEndDate)
-            if (scheduledEndDate) {
+            const initialScheduledEndDate = toDate(
+                initialPhaseEndDatesRef.current.get(phaseKey),
+            )
+
+            if (
+                scheduledEndDate
+                && (
+                    !initialScheduledEndDate
+                    || scheduledEndDate.getTime() < initialScheduledEndDate.getTime()
+                )
+            ) {
                 initialPhaseEndDatesRef.current.set(phaseKey, scheduledEndDate.toISOString())
             }
         })


### PR DESCRIPTION
What was broken
Active challenge schedule rows could keep a stale default/template phase end date as the calendar minimum. When a shorter persisted schedule hydrated afterward, the end-date picker could disable the next one or two days after the visible phase end.

Root cause
The schedule editor stored the first scheduled end date seen for a phase key and reused it as the active non-Design shortening guard, even when the form later received an earlier persisted end date for the same phase.

What was changed
The active phase minimum now uses the earlier of the stored baseline and the currently displayed scheduled end date, and the stored baseline is corrected when a shorter schedule hydrates. This preserves the existing no-shortening guard while allowing valid extensions from the visible end date.

Any added/updated tests
Added a ChallengeScheduleSection regression test covering hydration from a longer default schedule to a shorter active schedule, including a follow-up extension that keeps the true persisted end date as the minimum.

Validation
- yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeScheduleSection/ChallengeScheduleSection.component.spec.tsx passed.
- yarn lint passed.
- yarn build passed with existing warnings.
- yarn test:no-watch --silent still fails in unrelated existing suites: payment/engagement specs are missing mocked assignment helper functions, and ChallengeEditorForm launch tests currently receive the budget approval blocker before their expected billing or AI blockers.
