### PR TITLE
PM-5679: Correct special role details presentation

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.module.scss
@@ -90,7 +90,7 @@
 
     > strong {
         font-family: $font-barlow-condensed;
-        font-size: 24px;
+        font-size: 26px;
         font-weight: $font-weight-medium;
         line-height: 28px;
     }
@@ -142,11 +142,6 @@
 
     .roleCount {
         gap: $sp-1;
-
-        > strong {
-            font-size: 22px;
-            line-height: 26px;
-        }
     }
 
     .chevron {

--- a/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
+import { readFileSync } from 'fs'
 import type { PropsWithChildren, ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -34,6 +35,16 @@ jest.mock('../../../lib', () => ({
 }))
 
 const profile = { handle: 'Tester' } as UserProfile
+const tcSpecialRolesBannerStyles = readFileSync(`${__dirname}/TcSpecialRolesBanner.module.scss`, 'utf8')
+
+describe('TcSpecialRolesBanner styles', () => {
+    it('uses the approved role challenge count size at every breakpoint', () => {
+        expect(tcSpecialRolesBannerStyles)
+            .toMatch(/\.roleCount \{[\s\S]*?> strong \{[\s\S]*?font-size: 26px;/)
+        expect(tcSpecialRolesBannerStyles).not
+            .toMatch(/font-size: 22px;/)
+    })
+})
 
 /**
  * Renders role summary cards inside the router required by their detail links.

--- a/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.module.scss
+++ b/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.module.scss
@@ -10,6 +10,7 @@
         font-size: 20px;
         font-weight: $font-weight-medium;
         line-height: 24px;
+        text-transform: none;
     }
 
     > hr {
@@ -45,6 +46,10 @@
     height: 18px;
 }
 
+.backLink {
+    line-height: 22px;
+}
+
 .closeLink {
     color: $turq-160;
 
@@ -65,9 +70,10 @@
         margin-bottom: $sp-3;
         color: $black-80;
         font-family: $font-roboto;
-        font-size: 14px;
-        font-weight: $font-weight-bold;
-        line-height: 20px;
+        font-size: 16px;
+        font-weight: $font-weight-medium;
+        line-height: 24px;
+        text-transform: none;
     }
 }
 
@@ -88,9 +94,9 @@
     > strong {
         color: $turq-160;
         font-family: $font-barlow-condensed;
-        font-size: 28px;
+        font-size: 32px;
         font-weight: $font-weight-medium;
-        line-height: 32px;
+        line-height: 34px;
     }
 
     > span {
@@ -150,6 +156,12 @@
 
 .pagination {
     margin-top: $sp-3;
+}
+
+.loadingState {
+    height: 120px;
+    overflow: hidden;
+    border-radius: $sp-2;
 }
 
 .message {

--- a/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.spec.tsx
+++ b/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
+import { readFileSync } from 'fs'
 import { fireEvent, render, RenderResult, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
@@ -66,6 +67,33 @@ const mockedUseMemberRoleChallenges = useMemberRoleChallenges as jest.MockedFunc
     typeof useMemberRoleChallenges
 >
 const profile = { handle: 'tester' } as UserProfile
+const memberRoleDetailsStyles = readFileSync(`${__dirname}/MemberRoleDetailsView.module.scss`, 'utf8')
+
+describe('MemberRoleDetailsView styles', () => {
+    it('uses the approved role details typography and casing', () => {
+        const statsHeadingStyles = memberRoleDetailsStyles.match(/> h3 \{[\s\S]*?\n\s{4}\}/)?.[0]
+
+        expect(memberRoleDetailsStyles)
+            .toMatch(/> h2 \{[\s\S]*?text-transform: none;/)
+        expect(memberRoleDetailsStyles)
+            .toMatch(/\.backLink \{[\s\S]*?line-height: 22px;/)
+        expect(statsHeadingStyles)
+            .toContain('font-size: 16px;')
+        expect(statsHeadingStyles)
+            .toContain('font-weight: $font-weight-medium;')
+        expect(statsHeadingStyles)
+            .toContain('line-height: 24px;')
+        expect(statsHeadingStyles)
+            .toContain('text-transform: none;')
+        expect(memberRoleDetailsStyles)
+            .toMatch(/> strong \{[\s\S]*?font-size: 32px;[\s\S]*?line-height: 34px;/)
+    })
+
+    it('bounds the loading state within the achievements card', () => {
+        expect(memberRoleDetailsStyles)
+            .toMatch(/\.loadingState \{[\s\S]*?height: 120px;[\s\S]*?overflow: hidden;/)
+    })
+})
 
 /**
  * Creates a complete SWR-shaped response for a role details page.
@@ -168,6 +196,20 @@ describe('MemberRoleDetailsView', () => {
             .toBeInTheDocument()
         expect(screen.getByText('Challenges'))
             .toBeInTheDocument()
+    })
+
+    it('contains the loading spinner in the bounded loading state', () => {
+        mockedUseMemberRoleChallenges.mockReturnValue({
+            data: undefined,
+            error: undefined,
+            isValidating: true,
+            mutate: jest.fn(),
+        })
+
+        renderRole('reviewer')
+
+        expect(screen.getByText('Loading').parentElement)
+            .toHaveClass('loadingState')
     })
 
     it('requests fixed 100-item pages and loads the selected next page', () => {

--- a/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.tsx
+++ b/src/apps/profiles/src/member-profile/tc-achievements/member-role-details-view/MemberRoleDetailsView.tsx
@@ -261,7 +261,12 @@ const MemberRoleDetailsView: FC<MemberRoleDetailsViewProps> = props => {
             </section>
 
             {!data && !error && (
-                <LoadingSpinner inline message={`Loading ${roleTitle.toLowerCase()} challenges...`} />
+                <div className={styles.loadingState}>
+                    <LoadingSpinner
+                        inline
+                        message={`Loading ${roleTitle.toLowerCase()} challenges...`}
+                    />
+                </div>
             )}
 
             {error && (


### PR DESCRIPTION
## What was broken

The QA-failed implementation used incorrect special-role count and detail typography, inherited uppercase heading styles instead of the requested wording, and allowed the loading spinner to overflow the role details card.

## Root cause (if identifiable)

The initial UI retained default heading transforms and smaller type rules. Its shared full-height spinner also rendered without a bounded local loading container.

## What was changed

- Set summary challenge counts to 26px at all breakpoints.
- Set the back link to 22px line height, stats headings to 16px/24px at medium weight, and detail metrics to 32px/34px.
- Preserved natural Copilot/Reviewer wording and contained loading within the achievements card.
- Kept the approved responsive layout and existing long-list scrollbar behavior.

## Any added/updated tests

Added regression coverage for the approved typography, casing, and bounded loading state.

Validation completed:

- Targeted profile tests: 3 suites and 15 tests passed.
- `yarn lint` passed.
- `yarn run build` passed.
- The full `yarn test:no-watch` command also ran; 163 suites and 816 tests passed, while 10 unrelated admin/challenge-editor suites failed outside the changed profiles code.
