### PR TITLE
PM-5708: Show failed screening results to submitters

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentScreening.spec.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentScreening.spec.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render } from '@testing-library/react'
+
+import { ChallengeDetailContext } from '../../contexts'
+import type {
+    ChallengeDetailContextModel,
+    ChallengeInfo,
+    Screening,
+} from '../../models'
+
+import { TabContentScreening } from './TabContentScreening'
+
+const mockUseRole = jest.fn()
+const mockTableSubmissionScreening = jest.fn()
+
+jest.mock('~/libs/core', () => ({
+    getRatingColor: () => '#2a2a2a',
+}), { virtual: true })
+
+jest.mock('../../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({}),
+    }
+})
+
+jest.mock('../../hooks', () => ({
+    useRole: () => mockUseRole(),
+}))
+
+jest.mock('~/apps/admin/src/lib', () => ({
+    TableLoading: () => <div>Loading</div>,
+}), { virtual: true })
+
+jest.mock('../TableNoRecord', () => ({
+    TableNoRecord: (props: { message: string }) => <div>{props.message}</div>,
+}))
+
+jest.mock('../TableSubmissionScreening', () => ({
+    TableSubmissionScreening: (props: { screenings: Screening[] }) => {
+        mockTableSubmissionScreening(props)
+        return <div>{props.screenings.length}</div>
+    },
+}))
+
+const ownFailedScreening = {
+    challengeId: 'challenge-id',
+    createdAt: '2026-07-23T05:41:00.000Z',
+    memberId: 'member-current',
+    phaseName: 'Screening',
+    result: 'NO PASS',
+    reviewId: 'review-own',
+    score: '46.67',
+    submissionId: 'submission-own',
+} as Screening
+
+const foreignFailedScreening = {
+    ...ownFailedScreening,
+    memberId: 'member-other',
+    reviewId: 'review-other',
+    submissionId: 'submission-other',
+} as Screening
+
+const challengeInfo = {
+    status: 'Completed',
+} as ChallengeInfo
+
+const challengeContext = {
+    challengeInfo,
+    myResources: [
+        {
+            memberId: 'member-current',
+            roleName: 'Submitter',
+        },
+    ],
+} as ChallengeDetailContextModel
+
+describe('TabContentScreening', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUseRole.mockReturnValue({
+            actionChallengeRole: 'Submitter',
+            hasReviewerRole: false,
+            isPrivilegedRole: false,
+            reviewerResourceIds: new Set<string>(),
+            screenerResourceIds: new Set<string>(),
+        })
+    })
+
+    it('shows a failed submitter their own screening result for a completed challenge', () => {
+        render(
+            <ChallengeDetailContext.Provider value={challengeContext}>
+                <TabContentScreening
+                    downloadSubmission={jest.fn()}
+                    isActiveChallenge={false}
+                    isDownloading={{}}
+                    isLoadingScreening={false}
+                    screening={[
+                        ownFailedScreening,
+                        foreignFailedScreening,
+                    ]}
+                    screeningMinimumPassingScore={50}
+                />
+            </ChallengeDetailContext.Provider>,
+        )
+
+        expect(mockTableSubmissionScreening)
+            .toHaveBeenLastCalledWith(expect.objectContaining({
+                screenings: [ownFailedScreening],
+            }))
+    })
+})

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentScreening.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentScreening.tsx
@@ -87,10 +87,6 @@ export const TabContentScreening: FC<Props> = (props: Props) => {
             })
             const canSeeAll = isPrivilegedRole || hasReviewerRole
 
-            if (isChallengeCompleted && !canSeeAll && !hasPassedScreeningThreshold) {
-                return []
-            }
-
             if (canSeeAll || (isChallengeCompleted && hasPassedScreeningThreshold)) {
                 return phaseValidatedRows
             }


### PR DESCRIPTION
## What was broken

Members whose submissions failed screening on completed Design challenges saw an empty Screening tab instead of their failed result, score, and scorecard link.

## Root cause

The completed-challenge visibility filter returned an empty row set for non-privileged viewers below the screening threshold before the existing ownership filter could retain the viewer's own submission.

## What was changed

Removed the premature empty result so below-threshold viewers fall through to the existing ownership and assignment filter. Failed submitters can now see their own screening result while other members' rows remain hidden. Existing scorecard authorization and link rendering continue to provide access to the member's own scorecard.

## Any added/updated tests

Added a `TabContentScreening` regression test that supplies owned and foreign failed submissions for a completed challenge and verifies that only the owned row is displayed.

Validation:

- `yarn test:no-watch --runInBand src/apps/review/src` — 35 suites and 134 tests passed.
- `yarn lint` — passed.
- `yarn run build` — passed with existing repository warnings.
- The full monorepo test command reports 13 unrelated failing suites and 36 failing tests; a detached clean `origin/dev` run reports the same 13 suites and 36 tests failing.
