### PR TITLE
PM-5447: Avoid false immediate schedule warning

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -109,8 +109,9 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
   reapplies that refreshed same-id snapshot once it arrives.
 - Save create/update/delete: `createChallenge`, `patchChallenge`, `deleteChallenge`.
 - Manual saves for active scheduled challenges refetch the persisted challenge after `patchChallenge`
-  before resetting or navigating, so an API-rejected active-phase shortening is restored immediately
-  and the user sees a partial-save warning instead of a misleading success-only state.
+  before resetting or navigating. Rejected shortening is detected from the submitted and persisted
+  phase lengths, so an API-rejected edit is restored with a partial-save warning while a scheduler
+  timing adjustment that shifts an unchanged phase window does not show a false error.
 - Initial create refresh: after `createChallenge`, the form fetches full challenge details with `fetchChallenge` to avoid round-type regressions from sparse create responses and to surface the generated forum link for challenge types that provision a discussion on create.
 - Skills search: `searchSkills`.
 - Tracks fetch: `fetchChallengeTracks`.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -372,7 +372,7 @@ jest.mock('./ChallengeScheduleSection', () => ({
                 index === 0
                     ? {
                         ...phase,
-                        duration: 1440,
+                        duration: 10080,
                         phaseId: phase?.phaseId || 'submission-phase-id',
                         scheduledEndDate: '2026-04-18T04:58:51.000Z',
                         scheduledStartDate: phase?.scheduledStartDate || '2026-04-11T04:58:51.000Z',
@@ -3260,7 +3260,7 @@ describe('ChallengeEditorForm', () => {
                 useSchedulingAPI: true,
             },
             phases: [{
-                duration: 1440,
+                duration: 691200,
                 isOpen: true,
                 name: 'Submission',
                 phaseId: 'submission-phase-id',
@@ -3275,7 +3275,7 @@ describe('ChallengeEditorForm', () => {
             name: 'Active challenge updated',
             phases: [{
                 ...activeChallenge.phases?.[0],
-                duration: 1440,
+                duration: 604800,
                 scheduledEndDate: '2026-04-18T04:58:51.000Z',
             }],
         } as Challenge
@@ -3309,6 +3309,66 @@ describe('ChallengeEditorForm', () => {
             .toHaveBeenCalledWith('Active phase shortening cannot be saved. Other challenge changes were saved.')
         expect(mockedShowSuccessToast)
             .not.toHaveBeenCalledWith('Challenge saved successfully')
+    })
+
+    it('accepts an immediate phase window shifted later with its duration unchanged', async () => {
+        const user = userEvent.setup()
+        const activeChallenge = {
+            ...validDraftChallenge,
+            legacy: {
+                reviewType: 'INTERNAL',
+                useSchedulingAPI: true,
+            },
+            phases: [{
+                duration: 172800,
+                isOpen: true,
+                name: 'Registration',
+                phaseId: 'registration-phase-id',
+                scheduledEndDate: '2026-07-10T09:35:02.870Z',
+                scheduledStartDate: '2026-07-08T09:35:02.870Z',
+            }],
+            startDate: '2026-07-08T09:35:02.870Z',
+            status: 'ACTIVE',
+        } as Challenge
+        const persistedImmediateSchedule = {
+            ...activeChallenge,
+            name: 'Active challenge updated',
+            phases: [{
+                ...activeChallenge.phases?.[0],
+                actualStartDate: '2026-07-08T09:35:08.037Z',
+                scheduledEndDate: '2026-07-10T09:35:08.037Z',
+                scheduledStartDate: '2026-07-08T09:35:08.037Z',
+            }],
+        } as Challenge
+
+        mockedPatchChallenge.mockResolvedValue(persistedImmediateSchedule)
+        mockedFetchChallenge.mockResolvedValue(persistedImmediateSchedule)
+
+        render(
+            <MemoryRouter initialEntries={['/projects/100578/challenges/12345/edit']}>
+                <LocationDisplay />
+                <ChallengeEditorForm
+                    challenge={activeChallenge}
+                    projectId='100578'
+                />
+            </MemoryRouter>,
+        )
+
+        await user.type(screen.getByLabelText('Challenge Name'), ' updated')
+        await user.click(screen.getByRole('button', { name: 'Update Challenge' }))
+
+        await waitFor(() => {
+            expect(mockedFetchChallenge)
+                .toHaveBeenCalledWith('12345')
+            expect(screen.getByTestId('challenge-schedule-section'))
+                .toHaveAttribute('data-first-phase-end', '2026-07-10T09:35:08.037Z')
+            expect(screen.getByTestId('location-display'))
+                .toHaveTextContent('/projects/100578/challenges/12345/view')
+        })
+        expect(mockedShowErrorToast)
+            .not.toHaveBeenCalledWith('Active phase shortening cannot be saved. Other challenge changes were saved.')
+        expect(mockedShowSuccessToast)
+            .toHaveBeenCalledWith('Challenge saved successfully')
     })
 
     it('blocks saving when an assigned AI workflow has been disabled', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -1581,6 +1581,22 @@ function getPhaseDateTime(value: Date | string | undefined): number | undefined 
 }
 
 /**
+ * Resolves the canonical phase duration used by the schedule form.
+ *
+ * @param phase challenge phase containing a duration value.
+ * @returns the positive finite duration, or `undefined` when it is unavailable.
+ */
+function getPhaseDurationValue(
+    phase: ChallengePhase | undefined,
+): number | undefined {
+    const duration = Number(phase?.duration)
+
+    return Number.isFinite(duration) && duration > 0
+        ? duration
+        : undefined
+}
+
+/**
  * Resolves a stable phase identity for comparing submitted and persisted schedules.
  *
  * @param phase challenge phase from form or API state.
@@ -1605,11 +1621,11 @@ function isOpenPhase(phase: ChallengePhase | undefined): boolean {
 }
 
 /**
- * Detects an active phase end date that the API did not shorten.
+ * Detects an active phase schedule that the API did not shorten.
  *
  * @param submittedPhases schedule phases submitted with the save request.
  * @param persistedPhases schedule phases fetched after the save completed.
- * @returns `true` when an open phase still ends later in persisted data than in submitted data.
+ * @returns `true` when an open phase remains longer in persisted data than in submitted data.
  */
 function hasRejectedActivePhaseShortening(
     submittedPhases: ChallengeEditorFormData['phases'],
@@ -1641,6 +1657,23 @@ function hasRejectedActivePhaseShortening(
             (!isOpenPhase(submittedPhase) && !isOpenPhase(persistedPhase))
             || submittedPhase.actualEndDate
             || persistedPhase.actualEndDate
+        ) {
+            return false
+        }
+
+        const submittedDuration = getPhaseDurationValue(submittedPhase)
+        const persistedDuration = getPhaseDurationValue(persistedPhase)
+
+        if (submittedDuration !== undefined && persistedDuration !== undefined) {
+            return submittedDuration < persistedDuration
+        }
+
+        const submittedStartTime = getPhaseDateTime(submittedPhase.scheduledStartDate)
+        const persistedStartTime = getPhaseDateTime(persistedPhase.scheduledStartDate)
+        if (
+            submittedStartTime === undefined
+            || persistedStartTime === undefined
+            || submittedStartTime !== persistedStartTime
         ) {
             return false
         }


### PR DESCRIPTION
What was broken
Changing an active development challenge from Scheduled to Immediately could save the immediate schedule but still show “Active phase shortening cannot be saved. Other challenge changes were saved.”

Root cause (if identifiable)
The earlier challenge-api fixes correctly validated recalculated phase durations, and platform-ui PR #2019 preserved partial-minute API durations. The remaining Work post-save check still compared absolute phase end timestamps. When the scheduler opened an immediate phase a few seconds after the submitted start and shifted its dates without changing its duration, Work treated the later persisted end as rejected shortening.

What was changed
The post-save check now compares canonical submitted and persisted phase durations. It falls back to comparing end dates only when duration data is unavailable and the phase start did not move, preserving the genuine shortening warning without flagging scheduler timing shifts. The challenge editor documentation now describes this behavior.

Any added/updated tests
Added a ChallengeEditorForm save-flow regression using the timestamps and unchanged 48-hour duration seen in QA. Updated the existing PM-5446 true-shortening fixture to use consistent 8-day and 7-day durations so the rejection warning remains covered.

Validation
- Focused PM-5447 and PM-5446 regressions pass: 2 tests.
- `yarn lint` passes.
- `yarn run build` passes with existing repository CSS-order and lint-style warnings.
- `yarn test:no-watch` was run. The full baseline remains blocked by 10 unrelated failing suites (27 tests), including the existing PaymentFormModal `getAssignmentPaymentCycle` mock failure and ChallengeEditorForm launch tests that stop at budget-approval gating.
