### PR TITLE
PM-5522: Reconcile draft status after partial save

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
@@ -185,6 +185,7 @@ jest.mock('./components', () => {
                 status: string
             }) => void
             onChallengeApprovalStatusChange?: (status?: string) => void
+            onChallengeStatusChange?: (status?: string) => void
             isReadOnly?: boolean
             onRegisterLaunchAction?: (action: (() => Promise<void>) | undefined) => void
         }) => {
@@ -226,6 +227,18 @@ jest.mock('./components', () => {
                                 type='button'
                             >
                                 Mock create challenge
+                            </button>
+                        )
+                        : undefined}
+                    {!props.isReadOnly
+                        ? (
+                            <button
+                                onClick={function handleChallengeStatusChange() {
+                                    props.onChallengeStatusChange?.('DRAFT')
+                                }}
+                                type='button'
+                            >
+                                Mock save as draft
                             </button>
                         )
                         : undefined}
@@ -996,6 +1009,37 @@ describe('ChallengeEditorPage', () => {
         await waitFor(() => {
             expect(mockedDeleteChallenge)
                 .toHaveBeenCalledWith('789')
+        })
+    })
+
+    it('hides the delete action when a created challenge advances to DRAFT', async () => {
+        mockedUseFetchChallenge.mockReturnValue({
+            challenge: undefined,
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+        })
+
+        renderPage(
+            '/projects/123/challenges/new',
+            '/projects/:projectId/challenges/new',
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Mock create challenge' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Delete' }))
+                .toBeTruthy()
+        })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Mock save as draft' }))
+
+        await waitFor(() => {
+            expect(within(screen.getByTestId('title-action'))
+                .getByText('DRAFT'))
+                .toBeTruthy()
+            expect(screen.queryByRole('button', { name: 'Delete' }))
+                .toBeNull()
         })
     })
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -124,7 +124,9 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - `Launch` is shown on the details tab for `DRAFT` challenges in the header for both view and edit routes, and again in the footer beside `Save Challenge` while editing.
 - The work app blocks launch attempts when the parent project billing account is inactive, expired, or has insufficient remaining funds, matching the legacy work-manager launch restriction.
 - Task challenges cannot be launched until `Assigned Member` is set, which ensures the task is assigned before it becomes publicly visible.
-- After the first successful save from `NEW` to `DRAFT`, the editor updates the launch affordance immediately so the user can launch without reloading.
+- After the challenge PATCH persists a `NEW` to `DRAFT` transition, the editor updates the status
+  immediately before syncing resource-backed assignments. A later assignment error therefore keeps
+  the persisted `DRAFT` status visible and does not leave the `NEW`-only delete action available.
 - After the initial create request succeeds on the `/projects/:projectId/challenges/new` route, the
   page header immediately treats that record as an existing `NEW` challenge so the status pill and
   `Delete` action are available before the route transitions to the regular edit page.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -3613,6 +3613,73 @@ describe('ChallengeEditorForm', () => {
         })
     })
 
+    it('reports DRAFT status when task assignee sync fails after the challenge save', async () => {
+        const user = userEvent.setup()
+        const onChallengeStatusChange = jest.fn()
+        const termsError = 'The user has not yet agreed to the following terms: [Standard Terms 2026]'
+        const newTaskChallenge = {
+            ...validNewChallenge,
+            assignedMemberId: '12345',
+            task: {
+                isTask: true,
+            },
+            terms: ['standard-terms-2026'],
+            type: {
+                abbreviation: 'TSK',
+                name: 'Task',
+            },
+            typeId: 'task-type-id',
+        } as Challenge
+
+        mockedUseFetchTerms.mockReturnValue({
+            error: undefined,
+            isError: false,
+            isLoading: false,
+            terms: [{
+                id: 'standard-terms-2026',
+                title: 'Standard Terms 2026',
+            }],
+        })
+        mockedFetchResourceRolesService.mockResolvedValue([{
+            id: 'submitter-role-id',
+            name: 'Submitter',
+        }])
+        mockedPatchChallenge.mockResolvedValue({
+            ...newTaskChallenge,
+            status: 'DRAFT',
+        })
+        mockedCreateResource.mockRejectedValueOnce(new Error(termsError))
+
+        render(
+            <MemoryRouter initialEntries={['/projects/100578/challenges/new']}>
+                <LocationDisplay />
+                <ChallengeEditorForm
+                    challenge={newTaskChallenge}
+                    onChallengeStatusChange={onChallengeStatusChange}
+                    projectId='100578'
+                />
+            </MemoryRouter>,
+        )
+
+        await user.type(screen.getByLabelText('Challenge Name'), ' updated')
+        await user.click(screen.getByRole('button', { name: 'Save as Draft' }))
+
+        await waitFor(() => {
+            expect(mockedPatchChallenge)
+                .toHaveBeenCalledWith('12345', expect.objectContaining({
+                    status: 'DRAFT',
+                }))
+            expect(onChallengeStatusChange)
+                .toHaveBeenCalledWith('DRAFT')
+            expect(screen.getByText(/The user has not yet agreed to the following terms/))
+                .toBeInTheDocument()
+        })
+        expect(onChallengeStatusChange.mock.invocationCallOrder[0])
+            .toBeLessThan(mockedCreateResource.mock.invocationCallOrder[0])
+        expect(screen.getByTestId('location-display'))
+            .toHaveTextContent('/projects/100578/challenges/new')
+    })
+
     it('returns to view mode after saving from an edit route with a trailing slash', async () => {
         const user = userEvent.setup()
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -3244,6 +3244,9 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                     status: payloadStatus,
                 })
                 const savedChallenge = await patchChallenge(currentChallengeId, payload)
+                onChallengeStatusChange?.(
+                    normalizeStatus(savedChallenge.status) || payloadStatus,
+                )
                 await syncDraftSingleAssignments(currentChallengeId, formDataWithProjectBilling)
                 const shouldVerifyPersistedSchedule
                     = shouldVerifyPersistedScheduleAfterSave(formDataWithProjectBilling)
@@ -3295,7 +3298,6 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                         ? { keepValues: true }
                         : undefined,
                 )
-                onChallengeStatusChange?.(normalizeStatus(nextValues.status))
 
                 if (!options.isAutosave) {
                     if (wasActivePhaseShorteningRejected) {


### PR DESCRIPTION
## What was broken

Saving a newly created task as a draft could persist the challenge as `DRAFT` while the create page continued to show `NEW` and its `NEW`-only Delete action when assignee synchronization failed because the member had not signed the selected terms.

## Root cause

The challenge PATCH and assignee resource creation are separate API operations. The UI published the saved challenge status only after resource synchronization completed, so a resource error left stale `NEW` state even though the PATCH had already committed `DRAFT`.

## What was changed

- Publish the persisted challenge status immediately after the challenge PATCH succeeds and before resource-backed assignments are synchronized.
- Keep the existing assignee terms error handling intact.
- Document the partial-save status behavior.

## Any added/updated tests

- Added a form regression covering a successful `DRAFT` PATCH followed by an unsigned-assignee resource failure, including call-order and error assertions.
- Added page coverage confirming that advancing a created challenge to `DRAFT` removes Delete.
- Focused PM-5522 tests pass, `yarn lint` passes, and `yarn run build` passes.
- The full `yarn test:no-watch --runInBand --silent` command was run: 189 of 202 suites passed. The remaining 13 suites contain unrelated failures already present on `dev`, including the same 11 launch/approval failures in the untouched challenge form suite.
