### PR TITLE
PM-5609: Show infected status for failed virus scans

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentAiApproval.spec.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentAiApproval.spec.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import type { PropsWithChildren } from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { ChallengeDetailContext } from '../../contexts'
+import type {
+    BackendSubmission,
+    ChallengeDetailContextModel,
+    ChallengeInfo,
+} from '../../models'
+
+import { TabContentAiApproval } from './TabContentAiApproval'
+
+jest.mock('../../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({}),
+    }
+})
+
+jest.mock('react-router-dom', () => ({
+    useNavigate: () => jest.fn(),
+}))
+
+jest.mock('~/apps/admin/src/lib', () => ({
+    TableLoading: () => <div>Loading</div>,
+}), { virtual: true })
+
+jest.mock('~/libs/ui', () => ({
+    Table: (props: {
+        columns: Array<{
+            columnId?: string
+            renderer?: (row: { submission: BackendSubmission }) => JSX.Element
+        }>
+        data: Array<{ submission: BackendSubmission }>
+    }) => {
+        const statusColumn = props.columns.find(column => column.columnId === 'status')
+
+        return (
+            <div>
+                {props.data.map(row => (
+                    <div key={row.submission.id}>
+                        {statusColumn?.renderer?.(row)}
+                    </div>
+                ))}
+            </div>
+        )
+    },
+}), { virtual: true })
+
+jest.mock('../../hooks', () => ({
+    useRole: () => ({
+        isPrivilegedRole: false,
+    }),
+}))
+
+jest.mock('../../hooks/useRolePermissions', () => ({
+    useRolePermissions: () => ({
+        ownedMemberIds: new Set<string>(),
+    }),
+}))
+
+jest.mock('../../hooks/useSubmissionDownloadAccess', () => ({
+    useSubmissionDownloadAccess: () => ({
+        getRestrictionMessageForMember: () => undefined,
+        isSubmissionDownloadRestricted: false,
+        isSubmissionDownloadRestrictedForMember: () => false,
+        restrictionMessage: '',
+        shouldRestrictSubmitterToOwnSubmission: false,
+    }),
+}))
+
+jest.mock('../CollapsibleAiReviewsRow', () => ({
+    CollapsibleAiReviewsRow: () => <div>AI reviews</div>,
+}))
+
+jest.mock('../common', () => ({
+    renderSubmissionIdCell: () => <div>Submission</div>,
+}))
+
+jest.mock('../TableNoRecord', () => ({
+    TableNoRecord: (props: { message: string }) => <div>{props.message}</div>,
+}))
+
+jest.mock('../TableWrapper', () => ({
+    TableWrapper: (props: PropsWithChildren<{ className?: string }>) => (
+        <div className={props.className}>{props.children}</div>
+    ),
+}))
+
+const challengeInfo = {
+    phases: [],
+    reviewers: [],
+} as unknown as ChallengeInfo
+
+const challengeContext = {
+    aiReviewDecisionsBySubmissionId: {},
+    challengeInfo,
+} as unknown as ChallengeDetailContextModel
+
+/**
+ * Builds a minimal file-submission fixture for Approval status rendering tests.
+ *
+ * @param id - Unique submission identifier rendered by the table.
+ * @param virusScan - Whether the submission passed its virus scan.
+ * @returns A latest contest submission with the requested virus-scan result.
+ */
+function buildSubmission(id: string, virusScan: boolean): BackendSubmission {
+    return {
+        createdAt: '2026-07-08T02:45:00.000Z',
+        id,
+        isFileSubmission: true,
+        isLatest: true,
+        type: 'CONTEST_SUBMISSION',
+        virusScan,
+    } as BackendSubmission
+}
+
+describe('TabContentAiApproval', () => {
+    it('shows an infected submission status instead of pending', () => {
+        render(
+            <ChallengeDetailContext.Provider value={challengeContext}>
+                <TabContentAiApproval
+                    downloadSubmission={jest.fn()}
+                    isDownloading={{}}
+                    isLoading={false}
+                    submissions={[
+                        buildSubmission('infected-submission', false),
+                        buildSubmission('pending-submission', true),
+                    ]}
+                />
+            </ChallengeDetailContext.Provider>,
+        )
+
+        expect(screen.getByText('Infected'))
+            .toBeTruthy()
+        expect(screen.getByText('Pending'))
+            .toBeTruthy()
+    })
+})

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentAiApproval.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentAiApproval.tsx
@@ -174,11 +174,15 @@ export const TabContentAiApproval: FC<Props> = (props: Props) => {
                 columnId: 'status',
                 label: 'Status',
                 renderer: (row: SubmissionRowData) => {
-                    const status = row.decision?.status ?? 'PENDING'
+                    const status = row.submission.isFileSubmission !== false
+                        && row.submission.virusScan === false
+                        ? 'INFECTED'
+                        : row.decision?.status ?? 'PENDING'
                     const statusMap: Record<string, { label: string; className: string }> = {
                         ERROR: { className: styles.statusError, label: 'Error' },
                         FAILED: { className: styles.statusFailed, label: 'Failed' },
                         HUMAN_OVERRIDE: { className: styles.statusOverride, label: 'Override' },
+                        INFECTED: { className: styles.statusFailed, label: 'Infected' },
                         PASSED: { className: styles.statusPassed, label: 'Passed' },
                         PENDING: { className: styles.statusPending, label: 'Pending' },
                     }


### PR DESCRIPTION
## What was broken

Virus-scan failures appeared as Pending in the AI-only Approval table even though the expanded reviewer details showed the Virus Scan as failed.

## Root cause

Infected submissions do not continue to AI decision creation, and the Approval status renderer defaulted every submission without a decision to Pending.

## What was changed

Failed file-submission virus scans now take precedence over AI decision status and render as Infected using the existing failed-status styling. URL-only submissions remain exempt from virus-scan failure handling.

## Any added/updated tests

Added a focused Approval table regression test covering an infected submission and preserving the normal Pending fallback.

Validation completed:

- `yarn test:no-watch --runTestsByPath src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentAiApproval.spec.tsx` — passed.
- `yarn test:no-watch --testPathPattern=src/apps/review` — passed (35 suites, 134 tests).
- `yarn lint` — passed.
- `yarn run build` — passed with existing warnings.

The repository-wide `yarn test:no-watch` was also run. It retained 13 unrelated failing suites and 36 failing tests that were reproduced unchanged on a clean `origin/dev` worktree; all 35 Review app suites passed.
