### PR TITLE
PM-5770: Correct submitter scorecard title

### DIFF
--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.spec.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.spec.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen } from '@testing-library/react'
+
+import { ReviewScorecardHeader } from './ReviewScorecardHeader'
+
+jest.mock('~/apps/review/src/lib', () => ({
+    useChallengeDetailsContext: () => ({
+        resources: [],
+    }),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/assets/icons', () => ({
+    IconDeepseekAi: () => <></>,
+    IconPhaseReview: () => <></>,
+    IconPremium: () => <></>,
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/components/ProgressBar', () => ({
+    ProgressBar: () => <></>,
+}), { virtual: true })
+
+describe('ReviewScorecardHeader', () => {
+    it('labels the submitter scorecard as read-only details', () => {
+        render(<ReviewScorecardHeader isSubmitterView />)
+
+        expect(screen.getByRole('heading', { name: 'Scorecard Details' }))
+            .toBeTruthy()
+    })
+
+    it('keeps the edit label for non-submitter views', () => {
+        render(<ReviewScorecardHeader />)
+
+        expect(screen.getByRole('heading', { name: 'Edit Review Scorecard' }))
+            .toBeTruthy()
+    })
+})

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewScorecardHeader.tsx
@@ -9,6 +9,7 @@ import { AiWorkflow } from '~/apps/review/src/lib/hooks'
 import styles from './ReviewScorecardHeader.module.scss'
 
 interface Props {
+    isSubmitterView?: boolean
     reviewInfo?: ReviewInfo
     scorecardInfo?: ScorecardInfo
     workflow?: AiWorkflow
@@ -43,7 +44,9 @@ export const ReviewScorecardHeader: FC<Props> = (props: Props) => {
                         </div>
                     </div>
                     <div className={styles.details}>
-                        <h2 className={styles.title}>Edit Review Scorecard</h2>
+                        <h2 className={styles.title}>
+                            {props.isSubmitterView ? 'Scorecard Details' : 'Edit Review Scorecard'}
+                        </h2>
                         <div className={styles.infoSection}>
                             {reviewerHandle && (
                                 <div className={styles.infoRow}>

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
@@ -18,7 +18,7 @@ import { ChallengeLinks, ConfirmModal, useChallengeDetailsContext } from '~/apps
 import { useIsEditReview, useIsEditReviewProps } from '~/apps/review/src/lib/hooks/useIsEditReview'
 import { rootRoute } from '~/apps/review/src/config/routes.config'
 
-import { ADMIN, COPILOT, MANAGER } from '../../../../config/index.config'
+import { ADMIN, COPILOT, MANAGER, SUBMITTER } from '../../../../config/index.config'
 import { useReviewsContext } from '../../ReviewsContext'
 
 import { ReviewScorecardHeader } from './ReviewScorecardHeader'
@@ -253,6 +253,7 @@ const ReviewViewer: FC = () => {
                 {!isSubmitterPhaseLocked && (
                     <>
                         <ReviewScorecardHeader
+                            isSubmitterView={actionChallengeRole === SUBMITTER}
                             reviewInfo={reviewInfo}
                             scorecardInfo={scorecardInfo}
                             workflow={workflow}


### PR DESCRIPTION
## What was broken

Submitters viewing AI review scorecards saw “Edit Review Scorecard” even though the scorecard is read-only for them.

## Root cause

The review scorecard header used a hard-coded edit label and received no indication that it was rendering the submitter view.

## What was changed

Pass the existing submitter view context to the header and show “Scorecard Details” for submitters while preserving the existing edit label for other roles.

## Any added/updated tests

Added `ReviewScorecardHeader` component coverage for submitter and non-submitter headings.

Validation completed:

- Focused header tests: 2 passed.
- Review app suite: 39 suites and 143 tests passed.
- Lint passed.
- Production build passed with existing repository warnings.
- The full monorepo suite ran, with 195 suites passing and 13 unrelated suites outside the review app still failing on `dev`.
