### PR TITLE
PM-5771: Correct initial scorecard actions

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeLinksForAdmin/ChallengeLinksForAdmin.spec.tsx
+++ b/src/apps/review/src/lib/components/ChallengeLinksForAdmin/ChallengeLinksForAdmin.spec.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen } from '@testing-library/react'
+
+import { ChallengeDetailContext } from '../../contexts'
+import type {
+    ChallengeDetailContextModel,
+    ReviewInfo,
+} from '../../models'
+
+import { ChallengeLinksForAdmin } from './ChallengeLinksForAdmin'
+
+jest.mock('../../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({}),
+    }
+})
+
+jest.mock('../../hooks', () => ({
+    useAppNavigate: () => jest.fn(),
+}))
+
+jest.mock('../../utils', () => ({
+    filterResources: () => [],
+    isReviewPhase: () => true,
+}))
+
+jest.mock('../ConfirmModal', () => ({
+    ConfirmModal: () => <></>,
+}))
+
+jest.mock('../DialogContactManager', () => ({
+    DialogContactManager: () => <></>,
+}))
+
+jest.mock('../DialogPayments', () => ({
+    DialogPayments: () => <></>,
+}))
+
+const challengeContext = {
+    challengeInfo: {
+        currentPhase: 'Review',
+        currentPhaseObject: {
+            id: 'review-phase',
+            isOpen: true,
+            name: 'Review',
+        },
+        status: 'ACTIVE',
+    },
+    myResources: [],
+} as unknown as ChallengeDetailContextModel
+
+const reviewInfo = {
+    committed: false,
+    id: 'review-id',
+    phaseId: 'review-phase',
+} as ReviewInfo
+
+describe('ChallengeLinksForAdmin', () => {
+    it('shows Reopen only after the review has been committed', () => {
+        const rendered = render(
+            <ChallengeDetailContext.Provider value={challengeContext}>
+                <ChallengeLinksForAdmin
+                    isSavingReview={false}
+                    reviewInfo={reviewInfo}
+                    saveReviewInfo={jest.fn()}
+                />
+            </ChallengeDetailContext.Provider>,
+        )
+
+        expect(screen.queryByRole('button', { name: 'Reopen' }))
+            .toBeNull()
+
+        rendered.rerender(
+            <ChallengeDetailContext.Provider value={challengeContext}>
+                <ChallengeLinksForAdmin
+                    isSavingReview={false}
+                    reviewInfo={{
+                        ...reviewInfo,
+                        committed: true,
+                    }}
+                    saveReviewInfo={jest.fn()}
+                />
+            </ChallengeDetailContext.Provider>,
+        )
+
+        expect(screen.getByRole('button', { name: 'Reopen' }))
+            .toBeTruthy()
+    })
+})

--- a/src/apps/review/src/lib/components/ChallengeLinksForAdmin/ChallengeLinksForAdmin.tsx
+++ b/src/apps/review/src/lib/components/ChallengeLinksForAdmin/ChallengeLinksForAdmin.tsx
@@ -67,7 +67,7 @@ export const ChallengeLinksForAdmin: FC<Props> = (props: Props) => {
     )
 
     const canShowReopenButton = useMemo(() => {
-        if (!props.reviewInfo?.id) {
+        if (!props.reviewInfo?.id || !props.reviewInfo.committed) {
             return false
         }
 
@@ -105,6 +105,7 @@ export const ChallengeLinksForAdmin: FC<Props> = (props: Props) => {
         challengeInfo?.currentPhaseObject?.id,
         challengeInfo?.currentPhaseObject?.isOpen,
         challengeInfo?.status,
+        props.reviewInfo?.committed,
         props.reviewInfo?.id,
         props.reviewInfo?.phaseId,
     ])

--- a/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.tsx
+++ b/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.tsx
@@ -176,7 +176,7 @@ export const TableCheckpointSubmissions: FC<Props> = (props: Props) => {
         setIsReopening(true)
 
         try {
-            await updateReview(reviewId, { committed: false, status: 'PENDING' })
+            await updateReview(reviewId, { committed: false, status: 'IN_PROGRESS' })
             toast.success('Scorecard reopened.')
             closeReopenDialog()
             await refreshChallengeReviewData(challengeId)

--- a/src/apps/review/src/lib/components/TableReview/TableReview.tsx
+++ b/src/apps/review/src/lib/components/TableReview/TableReview.tsx
@@ -446,7 +446,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
         try {
             await updateReview(reviewId, {
                 committed: false,
-                status: 'PENDING',
+                status: 'IN_PROGRESS',
             })
             toast.success('Scorecard reopened.')
             closeReopenDialog()

--- a/src/apps/review/src/lib/components/TableSubmissionScreening/TableSubmissionScreening.tsx
+++ b/src/apps/review/src/lib/components/TableSubmissionScreening/TableSubmissionScreening.tsx
@@ -1091,7 +1091,7 @@ export const TableSubmissionScreening: FC<Props> = (props: Props) => {
         setIsReopening(true)
 
         try {
-            await updateReview(reviewId, { committed: false, status: 'PENDING' })
+            await updateReview(reviewId, { committed: false, status: 'IN_PROGRESS' })
             toast.success('Scorecard reopened.')
             closeReopenDialog()
             await refreshChallengeReviewData(challengeId)

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.spec.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.spec.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen } from '@testing-library/react'
+
+import type { ReviewInfo } from '~/apps/review/src/lib/models'
+
+import { ReviewScorecardHeader } from './ReviewScorecardHeader'
+
+jest.mock('~/apps/review/src/lib', () => ({
+    useChallengeDetailsContext: () => ({
+        resources: [],
+    }),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/assets/icons', () => ({
+    IconDeepseekAi: () => <></>,
+    IconPhaseReview: () => <></>,
+    IconPremium: () => <></>,
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/components/ProgressBar', () => ({
+    ProgressBar: () => <></>,
+}), { virtual: true })
+
+describe('ReviewScorecardHeader', () => {
+    it('distinguishes a pending first fill from an in-progress reopened review', () => {
+        const rendered = render(
+            <ReviewScorecardHeader
+                reviewInfo={{
+                    status: 'PENDING',
+                } as ReviewInfo}
+            />,
+        )
+
+        expect(screen.getByRole('heading', { name: 'Fill Scorecard' }))
+            .toBeTruthy()
+
+        rendered.rerender(
+            <ReviewScorecardHeader
+                reviewInfo={{
+                    status: 'IN_PROGRESS',
+                } as ReviewInfo}
+            />,
+        )
+
+        expect(screen.getByRole('heading', { name: 'Edit Review Scorecard' }))
+            .toBeTruthy()
+    })
+})

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.tsx
@@ -32,6 +32,10 @@ export const ReviewScorecardHeader: FC<Props> = (props: Props) => {
     const reviewerColor = reviewer?.handleColor
     const llmModelName = props.workflow?.llm?.name || 'N/A'
     const minimumPassingScore = props.scorecardInfo?.minimumPassingScore ?? 0
+    const isPendingReview = (props.reviewInfo?.status ?? '')
+        .toString()
+        .trim()
+        .toUpperCase() === 'PENDING'
 
     return (
         <div className={styles.wrap}>
@@ -43,7 +47,9 @@ export const ReviewScorecardHeader: FC<Props> = (props: Props) => {
                         </div>
                     </div>
                     <div className={styles.details}>
-                        <h2 className={styles.title}>Edit Review Scorecard</h2>
+                        <h2 className={styles.title}>
+                            {isPendingReview ? 'Fill Scorecard' : 'Edit Review Scorecard'}
+                        </h2>
                         <div className={styles.infoSection}>
                             {reviewerHandle && (
                                 <div className={styles.infoRow}>


### PR DESCRIPTION
What was broken

Pending review scorecards showed a Reopen button before their first commit and labeled the initial task as Edit Review Scorecard.

Root cause

Reopen visibility only required a persisted review ID, while the header title did not account for the review lifecycle status. Table reopen actions also returned reviews to PENDING, making reopened work indistinguishable from a first fill.

What was changed

Require a committed review before showing Reopen, label PENDING reviews as Fill Scorecard, and normalize all scorecard reopen actions to IN_PROGRESS so reopened work continues to use Edit Review Scorecard.

Any added/updated tests

Added component tests for committed-only Reopen visibility and the PENDING versus IN_PROGRESS scorecard titles.

- `yarn test:no-watch --runInBand src/apps/review/src`: passed, 40 suites and 143 tests.
- `yarn lint`: passed.
- `yarn run build`: passed with existing repository warnings.
- `yarn test:no-watch --runInBand`: completed with 196 suites passing and 13 unrelated existing suites failing outside the review app, primarily in Work, Wallet Admin, and Engagements.
