### PR TITLE
PM-5757: Add view-mode footer actions

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.module.scss
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.module.scss
@@ -83,6 +83,12 @@
     justify-content: flex-end;
 }
 
+.footerActions {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+}
+
 .cancelAction {
     position: relative;
 }

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
@@ -419,7 +419,7 @@ describe('ChallengeEditorPage', () => {
             .toBe('lg')
     })
 
-    it('renders a read-only draft challenge view with cancel, launch, and edit header actions', async () => {
+    it('renders a read-only draft challenge view with header and footer actions', async () => {
         renderPage(
             '/projects/123/challenges/456/view',
             '/projects/:projectId/challenges/:challengeId/view',
@@ -437,22 +437,35 @@ describe('ChallengeEditorPage', () => {
             .toBe('false')
         expect(screen.getByRole('heading', { name: 'View Edit test' }))
             .toBeTruthy()
-        expect(screen.getByRole('button', { name: 'Cancel' }))
+        const headerActions = within(screen.getByTestId('right-header'))
+        const footerActions = within(screen.getByRole('group', {
+            name: 'Challenge footer actions',
+        }))
+
+        expect(headerActions.getByRole('button', { name: 'Cancel' }))
             .toBeTruthy()
-        expect(screen.getByRole('button', { name: 'Launch' }))
+        expect(headerActions.getByRole('button', { name: 'Launch' }))
             .toBeTruthy()
-        expect(screen.getByRole('button', { name: 'Edit' }))
+        expect(headerActions.getByRole('button', { name: 'Edit' }))
+            .toBeTruthy()
+        expect(footerActions.getByRole('button', { name: 'Cancel' }))
+            .toBeTruthy()
+        expect(footerActions.getByRole('button', { name: 'Launch' }))
+            .toBeTruthy()
+        expect(footerActions.getByRole('button', { name: 'Edit' }))
             .toBeTruthy()
         expect(
-            screen.getByRole('button', { name: 'Edit' })
+            footerActions.getByRole('button', { name: 'Edit' })
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Edit' })
+            footerActions.getByRole('button', { name: 'Edit' })
                 .getAttribute('data-size'),
         )
             .toBe('lg')
+        expect(footerActions.queryByRole('link'))
+            .toBeNull()
     })
 
     it('disables launch when challenge budget is not approved', async () => {
@@ -482,7 +495,10 @@ describe('ChallengeEditorPage', () => {
                 .toBeTruthy()
         })
 
-        expect((screen.getByRole('button', { name: 'Launch' }) as HTMLButtonElement).disabled)
+        expect(screen.getAllByRole('button', { name: 'Launch' }))
+            .toHaveLength(2)
+        expect(screen.getAllByRole('button', { name: 'Launch' })
+            .every(button => (button as HTMLButtonElement).disabled))
             .toBe(true)
     })
 
@@ -513,8 +529,11 @@ describe('ChallengeEditorPage', () => {
                 .toBeTruthy()
         })
 
-        expect((screen.getByRole('button', { name: 'Launch' }) as HTMLButtonElement).disabled)
-            .toBe(false)
+        expect(screen.getAllByRole('button', { name: 'Launch' }))
+            .toHaveLength(2)
+        expect(screen.getAllByRole('button', { name: 'Launch' })
+            .every(button => !(button as HTMLButtonElement).disabled))
+            .toBe(true)
     })
 
     it('enables launch immediately after approving the budget from the form', async () => {
@@ -546,13 +565,15 @@ describe('ChallengeEditorPage', () => {
                 .toBeTruthy()
         })
 
-        expect((screen.getByRole('button', { name: 'Launch' }) as HTMLButtonElement).disabled)
+        expect(screen.getAllByRole('button', { name: 'Launch' })
+            .every(button => (button as HTMLButtonElement).disabled))
             .toBe(true)
 
         await user.click(screen.getByRole('button', { name: 'Mock approve budget' }))
 
-        expect((screen.getByRole('button', { name: 'Launch' }) as HTMLButtonElement).disabled)
-            .toBe(false)
+        expect(screen.getAllByRole('button', { name: 'Launch' })
+            .every(button => !(button as HTMLButtonElement).disabled))
+            .toBe(true)
     })
 
     it('allows project-scoped challenge views when the user has challenge resource read access', async () => {
@@ -651,8 +672,8 @@ describe('ChallengeEditorPage', () => {
                     .toBeTruthy()
             })
 
-            expect(screen.getByRole('button', { name: 'Edit' }))
-                .toBeTruthy()
+            expect(screen.getAllByRole('button', { name: 'Edit' }))
+                .toHaveLength(2)
         },
     )
 
@@ -742,8 +763,8 @@ describe('ChallengeEditorPage', () => {
                 .getAttribute('data-edit-mode'),
         )
             .toBe('false')
-        expect(screen.getByRole('button', { name: 'Edit' }))
-            .toBeTruthy()
+        expect(screen.getAllByRole('button', { name: 'Edit' }))
+            .toHaveLength(2)
     })
 
     it('does not render a launch action for non-draft challenges in read-only view mode', async () => {
@@ -774,8 +795,8 @@ describe('ChallengeEditorPage', () => {
 
         expect(screen.queryByRole('button', { name: 'Launch' }))
             .toBeNull()
-        expect(screen.getByRole('button', { name: 'Edit' }))
-            .toBeTruthy()
+        expect(screen.getAllByRole('button', { name: 'Edit' }))
+            .toHaveLength(2)
     })
 
     it('shows mark complete in read-only view mode for active task challenges', async () => {
@@ -824,10 +845,10 @@ describe('ChallengeEditorPage', () => {
                     },
                 }),
             )
-        expect(screen.getByRole('button', { name: 'Mark Complete' }))
-            .toBeTruthy()
-        expect(screen.getByRole('button', { name: 'Edit' }))
-            .toBeTruthy()
+        expect(screen.getAllByRole('button', { name: 'Mark Complete' }))
+            .toHaveLength(2)
+        expect(screen.getAllByRole('button', { name: 'Edit' }))
+            .toHaveLength(2)
     })
 
     it('hides the read-only edit action for completed challenges', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
@@ -1448,7 +1448,7 @@ export const ChallengeEditorPage: FC = () => {
         && !!editChallengePath
         && (!baseProjectAccessState.isDenied || challengeResourceAccess.canWrite)
         && !isChallengeCompletedOrCancelled(effectiveChallengeStatus)
-    const rightHeader = renderHeaderAction({
+    const challengeActionParams: RenderHeaderActionParams = {
         canCancelChallenge: canRenderChallengeDetails && canCancelChallenge,
         canCompleteTask: canRenderChallengeDetails && canCompleteTask,
         canDeleteChallenge: canRenderChallengeDetails && canDeleteChallenge,
@@ -1461,7 +1461,6 @@ export const ChallengeEditorPage: FC = () => {
             ? persistedChallengeId
             : undefined,
         challengeName: launchChallengeName,
-        challengeQuickLinks,
         isDeleting,
         isLaunchDisabled,
         isLaunching,
@@ -1470,7 +1469,14 @@ export const ChallengeEditorPage: FC = () => {
         onDeleteOpen: handleDeleteOpen,
         onEditOpen: handleEditOpen,
         onLaunchOpen: handleLaunchOpen,
+    }
+    const rightHeader = renderHeaderAction({
+        ...challengeActionParams,
+        challengeQuickLinks,
     })
+    const footerActions = isViewMode
+        ? renderHeaderAction(challengeActionParams)
+        : undefined
     const deleteModal = renderDeleteModal({
         canDeleteChallenge: canRenderChallengeDetails && canDeleteChallenge,
         challengeName: deleteChallengeName,
@@ -1532,6 +1538,17 @@ export const ChallengeEditorPage: FC = () => {
                         onSubmissionsTabClick={handleSubmissionsTabClick}
                         projectId={projectId}
                     />
+                    {footerActions
+                        ? (
+                            <div
+                                aria-label='Challenge footer actions'
+                                className={styles.footerActions}
+                                role='group'
+                            >
+                                {footerActions}
+                            </div>
+                        )
+                        : undefined}
                 </div>
             </PageWrapper>
             {launchModal}

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -122,6 +122,7 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 ## Header Actions
 
 - `Launch` is shown on the details tab for `DRAFT` challenges in the header for both view and edit routes, and again in the footer beside `Save Challenge` while editing.
+- Read-only view routes repeat the available `Edit`, `Launch`, `Cancel`, and `Mark Complete` actions at the bottom of the page. Challenge quick links remain in the header only.
 - The work app blocks launch attempts when the parent project billing account is inactive, expired, or has insufficient remaining funds, matching the legacy work-manager launch restriction.
 - Task challenges cannot be launched until `Assigned Member` is set, which ensures the task is assigned before it becomes publicly visible.
 - After the challenge PATCH persists a `NEW` to `DRAFT` transition, the editor updates the status


### PR DESCRIPTION
## What was broken

Read-only challenge views exposed their available actions only in the page header, leaving no action controls at the bottom of long challenge pages.

## Root cause

The challenge form footer is intentionally limited to edit mode, and the read-only page did not render its header action set anywhere after the page content.

## What was changed

Added a read-only footer action group that reuses the existing status, permission, and handler logic for Edit, Launch, Cancel, and Mark Complete.

Kept Challenge, Review, and Forum quick links in the header only, right-aligned the new footer group, and updated the challenge editor documentation.

## Any added/updated tests

Updated `ChallengeEditorPage.spec.tsx` to verify matching header and footer actions, footer launch state, action visibility, styling, and exclusion of quick links.

Validation:

- Focused `ChallengeEditorPage` suite: 19 tests passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- Full `yarn test:no-watch --runInBand`: 919 tests passed; 36 pre-existing failures remain across 13 unrelated baseline suites.
