### PR TITLE
PM-5725: Enable compilation errors in view mode

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.module.scss
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.module.scss
@@ -83,6 +83,7 @@
     font: inherit;
     font-weight: 600;
     padding: 0;
+    pointer-events: auto;
     text-decoration: underline;
 }
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.spec.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports, unicorn/no-null */
 import '@testing-library/jest-dom'
 import {
+    fireEvent,
     render,
     screen,
     waitFor,
@@ -221,5 +222,54 @@ describe('MarathonMatchScorerSection', () => {
                     }),
                 )
         })
+    })
+
+    it('opens compilation errors from a disabled view-mode fieldset', async () => {
+        const failedTester: MarathonMatchTester = {
+            ...tester,
+            compilationError: 'ExampleScorer.java:1: compilation failed',
+            compilationStatus: 'FAILED',
+        }
+        const savedConfig = buildSavedConfig(CHALLENGE_ID, {
+            compileTimeout: defaults.compileTimeout,
+            name: 'Marathon Match Scorer',
+            reviewScorecardId: defaults.reviewScorecardId,
+            taskDefinitionName: defaults.taskDefinitionName,
+            taskDefinitionVersion: defaults.taskDefinitionVersion,
+            testerId: failedTester.id,
+            testTimeout: defaults.testTimeout,
+        })
+
+        mockFetchMarathonMatchConfig.mockResolvedValue(savedConfig)
+        mockFetchTester.mockResolvedValue(failedTester)
+
+        render(
+            <fieldset disabled>
+                <MarathonMatchScorerSection
+                    challengeId={CHALLENGE_ID}
+                    onScorerConfigChange={jest.fn()}
+                    phases={phases}
+                />
+            </fieldset>,
+        )
+
+        const compilationErrorsControl = await screen.findByRole('button', {
+            name: 'View compilation errors',
+        })
+
+        expect(compilationErrorsControl)
+            .toBeEnabled()
+        fireEvent.click(compilationErrorsControl)
+
+        const compilationErrorsDialog = screen.getByRole('dialog')
+        const compilationErrorsHeading = within(compilationErrorsDialog)
+            .getByRole('heading', {
+                name: 'Compilation Errors',
+            })
+
+        expect(compilationErrorsHeading)
+            .toBeInTheDocument()
+        expect(compilationErrorsDialog)
+            .toHaveTextContent('ExampleScorer.java:1: compilation failed')
     })
 })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.tsx
@@ -1,6 +1,7 @@
 import {
     ChangeEvent,
     FC,
+    KeyboardEvent,
     useCallback,
     useEffect,
     useMemo,
@@ -1006,6 +1007,20 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
     }, [])
 
     /**
+     * Opens compilation diagnostics when the link-styled control is activated from the keyboard.
+     * @param event Keyboard event from the compilation errors control.
+     * @returns void
+     */
+    const handleCompilationErrorsKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>): void => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+            return
+        }
+
+        event.preventDefault()
+        handleOpenCompilationErrorsModal()
+    }, [handleOpenCompilationErrorsModal])
+
+    /**
      * Closes the failed scorer compilation diagnostics modal.
      * @returns void
      */
@@ -1793,13 +1808,16 @@ export const MarathonMatchScorerSection: FC<MarathonMatchScorerSectionProps> = (
                     <div className={styles.error}>
                         <div className={styles.errorActionRow}>
                             <strong>Scorer compilation failed.</strong>
-                            <button
+                            <span
+                                aria-haspopup='dialog'
                                 className={styles.linkButton}
                                 onClick={handleOpenCompilationErrorsModal}
-                                type='button'
+                                onKeyDown={handleCompilationErrorsKeyDown}
+                                role='button'
+                                tabIndex={0}
                             >
                                 View compilation errors
-                            </button>
+                            </span>
                         </div>
                     </div>
                 )


### PR DESCRIPTION
## What was broken

The "View compilation errors" action for a failed Marathon Match scorer could not be activated when Work Manager displayed the challenge in view mode. It worked only in edit mode.

## Root cause

View mode places the scorer inside a disabled fieldset and applies `pointer-events: none` to the form content. The diagnostic action was a native form button, so it was disabled together with the editing controls.

## What was changed

Kept the action visually link-styled while making it an enabled, keyboard-accessible button-role control. Pointer events are restored only for this diagnostic action, so scorer editing controls remain disabled in view mode.

## Any added/updated tests

Added a `MarathonMatchScorerSection` regression test that renders a failed scorer inside a disabled view-mode fieldset, verifies the diagnostic action remains enabled, and confirms the modal displays the compilation output.

Validation:

- `yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/components/MarathonMatchScorerSection/MarathonMatchScorerSection.spec.tsx` — passed (2 tests).
- `yarn lint` — passed.
- `yarn run build` — passed with existing repository warnings.
- `yarn test:no-watch --silent` — the branch passed 194 of 207 suites and 920 of 956 tests. Untouched `origin/dev` passed 194 of 207 suites and 919 of 955 tests with the same 13 failing suites and 36 failing tests, confirming the remaining failures are pre-existing and unrelated to this change.
