### PR TITLE
PM-5471: add reviewer filter to past challenges

### DIFF
--- a/src/apps/review/src/config/index.config.ts
+++ b/src/apps/review/src/config/index.config.ts
@@ -19,6 +19,30 @@ export const CHALLENGE_TYPE_SELECT_ALL_OPTION: SelectOption = {
     value: '',
 }
 
+export const ROLE_SELECT_ALL_OPTION: SelectOption = {
+    label: 'All roles',
+    value: '',
+}
+
+export const REVIEWER_RESOURCE_ROLE_IDS = [
+    '318b9c07-079a-42d9-a81f-b96be1dc1099',
+    '3970272b-85b4-48d8-8439-672b4f6031bd',
+    '3eedd4a4-3c68-4f68-8de4-a1ca5c2055e5',
+    '4857fd2e-d9d2-44bb-a429-f75b7c5d5feb',
+    'ac953811-8268-403a-ac06-fd88a100c9c7',
+    'caf7b717-3dee-41e0-8bf8-3217cc5a878c',
+    'e0544b94-6420-4afc-8f63-238eddc751b9',
+    'f6df7212-b9d6-4193-bfb1-b383586fce63',
+]
+
+export const PAST_CHALLENGE_ROLE_SELECT_OPTIONS: SelectOption[] = [
+    ROLE_SELECT_ALL_OPTION,
+    {
+        label: 'Reviewer',
+        value: REVIEWER_RESOURCE_ROLE_IDS.join(','),
+    },
+]
+
 export const CHALLENGE_TYPE_SELECT_OPTIONS: SelectOption[] = [
     CHALLENGE_TYPE_SELECT_ALL_OPTION,
     ...[

--- a/src/apps/review/src/lib/hooks/useFetchPastReviews.spec.tsx
+++ b/src/apps/review/src/lib/hooks/useFetchPastReviews.spec.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react'
+
+import { fetchPastReviews } from '../services'
+
+import {
+    DEFAULT_PAST_REVIEWS_PER_PAGE,
+    useFetchPastReviews,
+    useFetchPastReviewsProps,
+} from './useFetchPastReviews'
+
+jest.mock('~/libs/shared', () => ({
+    handleError: jest.fn(),
+}), { virtual: true })
+
+jest.mock('../services', () => ({
+    fetchPastReviews: jest.fn(),
+}))
+
+jest.mock('./useFetchActiveReviews', () => ({
+    transformAssignments: jest.fn()
+        .mockReturnValue([]),
+}))
+
+const mockedFetchPastReviews = fetchPastReviews as jest.Mock
+const reviewerRoleIds: string[] = [
+    'reviewer-role',
+    'screening-role',
+]
+
+const TestComponent = (): JSX.Element => {
+    const {
+        isLoading,
+        loadPastReviews,
+    }: useFetchPastReviewsProps = useFetchPastReviews()
+
+    function loadReviewerChallenges(): void {
+        loadPastReviews({
+            page: 1,
+            perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+            resourceRoleIds: reviewerRoleIds,
+        })
+            .catch(() => undefined)
+    }
+
+    function loadNextPage(): void {
+        loadPastReviews({
+            page: 2,
+            perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+        })
+            .catch(() => undefined)
+    }
+
+    function clearRoleFilter(): void {
+        loadPastReviews({
+            page: 1,
+            perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+            resourceRoleIds: undefined,
+        })
+            .catch(() => undefined)
+    }
+
+    return (
+        <>
+            <button onClick={loadReviewerChallenges} type='button'>
+                Load reviewer challenges
+            </button>
+            <button onClick={loadNextPage} type='button'>
+                Load next page
+            </button>
+            <button onClick={clearRoleFilter} type='button'>
+                Clear role filter
+            </button>
+            <div data-testid='loading'>
+                {String(isLoading)}
+            </div>
+        </>
+    )
+}
+
+describe('useFetchPastReviews role filter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockedFetchPastReviews.mockResolvedValue({
+            data: [],
+            meta: {
+                page: 1,
+                perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+                totalCount: 0,
+                totalPages: 0,
+            },
+        })
+    })
+
+    it('persists reviewer role IDs across page changes and supports an explicit clear', async () => {
+        render(<TestComponent />)
+        const loadingIndicator = screen.getByTestId('loading')
+
+        fireEvent.click(screen.getByRole('button', {
+            name: 'Load reviewer challenges',
+        }))
+        await waitFor(() => {
+            expect(loadingIndicator.textContent)
+                .toBe('false')
+        })
+        expect(mockedFetchPastReviews)
+            .toHaveBeenCalledTimes(1)
+        expect(mockedFetchPastReviews)
+            .toHaveBeenNthCalledWith(1, expect.objectContaining({
+                page: 1,
+                resourceRoleIds: reviewerRoleIds,
+            }))
+
+        fireEvent.click(screen.getByRole('button', {
+            name: 'Load next page',
+        }))
+        await waitFor(() => {
+            expect(loadingIndicator.textContent)
+                .toBe('false')
+        })
+        expect(mockedFetchPastReviews)
+            .toHaveBeenCalledTimes(2)
+        expect(mockedFetchPastReviews)
+            .toHaveBeenNthCalledWith(2, expect.objectContaining({
+                page: 2,
+                resourceRoleIds: reviewerRoleIds,
+            }))
+
+        fireEvent.click(screen.getByRole('button', {
+            name: 'Clear role filter',
+        }))
+        await waitFor(() => {
+            expect(loadingIndicator.textContent)
+                .toBe('false')
+        })
+        expect(mockedFetchPastReviews)
+            .toHaveBeenCalledTimes(3)
+        expect(mockedFetchPastReviews)
+            .toHaveBeenNthCalledWith(3, expect.objectContaining({
+                page: 1,
+                resourceRoleIds: undefined,
+            }))
+    })
+})

--- a/src/apps/review/src/lib/hooks/useFetchPastReviews.ts
+++ b/src/apps/review/src/lib/hooks/useFetchPastReviews.ts
@@ -40,6 +40,7 @@ type LoadPastReviewsInternalParams = Required<Pick<FetchPastReviewsParams, 'page
     challengeStatus?: string
     challengeTrackId?: string
     challengeTypeId?: string
+    resourceRoleIds?: string[]
     sortBy?: string
     sortOrder?: 'asc' | 'desc'
 }
@@ -57,6 +58,7 @@ function buildRequestKey(params: LoadPastReviewsInternalParams): string {
         params.challengeTrackId ?? '',
         params.challengeName ?? '',
         params.challengeStatus ?? '',
+        params.resourceRoleIds?.join(',') ?? '',
         params.page,
         params.perPage,
         params.sortBy ?? '',
@@ -113,6 +115,7 @@ function mergePastReviewParams(
     assignFromNext('challengeStatus')
     assignFromNext('challengeTrackId')
     assignFromNext('challengeTypeId')
+    assignFromNext('resourceRoleIds')
     assignFromNext('sortBy')
     assignFromNext('sortOrder')
 
@@ -147,6 +150,7 @@ export function useFetchPastReviews(): useFetchPastReviewsProps {
         challengeTypeId: undefined,
         page: 1,
         perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+        resourceRoleIds: undefined,
         sortBy: undefined,
         sortOrder: undefined,
     })

--- a/src/apps/review/src/lib/services/reviews.service.spec.ts
+++ b/src/apps/review/src/lib/services/reviews.service.spec.ts
@@ -2,7 +2,10 @@ import { xhrGetAsync } from '~/libs/core'
 
 import type { BackendProjectResult } from '../models'
 
-import { fetchAllProjectResults } from './reviews.service'
+import {
+    fetchAllProjectResults,
+    fetchPastReviews,
+} from './reviews.service'
 
 jest.mock('~/config', () => ({
     EnvironmentConfig: {
@@ -108,5 +111,36 @@ describe('fetchAllProjectResults', () => {
             .toEqual([])
         expect(mockedXhrGetAsync)
             .not.toHaveBeenCalled()
+    })
+})
+
+describe('fetchPastReviews', () => {
+    beforeEach(() => {
+        mockedXhrGetAsync.mockReset()
+    })
+
+    it('includes reviewer resource role IDs in the server-side filter', async () => {
+        mockedXhrGetAsync.mockResolvedValue({
+            data: [],
+            meta: {
+                page: 1,
+                perPage: 50,
+                totalCount: 0,
+                totalPages: 0,
+            },
+        } as never)
+
+        await fetchPastReviews({
+            page: 1,
+            perPage: 50,
+            resourceRoleIds: ['reviewer-role', 'screening-role'],
+        })
+
+        expect(mockedXhrGetAsync)
+            .toHaveBeenCalledWith(
+                'https://api.topcoder.test/v6/my-reviews'
+                + '?resourceRoleIds=reviewer-role%2Cscreening-role'
+                + '&page=1&perPage=50&past=true',
+            )
     })
 })

--- a/src/apps/review/src/lib/services/reviews.service.ts
+++ b/src/apps/review/src/lib/services/reviews.service.ts
@@ -95,6 +95,7 @@ export interface FetchPastReviewsParams {
     challengeTrackId?: string
     challengeName?: string
     challengeStatus?: string
+    resourceRoleIds?: string[]
     page?: number
     perPage?: number
     sortBy?: string
@@ -106,6 +107,7 @@ export const fetchPastReviews = async ({
     challengeTrackId,
     challengeName,
     challengeStatus,
+    resourceRoleIds,
     page,
     perPage,
     sortBy,
@@ -117,13 +119,17 @@ export const fetchPastReviews = async ({
             ...(challengeTrackId ? { challengeTrackId } : {}),
             ...(challengeName ? { challengeName } : {}),
             ...(challengeStatus ? { challengeStatus } : {}),
+            ...(resourceRoleIds?.length ? { resourceRoleIds } : {}),
             ...(page ? { page } : {}),
             ...(perPage ? { perPage } : {}),
             ...(sortBy ? { sortBy } : {}),
             ...(sortOrder ? { sortOrder } : {}),
             past: true,
         },
-        { addQueryPrefix: true },
+        {
+            addQueryPrefix: true,
+            arrayFormat: 'comma',
+        },
     )
 
     return xhrGetAsync<BackendResponseWithMeta<BackendMyReviewAssignment[]>>(

--- a/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.spec.tsx
+++ b/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.spec.tsx
@@ -1,0 +1,214 @@
+/* eslint-disable @typescript-eslint/no-var-requires, global-require */
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react'
+
+import {
+    PAST_CHALLENGE_ROLE_SELECT_OPTIONS,
+    REVIEWER_RESOURCE_ROLE_IDS,
+} from '../../../config/index.config'
+import {
+    useFetchChallengeTracks,
+    useFetchChallengeTypes,
+    useFetchPastReviews,
+} from '../../../lib/hooks'
+
+import { PastReviewsPage } from './PastReviewsPage'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        REVIEW: {
+            PROFILE_PAGE_URL: 'https://profiles.example.com',
+        },
+    },
+}), { virtual: true })
+
+jest.mock('react-select', () => ({
+    __esModule: true,
+    default: (props: {
+        inputId?: string
+        isDisabled?: boolean
+        onChange: (option?: { label: string; value: string }) => void
+        options: Array<{ label: string; value: string }>
+        value?: { label: string; value: string }
+    }) => {
+        function handleChange(event: { target: { value: string } }): void {
+            const selectedOption = props.options.find(
+                option => option.value === event.target.value,
+            )
+            props.onChange(selectedOption)
+        }
+
+        return (
+            <select
+                aria-label={props.inputId}
+                disabled={props.isDisabled}
+                id={props.inputId}
+                onChange={handleChange}
+                value={props.value?.value ?? ''}
+            >
+                {props.options.map(option => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        )
+    },
+}))
+
+jest.mock('~/apps/admin/src/lib', () => ({
+    Pagination: () => <div>Pagination</div>,
+    TableLoading: () => <div>Loading</div>,
+}), { virtual: true })
+
+jest.mock('~/libs/ui', () => ({
+    Button: (props: {
+        label: string
+        onClick?: () => void
+    }) => (
+        <button onClick={props.onClick} type='button'>
+            {props.label}
+        </button>
+    ),
+    IconOutline: {
+        XIcon: () => <span>clear-icon</span>,
+    },
+    InputText: (props: {
+        name: string
+        onChange?: (event: { target: { value: string } }) => void
+        value?: string
+    }) => (
+        <input
+            aria-label={props.name}
+            name={props.name}
+            onChange={props.onChange}
+            value={props.value}
+        />
+    ),
+}), { virtual: true })
+
+jest.mock('../../../lib', () => {
+    const React = require('react') as typeof import('react')
+
+    return {
+        PageWrapper: (props: React.PropsWithChildren) => <div>{props.children}</div>,
+        ReviewAppContext: React.createContext({
+            loginUserInfo: {
+                userId: '40587818',
+            },
+        }),
+        TableActiveReviews: () => <div>Past reviews</div>,
+        TableNoRecord: () => <div>No records</div>,
+    }
+})
+
+jest.mock('../../../lib/hooks', () => ({
+    useFetchChallengeTracks: jest.fn(),
+    useFetchChallengeTypes: jest.fn(),
+    useFetchPastReviews: jest.fn(),
+}))
+
+jest.mock('../../../lib/utils', () => ({
+    CHALLENGE_STATUS_SELECT_ALL_OPTION: {
+        label: 'All statuses',
+        value: '',
+    },
+    PAST_CHALLENGE_STATUS_OPTIONS: [
+        {
+            label: 'All statuses',
+            value: '',
+        },
+    ],
+}))
+
+const mockedUseFetchChallengeTracks = useFetchChallengeTracks as jest.Mock
+const mockedUseFetchChallengeTypes = useFetchChallengeTypes as jest.Mock
+const mockedUseFetchPastReviews = useFetchPastReviews as jest.Mock
+const loadPastReviews = jest.fn()
+
+describe('PastReviewsPage role filter', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        loadPastReviews.mockResolvedValue(undefined)
+        mockedUseFetchChallengeTracks.mockReturnValue({
+            challengeTracks: [],
+            isLoading: false,
+        })
+        mockedUseFetchChallengeTypes.mockReturnValue({
+            challengeTypes: [],
+            isLoading: false,
+        })
+        mockedUseFetchPastReviews.mockReturnValue({
+            isLoading: false,
+            loadPastReviews,
+            pagination: {
+                page: 1,
+                perPage: 50,
+                totalCount: 0,
+                totalPages: 1,
+            },
+            pastReviews: [],
+        })
+    })
+
+    it('offers one aggregate Reviewer option and loads page one with every reviewer role ID', async () => {
+        render(<PastReviewsPage />)
+
+        const roleSelect = screen.getByLabelText('Role') as HTMLSelectElement
+        expect(Array.from(roleSelect.options)
+            .map(option => option.text))
+            .toEqual(['All roles', 'Reviewer'])
+        expect(PAST_CHALLENGE_ROLE_SELECT_OPTIONS)
+            .toHaveLength(2)
+
+        fireEvent.change(roleSelect, {
+            target: {
+                value: REVIEWER_RESOURCE_ROLE_IDS.join(','),
+            },
+        })
+
+        await waitFor(() => {
+            expect(loadPastReviews)
+                .toHaveBeenLastCalledWith(expect.objectContaining({
+                    page: 1,
+                    resourceRoleIds: REVIEWER_RESOURCE_ROLE_IDS,
+                }))
+        })
+    })
+
+    it('removes the reviewer role IDs when filters are cleared', async () => {
+        render(<PastReviewsPage />)
+
+        const roleSelect = screen.getByLabelText('Role') as HTMLSelectElement
+        fireEvent.change(roleSelect, {
+            target: {
+                value: REVIEWER_RESOURCE_ROLE_IDS.join(','),
+            },
+        })
+
+        await waitFor(() => {
+            expect(loadPastReviews)
+                .toHaveBeenLastCalledWith(expect.objectContaining({
+                    resourceRoleIds: REVIEWER_RESOURCE_ROLE_IDS,
+                }))
+        })
+
+        loadPastReviews.mockClear()
+        fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+
+        await waitFor(() => {
+            expect(loadPastReviews)
+                .toHaveBeenCalledWith(expect.objectContaining({
+                    page: 1,
+                    resourceRoleIds: undefined,
+                }))
+        })
+        expect(roleSelect.value)
+            .toBe('')
+    })
+})

--- a/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.tsx
+++ b/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.tsx
@@ -18,7 +18,11 @@ import { Pagination, TableLoading } from '~/apps/admin/src/lib'
 import { Sort } from '~/apps/admin/src/platform/gamification-admin/src/game-lib'
 import { Button, IconOutline, InputText } from '~/libs/ui'
 
-import { CHALLENGE_TYPE_SELECT_ALL_OPTION } from '../../../config/index.config'
+import {
+    CHALLENGE_TYPE_SELECT_ALL_OPTION,
+    PAST_CHALLENGE_ROLE_SELECT_OPTIONS,
+    ROLE_SELECT_ALL_OPTION,
+} from '../../../config/index.config'
 import {
     PageWrapper,
     ReviewAppContext,
@@ -82,6 +86,9 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
     const [challengeStatus, setChallengeStatus] = useState<SingleValue<SelectOption>>(
         CHALLENGE_STATUS_SELECT_ALL_OPTION,
     )
+    const [challengeRole, setChallengeRole] = useState<SingleValue<SelectOption>>(
+        ROLE_SELECT_ALL_OPTION,
+    )
 
     const challengeTypeOptions = useMemo<SelectOption[]>(() => {
         const results: SelectOption[] = [CHALLENGE_TYPE_SELECT_ALL_OPTION]
@@ -115,6 +122,14 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
     const selectedChallengeTrackId = challengeTrack?.value || undefined
     const selectedChallengeTypeId = challengeType?.value || undefined
     const selectedChallengeStatus = challengeStatus?.value || undefined
+    const selectedResourceRoleIds = useMemo(
+        () => (
+            challengeRole?.value
+                ? challengeRole.value.split(',')
+                : undefined
+        ),
+        [challengeRole],
+    )
 
     // If the selected type is not allowed for the selected track, reset to All
     useEffect(() => {
@@ -137,6 +152,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
                 challengeTypeId: selectedChallengeTypeId || undefined,
                 page: 1,
                 perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+                resourceRoleIds: selectedResourceRoleIds,
                 sortBy: sort?.fieldName,
                 sortOrder: sort?.direction,
             })
@@ -151,6 +167,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
         selectedChallengeTrackId,
         selectedChallengeTypeId,
         selectedChallengeStatus,
+        selectedResourceRoleIds,
         sort,
     ])
 
@@ -163,6 +180,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
                 challengeTypeId: selectedChallengeTypeId || undefined,
                 page: nextPage,
                 perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+                resourceRoleIds: selectedResourceRoleIds,
                 sortBy: sort?.fieldName,
                 sortOrder: sort?.direction,
             })
@@ -173,6 +191,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
             selectedChallengeTrackId,
             selectedChallengeTypeId,
             selectedChallengeStatus,
+            selectedResourceRoleIds,
             sort,
         ],
     )
@@ -196,6 +215,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
         setChallengeType(CHALLENGE_TYPE_SELECT_ALL_OPTION)
         setChallengeName('')
         setChallengeStatus(CHALLENGE_STATUS_SELECT_ALL_OPTION)
+        setChallengeRole(ROLE_SELECT_ALL_OPTION)
         loadPastReviews({
             challengeName: undefined,
             challengeStatus: undefined,
@@ -203,6 +223,7 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
             challengeTypeId: undefined,
             page: 1,
             perPage: DEFAULT_PAST_REVIEWS_PER_PAGE,
+            resourceRoleIds: undefined,
             sortBy: sort?.fieldName,
             sortOrder: sort?.direction,
         })
@@ -234,6 +255,18 @@ export const PastReviewsPage: FC<Props> = (props: Props) => {
                                     Search by name
                                 </span>
                             )}
+                        />
+                    </div>
+                    <div className={styles.filterGroup}>
+                        <label htmlFor='pastChallengeRole'>Role</label>
+                        <Select
+                            inputId='pastChallengeRole'
+                            className='react-select-container'
+                            classNamePrefix='select'
+                            options={PAST_CHALLENGE_ROLE_SELECT_OPTIONS}
+                            value={challengeRole}
+                            onChange={setChallengeRole}
+                            isDisabled={isLoadingPastReviews}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
## What was broken

Members could not narrow My Past Challenges to challenges where they served in a reviewer role.

## Root cause

The page had no role control, and its request service and state did not carry resource-role filters to the review API.

## What was changed

- Added an `All roles`/`Reviewer` filter to My Past Challenges.
- Mapped `Reviewer` to the eight resource-role IDs identified in PM-5471.
- Serialized the selected IDs to the API and retained them across sorting and pagination.
- Reset the role filter with the existing Clear action.
- Added the companion API support in https://github.com/topcoder-platform/review-api-v6/pull/306.

## Any added/updated tests

- Added page and hook coverage for the role options, all eight IDs, pagination persistence, and clearing.
- Updated the review service test for comma-separated query serialization.
- Focused PM-5471 run: 3 suites and 6 tests passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- Full `yarn test:no-watch --runInBand`: all PM-5471 tests passed; the repository retains the same 13 failing suites and 36 failing tests as clean `origin/dev`, all outside the review app.
