### PR TITLE
PM-5778: Show N/A for in-progress scores

### DIFF
--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx
@@ -399,6 +399,87 @@ describe('SubmissionsTable', () => {
             .toBeNull()
     })
 
+    it('renders N/A only for the marathon score whose tests are in progress', () => {
+        render(
+            <SubmissionsTable
+                canDownloadSubmissions
+                challengeId='challenge-123'
+                onDownloadSubmission={jest.fn()}
+                onOpenArtifacts={jest.fn()}
+                onSort={jest.fn()}
+                showMarathonMatchTestProgress
+                sortBy='createdAt'
+                sortOrder='desc'
+                submissions={[
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-1',
+                        id: 'submission-1',
+                        reviewSummation: [
+                            {
+                                aggregateScore: 0,
+                                isProvisional: true,
+                                metadata: {
+                                    testProcess: 'provisional',
+                                    testProgress: 0.02,
+                                    testStatus: 'IN PROGRESS',
+                                },
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-2',
+                        id: 'submission-2',
+                        reviewSummation: [
+                            {
+                                aggregateScore: 0,
+                                isFinal: true,
+                                metadata: {
+                                    testProcess: 'system',
+                                    testProgress: 0.2,
+                                    testStatus: 'IN PROGRESS',
+                                },
+                            },
+                            {
+                                aggregateScore: 31.41,
+                                isProvisional: true,
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                    {
+                        challengeId: 'challenge-123',
+                        createdBy: 'member-3',
+                        id: 'submission-3',
+                        reviewSummation: [
+                            {
+                                aggregateScore: 0,
+                                isProvisional: true,
+                                metadata: {
+                                    testProcess: 'provisional',
+                                    testProgress: 1,
+                                    testStatus: 'SUCCESS',
+                                },
+                            },
+                        ],
+                        type: 'SUBMISSION',
+                    },
+                ]}
+            />,
+        )
+
+        expect(screen.getByRole('link', { name: 'N/A / -' }))
+            .toBeTruthy()
+        expect(screen.getByRole('link', { name: '31.41 / N/A' }))
+            .toBeTruthy()
+        expect(screen.getByRole('link', { name: '0.00 / -' }))
+            .toBeTruthy()
+        expect(screen.queryByRole('link', { name: '0.00 / N/A' }))
+            .toBeNull()
+    })
+
     it('renders example validation process and score for marathon submissions', () => {
         render(
             <SubmissionsTable

--- a/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
+++ b/src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.tsx
@@ -384,8 +384,19 @@ export const SubmissionsTable: FC<SubmissionsTableProps> = (
                         const emptyScoreValue = props.showMarathonMatchTestProgress
                             ? '-'
                             : 'N/A'
-                        const initialScore = formatScore(initialScoreValue, emptyScoreValue)
-                        const finalScore = formatScore(finalScoreValue, emptyScoreValue)
+                        const isInitialScoreInProgress = testProgress?.status === 'IN PROGRESS'
+                            && (
+                                testProgress.process === 'example'
+                                || testProgress.process === 'provisional'
+                            )
+                        const isFinalScoreInProgress = testProgress?.status === 'IN PROGRESS'
+                            && testProgress.process === 'system'
+                        const initialScore = isInitialScoreInProgress
+                            ? 'N/A'
+                            : formatScore(initialScoreValue, emptyScoreValue)
+                        const finalScore = isFinalScoreInProgress
+                            ? 'N/A'
+                            : formatScore(finalScoreValue, emptyScoreValue)
                         const reviewTab = submission.type === 'CHECKPOINT_SUBMISSION'
                             ? 'checkpoint-submission'
                             : 'submission'


### PR DESCRIPTION
## What was broken

The Work submissions table displayed 0.00 for placeholder aggregate scores while the corresponding Marathon Match tests were still running, which made a pending result look final.

## Root cause

The table formatted every finite provisional or system aggregate as a completed score without considering the current Review API test status and process.

## What was changed

The table now displays N/A only on the score side whose example, provisional, or system tests are in progress. Completed scores on the other side and legitimate completed zero scores remain visible.

## Any added/updated tests

Added focused coverage for an in-progress provisional score, an in-progress system score with a completed provisional result, and a successful zero score.

The focused suite passes all 10 tests, and lint and the production build pass. The repository-wide suite retains the same 13 failing suites and 36 failing tests reproduced on untouched origin/dev; this branch adds one passing test and introduces no additional failures.
