### PR TITLE
PM-5637: Keep long assignment labels inside cards

### DIFF
--- a/src/apps/customer-portal/src/pages/flexi-talent/FlexiTalentPage/FlexiTalentPage.module.scss
+++ b/src/apps/customer-portal/src/pages/flexi-talent/FlexiTalentPage/FlexiTalentPage.module.scss
@@ -416,6 +416,13 @@
     color: $black-80;
 }
 
+.detailCapacity {
+    box-sizing: border-box;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
 .memberTimePill {
     display: inline-flex;
     align-items: center;

--- a/src/apps/customer-portal/src/pages/flexi-talent/components/MembersView/MembersView.spec.tsx
+++ b/src/apps/customer-portal/src/pages/flexi-talent/components/MembersView/MembersView.spec.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports, sort-keys */
 import '@testing-library/jest-dom'
 
+import { readFileSync } from 'fs'
 import React from 'react'
 import {
     fireEvent,
@@ -20,6 +21,18 @@ import { MembersView } from './MembersView'
 const mockGetFlexiMemberSummary = getFlexiMemberSummary as jest.Mock
 const mockGetFlexiMemberList = getFlexiMemberList as jest.Mock
 const mockGetFlexiMemberDetail = getFlexiMemberDetail as jest.Mock
+const flexiTalentPageStyles = readFileSync(
+    `${__dirname}/../../FlexiTalentPage/FlexiTalentPage.module.scss`,
+    'utf8',
+)
+const detailCapacityWrappingPattern = [
+    '[.]detailCapacity \\{',
+    '[^}]*box-sizing: border-box;',
+    '[^}]*max-width: 100%;',
+    '[^}]*overflow-wrap: anywhere;',
+    '[^}]*white-space: normal;',
+    '[^}]*\\}',
+].join('')
 
 jest.mock('~/apps/admin/src/lib/components/common/Pagination', () => ({
     Pagination: () => <div>pagination</div>,
@@ -52,6 +65,13 @@ jest.mock('../../../../lib', () => ({
 jest.mock('../MemberHistoryModal', () => ({
     MemberHistoryModal: () => undefined,
 }))
+
+describe('MembersView styles', () => {
+    it('allows long assignment labels to wrap within the member detail card', () => {
+        expect(flexiTalentPageStyles)
+            .toMatch(new RegExp(detailCapacityWrappingPattern))
+    })
+})
 
 describe('MembersView', () => {
     beforeEach(() => {


### PR DESCRIPTION
## What was broken

Long assignment labels in the Flexi-Talent member detail view extended beyond the card boundary.

## Root cause

The detail label inherited no-wrap pill styling and had no maximum width, so its intrinsic width could exceed the detail pane.

## What was changed

Constrained the detail label to the card width and allowed normal wrapping, including breaks within long unbroken values.

## Any added/updated tests

Added a MembersView stylesheet regression test covering the width and wrapping rules for long assignment labels.

The focused MembersView suite passes with 2 tests, lint passes, and the production build passes. The full repository run completed with 163 suites passing and 10 unrelated existing Work and Wallet suites failing; the changed Flexi-Talent suite passed in that run.
