### PR TITLE
PM-5722: Show final Marathon Match winner scores

### DIFF
--- a/src/apps/review/README.md
+++ b/src/apps/review/README.md
@@ -28,8 +28,9 @@ sudo yarn start
 - Each final-placement winner is matched by normalized member ID and placement. The endpoint's
   `submissionId` is authoritative for display and download; another submission from the same
   member is never substituted based on score or recency.
-- Local submission and review data may enrich the submitted date and reviews only when the local
-  submission ID exactly matches the canonical ID. Missing or malformed canonical results are
-  omitted safely.
+- Local submission data may supply a final/system aggregate score, submitted date, and reviews only
+  when the local submission ID exactly matches the canonical ID. This preserves Marathon Match
+  system scores without accepting provisional or sibling-submission scores. Missing or malformed
+  canonical results are omitted safely.
 - Canonical `PLACEMENT` winner types are shown. Untyped and contest-submission winner types remain
   supported for legacy challenge records, while checkpoint winner types are excluded.

--- a/src/apps/review/src/lib/hooks/useFetchChallengeResults.spec.ts
+++ b/src/apps/review/src/lib/hooks/useFetchChallengeResults.spec.ts
@@ -163,6 +163,37 @@ describe('getSubmissionFinalScoreCandidate', () => {
 })
 
 describe('buildCanonicalChallengeResults', () => {
+    it('uses the exact canonical submission final aggregate score for Marathon Match winners', () => {
+        const finalAggregateScore = 99.50699286094532
+        const results = buildCanonicalChallengeResults({
+            canonicalResults: [buildProjectResult({
+                finalScore: 0,
+                submissionId: 'canonical-submission',
+            })],
+            challengeUuid: 'challenge-id',
+            memberMapping: {},
+            submissions: [
+                buildSubmission({
+                    finalAggregateScore: 100,
+                    id: 'higher-scoring-sibling',
+                }),
+                buildSubmission({
+                    finalAggregateScore,
+                    id: 'canonical-submission',
+                }),
+            ],
+            winners: [buildWinner({ type: 'PLACEMENT' })],
+        })
+
+        expect(results)
+            .toHaveLength(1)
+        expect(results[0])
+            .toMatchObject({
+                finalScore: finalAggregateScore,
+                submissionId: 'canonical-submission',
+            })
+    })
+
     it('uses the exact canonical submission and ignores checkpoint and duplicate winner rows', () => {
         const exactReview = buildReview()
         const siblingReview = buildReview({

--- a/src/apps/review/src/lib/hooks/useFetchChallengeResults.ts
+++ b/src/apps/review/src/lib/hooks/useFetchChallengeResults.ts
@@ -167,10 +167,10 @@ function isFinalPlacementWinner(winner: ChallengeWinner): boolean {
 /**
  * Enriches one canonical Review API result with display data from its exact local submission.
  *
- * The canonical result remains authoritative for submission identity, placement, and scores.
- * Local data may supply reviews and the submitted date only when its submission id exactly
- * matches the canonical id, which prevents a multi-submission winner's sibling submission from
- * replacing the downloadable winner.
+ * The canonical result remains authoritative for submission identity and placement. An exact
+ * matching submission may supply its final/system aggregate score, reviews, and submitted date,
+ * which restores Marathon Match scoring without allowing a sibling submission to replace the
+ * downloadable winner.
  *
  * @param params canonical result, matching challenge winner, submissions, reviews, and members.
  * @returns The display-ready project result, or undefined when the canonical identity is invalid.
@@ -193,6 +193,7 @@ const buildProjectResult = ({
     const exactSubmission = submissions.find(
         submission => normalizeIdentifier(submission.id) === canonicalSubmissionId,
     )
+    const finalAggregateScore = toFiniteNumber(exactSubmission?.finalAggregateScore)
     const fallbackReviews = exactSubmission?.reviews ?? canonicalResult.reviews ?? []
     const orderedReviews = orderReviewsByCreatedDate(fallbackReviews)
 
@@ -206,6 +207,7 @@ const buildProjectResult = ({
     return adjustProjectResult({
         ...canonicalResult,
         challengeId: normalizeIdentifier(canonicalResult.challengeId) ?? challengeUuid,
+        finalScore: finalAggregateScore ?? canonicalResult.finalScore,
         reviews: orderedReviews,
         submissionId: canonicalSubmissionId,
         submittedDate: exactSubmission?.submittedDate ?? canonicalResult.submittedDate,
@@ -294,11 +296,11 @@ export interface useFetchChallengeResultsProps {
 /**
  * Fetches canonical Winners-tab results and enriches them with local display data.
  *
- * The Review API project-result endpoint is authoritative for the winning submission id,
- * placement, and scores. Challenge submissions contribute display-only data for the exact
- * canonical submission. Loading remains active until both request streams settle. Challenge
- * reviews are deliberately not fetched because registered members without submissions may
- * download winners but are not authorized to inspect challenge review data.
+ * The Review API project-result endpoint is authoritative for the winning submission id and
+ * placement. The exact challenge submission may contribute its final/system aggregate score and
+ * display data. Loading remains active until both request streams settle. Challenge reviews are
+ * deliberately not fetched because registered members without submissions may download winners
+ * but are not authorized to inspect challenge review data.
  *
  * @param submissions submissions already available in the challenge detail view.
  * @returns Canonical display-ready project results and their combined loading state.


### PR DESCRIPTION
## What was broken

The Review app Winners tab displayed `0.00` for completed Marathon Match winners even though their final SYSTEM scores were available and displayed correctly on the Review tab.

## Root cause

The Winners flow used the canonical project-result score, which is zero for affected Marathon Match results, and no longer applied the exact winning submission's final SYSTEM review summation. The regression was introduced when canonical project-result identity and scores became authoritative for winner rows.

## What was changed

Canonical winner submission identity and placement remain authoritative. When that exact submission has a finite final/system aggregate score, the Winners row now uses it as the final review score. Provisional aggregates and scores belonging to sibling submissions are not considered. The Review app documentation was updated to describe this behavior.

## Any added/updated tests

Added a regression test covering a zero canonical score, a precise final Marathon Match aggregate score, and a higher-scoring sibling submission that must not be selected.

Validation:

- `yarn test:no-watch src/apps/review`: 38 suites and 142 tests passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing repository warnings.
- `yarn test:no-watch`: 194 suites passed and 13 unrelated suites failed. The identical 13-suite/36-test failure set was reproduced on an untouched `origin/dev` worktree; this branch adds one passing test (920 passed versus 919 on the baseline).
