### PR TITLE
PM-5557: Include project billing accounts in filter search

### DIFF
--- a/src/apps/work/src/lib/components/ProjectsFilter/ProjectsFilter.spec.tsx
+++ b/src/apps/work/src/lib/components/ProjectsFilter/ProjectsFilter.spec.tsx
@@ -1,0 +1,118 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import {
+    act,
+    render,
+} from '@testing-library/react'
+
+import {
+    fetchBillingAccountById,
+    searchBillingAccounts,
+} from '../../services'
+
+import { ProjectsFilter } from './ProjectsFilter'
+
+let latestAsyncSelectProps: Record<string, unknown> | undefined
+
+const searchBillingAccountsMock = searchBillingAccounts as jest.Mock
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        ADMIN: {},
+        API: {
+            V5: 'https://example.com/v5',
+            V6: 'https://example.com/v6',
+        },
+        TC_DOMAIN: 'example.com',
+    },
+}), {
+    virtual: true,
+})
+
+jest.mock('react-select/async', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+        latestAsyncSelectProps = props
+
+        return false
+    },
+}))
+
+jest.mock('react-select', () => ({
+    __esModule: true,
+    default: () => false,
+}))
+
+jest.mock('~/libs/ui', () => ({
+    Button: () => false,
+    IconOutline: {
+        SearchIcon: () => false,
+    },
+    InputCheckbox: () => false,
+}), {
+    virtual: true,
+})
+
+jest.mock('../../services', () => ({
+    fetchBillingAccountById: jest.fn(),
+    searchBillingAccounts: jest.fn(),
+}))
+
+describe('ProjectsFilter', () => {
+    beforeEach(() => {
+        latestAsyncSelectProps = undefined
+        jest.clearAllMocks()
+        searchBillingAccountsMock.mockResolvedValue([])
+    })
+
+    it('includes matching billing accounts from visible project rows for project managers', async () => {
+        render(
+            <ProjectsFilter
+                filters={{}}
+                isManager
+                onFiltersChange={jest.fn()}
+                projects={[
+                    {
+                        billingAccountId: 80001012,
+                        billingAccountName: 'Platform Dev - One',
+                        id: 'project-1',
+                        name: 'Visible Platform project',
+                        status: 'active',
+                    },
+                    {
+                        billingAccountId: 80001063,
+                        billingAccountName: 'BA For Marios',
+                        id: 'project-2',
+                        name: 'Other project',
+                        status: 'active',
+                    },
+                ]}
+            />,
+        )
+
+        const loadOptions = latestAsyncSelectProps?.loadOptions as (
+            (value: string) => Promise<unknown>
+        )
+        let options: unknown
+
+        await act(async () => {
+            options = await loadOptions('pla')
+        })
+
+        expect(searchBillingAccountsMock)
+            .toHaveBeenCalledWith({
+                name: 'pla',
+                page: 1,
+                perPage: 20,
+            })
+        expect(options)
+            .toEqual([
+                {
+                    label: 'Platform Dev - One / 80001012',
+                    value: '80001012',
+                },
+            ])
+        expect(fetchBillingAccountById)
+            .not
+            .toHaveBeenCalled()
+    })
+})

--- a/src/apps/work/src/lib/components/ProjectsFilter/ProjectsFilter.tsx
+++ b/src/apps/work/src/lib/components/ProjectsFilter/ProjectsFilter.tsx
@@ -247,13 +247,23 @@ export const ProjectsFilter: FC<ProjectsFilterProps> = (props: ProjectsFilterPro
                 return []
             }
 
+            const normalizedSearchValue = normalizedInputValue.toLowerCase()
+            const matchingProjectOptions = projectBillingAccountOptions.filter(
+                option => option.label
+                    .toLowerCase()
+                    .includes(normalizedSearchValue),
+            )
+
             try {
                 const billingAccounts = await searchBillingAccounts({
                     name: normalizedInputValue,
                     page: 1,
                     perPage: 20,
                 })
-                const options = billingAccounts.map(account => toBillingAccountOption(account))
+                const options = mergeOptions(
+                    matchingProjectOptions,
+                    billingAccounts.map(account => toBillingAccountOption(account)),
+                )
 
                 setBillingAccountOptionCache(previousOptions => mergeOptions(previousOptions, options))
 
@@ -265,10 +275,10 @@ export const ProjectsFilter: FC<ProjectsFilterProps> = (props: ProjectsFilterPro
 
                 setBillingAccountSearchError(errorMessage)
 
-                return []
+                return matchingProjectOptions
             }
         },
-        [],
+        [projectBillingAccountOptions],
     )
 
     const debouncedLoadBillingAccountOptions = useMemo(


### PR DESCRIPTION
What was broken

Project Managers could see projects with billing accounts, but searching for those accounts in the Projects filter returned no options.

Root cause (if identifiable)

The async filter returned only Billing Accounts API matches. Project Managers can see project-assigned accounts that are intentionally absent from their direct billing-account grants, and the loader ignored options already derived from visible projects.

What was changed

Merged case-insensitive matches from visible project billing accounts with remote search results. Local project matches remain available if the remote billing-account search fails.

Any added/updated tests

Added a ProjectsFilter regression test confirming a Project Manager can find Platform Dev - One from a visible project when the API returns no matching accounts.

Validation:

- Focused PM-5557 regression test passes.
- `yarn lint` passes.
- `yarn run build` passes with existing repository warnings.
- Full `yarn test:no-watch` retains 13 failing suites and 36 failing tests that reproduce unchanged on untouched `origin/dev`; this branch adds one passing suite and one passing test.
