### PR TITLE
PM-5471: complete past challenge role filter

### DIFF
--- a/src/apps/review/src/config/index.config.ts
+++ b/src/apps/review/src/config/index.config.ts
@@ -35,11 +35,22 @@ export const REVIEWER_RESOURCE_ROLE_IDS = [
     'f6df7212-b9d6-4193-bfb1-b383586fce63',
 ]
 
+export const COPILOT_RESOURCE_ROLE_ID = 'cfe12b3f-2a24-4639-9d8b-ec86726f76bd'
+export const SUBMITTER_RESOURCE_ROLE_ID = '732339e7-8e30-49d7-9198-cccf9451e221'
+
 export const PAST_CHALLENGE_ROLE_SELECT_OPTIONS: SelectOption[] = [
     ROLE_SELECT_ALL_OPTION,
     {
         label: 'Reviewer',
         value: REVIEWER_RESOURCE_ROLE_IDS.join(','),
+    },
+    {
+        label: 'Copilot',
+        value: COPILOT_RESOURCE_ROLE_ID,
+    },
+    {
+        label: 'Submitter',
+        value: SUBMITTER_RESOURCE_ROLE_ID,
     },
 ]
 

--- a/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.module.scss
+++ b/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.module.scss
@@ -40,7 +40,7 @@
     .searchRow {
         width: 100%;
         display: flex;
-        align-items: flex-end;
+        align-items: flex-start;
         gap: $sp-4;
         flex-wrap: wrap;
     }

--- a/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.spec.tsx
+++ b/src/apps/review/src/pages/past-review-assignments/PastReviewsPage/PastReviewsPage.spec.tsx
@@ -8,8 +8,10 @@ import {
 } from '@testing-library/react'
 
 import {
+    COPILOT_RESOURCE_ROLE_ID,
     PAST_CHALLENGE_ROLE_SELECT_OPTIONS,
     REVIEWER_RESOURCE_ROLE_IDS,
+    SUBMITTER_RESOURCE_ROLE_ID,
 } from '../../../config/index.config'
 import {
     useFetchChallengeTracks,
@@ -156,15 +158,15 @@ describe('PastReviewsPage role filter', () => {
         })
     })
 
-    it('offers one aggregate Reviewer option and loads page one with every reviewer role ID', async () => {
+    it('offers every supported role and loads page one with every reviewer role ID', async () => {
         render(<PastReviewsPage />)
 
         const roleSelect = screen.getByLabelText('Role') as HTMLSelectElement
         expect(Array.from(roleSelect.options)
             .map(option => option.text))
-            .toEqual(['All roles', 'Reviewer'])
+            .toEqual(['All roles', 'Reviewer', 'Copilot', 'Submitter'])
         expect(PAST_CHALLENGE_ROLE_SELECT_OPTIONS)
-            .toHaveLength(2)
+            .toHaveLength(4)
 
         fireEvent.change(roleSelect, {
             target: {
@@ -177,6 +179,27 @@ describe('PastReviewsPage role filter', () => {
                 .toHaveBeenLastCalledWith(expect.objectContaining({
                     page: 1,
                     resourceRoleIds: REVIEWER_RESOURCE_ROLE_IDS,
+                }))
+        })
+    })
+
+    it.each([
+        ['Copilot', COPILOT_RESOURCE_ROLE_ID],
+        ['Submitter', SUBMITTER_RESOURCE_ROLE_ID],
+    ])('loads page one for the %s role', async (_label, resourceRoleId) => {
+        render(<PastReviewsPage />)
+
+        fireEvent.change(screen.getByLabelText('Role'), {
+            target: {
+                value: resourceRoleId,
+            },
+        })
+
+        await waitFor(() => {
+            expect(loadPastReviews)
+                .toHaveBeenLastCalledWith(expect.objectContaining({
+                    page: 1,
+                    resourceRoleIds: [resourceRoleId],
                 }))
         })
     })


### PR DESCRIPTION
## What was broken

The QA follow-up found two remaining issues after #2060: the Role filter was lower than Challenge Name, and its options omitted Copilot and Submitter.

## Root cause

The first filter row used bottom alignment while the shared Challenge Name input reserves space for inline errors, so the shorter Role group was pushed down. The initial role configuration included only the aggregate Reviewer option.

## What was changed

- Added Copilot and Submitter options using their active resource-role IDs.
- Top-aligned the first filter row so the Challenge Name and Role labels and controls are even.
- Retained the existing filter state, request serialization, pagination, clearing, and API implementation from #2060 and topcoder-platform/review-api-v6#306.

## Any added/updated tests

- Updated the past reviews page test to expect All roles, Reviewer, Copilot, and Submitter.
- Added request assertions for the Copilot and Submitter resource-role IDs.
- PM-5471 focused run: 3 suites and 8 tests passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- Full `yarn test:no-watch --runInBand --silent`: all PM-5471 tests passed; the repository retains the same 13 failing suites and 36 failing tests reproduced on clean `origin/dev`.
