### PR TITLE
PM-5756: Improve challenge autosave controls

### DIFF
--- a/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+    formatLastSaved,
     transformChallengeToFormData,
     transformFormDataToChallenge,
 } from './challenge-editor.utils'
@@ -22,6 +23,24 @@ jest.mock('~/config', () => ({
         },
     }),
 }), { virtual: true })
+
+describe('formatLastSaved', () => {
+    it('reports when a challenge has not been saved', () => {
+        expect(formatLastSaved())
+            .toBe('Not saved yet')
+    })
+
+    it('shows the exact localized time immediately after a save', () => {
+        const timestamp = new Date()
+        const localizedTime = timestamp.toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: '2-digit',
+        })
+
+        expect(formatLastSaved(timestamp))
+            .toBe(`Last saved at ${localizedTime}`)
+    })
+})
 
 describe('challenge-editor utils funChallenge mapping', () => {
     it('defaults funChallenge to false in form data', () => {

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.ts
@@ -935,11 +935,6 @@ export function formatLastSaved(timestamp?: Date): string {
         return 'Not saved yet'
     }
 
-    const diffMs = Date.now() - timestamp.getTime()
-    if (diffMs < 5000) {
-        return 'Saved just now'
-    }
-
     return `Last saved at ${timestamp.toLocaleTimeString([], {
         hour: 'numeric',
         minute: '2-digit',

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -54,7 +54,10 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - Autosave keeps the current editor values in place after patch responses so in-flight typing is
   not replaced by challenge-api normalized content.
 - Status values: `idle`, `saving`, `saved`, `error`.
-- Last save time is shown in the footer.
+- The footer keeps Cancel on the left and groups autosave status plus the exact last-save time beside
+  the manual Save action.
+- Manual Save reports `Saving...`, then `Saved` for two seconds after a successful save, before
+  becoming available again even when the form is unchanged.
 
 ## Field Components
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.module.scss
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.module.scss
@@ -193,6 +193,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-width: 0;
 }
 
 .statusText {
@@ -232,7 +233,10 @@
 .actions {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: 16px;
+    justify-content: flex-end;
+    min-width: 0;
 }
 
 .cancelLink {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -133,7 +133,11 @@ jest.mock('../../../../lib/utils', () => ({
         && (project?.members || []).some(member => (
             member.userId === userId && member.role === 'manager'
         )),
-    formatLastSaved: () => '',
+    formatLastSaved: (timestamp?: Date) => (
+        timestamp
+            ? 'Last saved at 1:25 PM'
+            : 'Not saved yet'
+    ),
     showErrorToast: jest.fn(),
     showSuccessToast: jest.fn(),
     transformChallengeToFormData: (challenge?: Partial<Challenge>) => ({
@@ -1252,26 +1256,39 @@ describe('ChallengeEditorForm', () => {
             </MemoryRouter>,
         )
 
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+        const saveButton = screen.getByRole('button', { name: 'Save Challenge' })
+        const lastSaved = screen.getByText('Not saved yet')
+        const actionGroup = saveButton.parentElement
+
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            cancelButton
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            cancelButton
                 .getAttribute('data-size'),
         )
             .toBe('lg')
         expect(
-            screen.getByRole('button', { name: 'Save Challenge' })
+            saveButton
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Save Challenge' })
+            saveButton
                 .getAttribute('data-size'),
         )
             .toBe('lg')
+        expect(saveButton)
+            .toBeEnabled()
+        expect(actionGroup)
+            .toContainElement(lastSaved)
+        expect(actionGroup)
+            .not.toContainElement(cancelButton)
+        expect(cancelButton.parentElement)
+            .toBe(actionGroup?.parentElement)
         expect(
             screen.getByRole('button', { name: 'Launch' })
                 .getAttribute('data-primary'),
@@ -1282,6 +1299,65 @@ describe('ChallengeEditorForm', () => {
                 .getAttribute('data-size'),
         )
             .toBe('lg')
+    })
+
+    it('manually saves an unchanged challenge', async () => {
+        const user = userEvent.setup()
+        mockedPatchChallenge.mockResolvedValue(validDraftChallenge)
+
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm challenge={validDraftChallenge} />
+            </MemoryRouter>,
+        )
+
+        const saveButton = screen.getByRole('button', { name: 'Save Challenge' })
+
+        expect(saveButton)
+            .toBeEnabled()
+
+        await user.click(saveButton)
+
+        await waitFor(() => {
+            expect(mockedPatchChallenge)
+                .toHaveBeenCalledWith('12345', expect.objectContaining({
+                    name: validDraftChallenge.name,
+                }))
+        })
+    })
+
+    it('uses the save action for transient autosave feedback before enabling it again', () => {
+        jest.useFakeTimers()
+        mockedUseAutosave.mockReturnValue({
+            lastSaved: new Date('2026-07-29T13:25:00+03:00'),
+            saveStatus: 'saved',
+        })
+
+        try {
+            render(
+                <MemoryRouter>
+                    <ChallengeEditorForm challenge={draftChallenge} />
+                </MemoryRouter>,
+            )
+
+            expect(screen.getByText('Last saved at 1:25 PM'))
+                .toBeInTheDocument()
+            expect(screen.getAllByText('Saved'))
+                .toHaveLength(1)
+            expect(screen.getByRole('button', { name: 'Saved' }))
+                .toBeDisabled()
+
+            act(() => {
+                jest.advanceTimersByTime(2000)
+            })
+
+            expect(screen.queryByRole('button', { name: 'Saved' }))
+                .toBeNull()
+            expect(screen.getByRole('button', { name: 'Save Challenge' }))
+                .toBeEnabled()
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('renders existing challenges as read-only in view mode', () => {
@@ -3996,8 +4072,8 @@ describe('ChallengeEditorForm', () => {
         await user.click(screen.getByRole('button', { name: 'New' }))
 
         await waitFor(() => {
-            expect(screen.getByRole('button', { name: 'Save as Draft' }))
-                .toBeInTheDocument()
+            expect(screen.getByRole('button', { name: 'Saved' }))
+                .toBeDisabled()
         })
         expect(screen.queryByRole('button', { name: 'New' }))
             .toBeNull()
@@ -4050,8 +4126,8 @@ describe('ChallengeEditorForm', () => {
         await waitFor(() => {
             expect(screen.getByText('Specification'))
                 .toBeInTheDocument()
-            expect(screen.getByRole('button', { name: 'Save as Draft' }))
-                .toBeInTheDocument()
+            expect(screen.getByRole('button', { name: 'Saved' }))
+                .toBeDisabled()
             expect(screen.queryByRole('button', { name: 'New' }))
                 .toBeNull()
         })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -284,6 +284,7 @@ interface PersistCreatedChallengeCopilotResult {
 }
 
 const SAVE_VALIDATION_ERROR_MESSAGE = 'Please fix validation errors before saving.'
+const SAVED_BUTTON_STATE_DURATION_MS = 2000
 const DESIGN_WORK_TYPE_REQUIRED_MESSAGE = 'Select a work type'
 const TASK_ASSIGNED_MEMBER_REQUIRED_FOR_LAUNCH_MESSAGE
     = 'Assign a member before launching a task challenge.'
@@ -1859,6 +1860,10 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     const [saveError, setSaveError] = useState<string | undefined>()
     const [saveValidationError, setSaveValidationError] = useState<string | undefined>()
     const [saveStatus, setSaveStatus] = useState<'error' | 'idle' | 'saved' | 'saving'>('idle')
+    const [dismissedSavedAt, setDismissedSavedAt] = useState<Date | undefined>()
+    const isSavedButtonStateVisible = saveStatus === 'saved'
+        && !!lastSaved
+        && dismissedSavedAt !== lastSaved
     const [scorerHasUnsavedChanges, setScorerHasUnsavedChanges] = useState<boolean>(false)
     const [scorerHasError, setScorerHasError] = useState<boolean>(false)
     const [isUpdatingApproval, setIsUpdatingApproval] = useState<boolean>(false)
@@ -3543,6 +3548,21 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
         }
     }, [autosaveResult.lastSaved, autosaveResult.saveStatus])
 
+    useEffect(() => {
+        if (!isSavedButtonStateVisible || !lastSaved) {
+            return undefined
+        }
+
+        const savedAt = lastSaved
+        const timeoutId = window.setTimeout(() => {
+            setDismissedSavedAt(savedAt)
+        }, SAVED_BUTTON_STATE_DURATION_MS)
+
+        return () => {
+            window.clearTimeout(timeoutId)
+        }
+    }, [isSavedButtonStateVisible, lastSaved])
+
     const onSubmit = useCallback(
         async (formData: ChallengeEditorFormData): Promise<void> => {
             const {
@@ -3620,6 +3640,12 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
         () => getSubmitButtonLabel(normalizedChallengeStatus),
         [normalizedChallengeStatus],
     )
+    const isSaveButtonSaving = isSaving || saveStatus === 'saving'
+    const displayedSubmitButtonLabel = isSaveButtonSaving
+        ? 'Saving...'
+        : isSavedButtonStateVisible
+            ? 'Saved'
+            : submitButtonLabel
     const displayedBillingAccountId = useMemo(
         (): string => {
             const billingAccountId = values.billing?.billingAccountId ?? projectBillingAccount?.id
@@ -3757,41 +3783,41 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     const footerSection = !isReadOnly
         ? (
             <div className={styles.footer}>
-                <div className={styles.statusArea}>
-                    {statusText
-                        ? <span className={styles.statusText}>{statusText}</span>
-                        : undefined}
-                    <span className={styles.lastSaved}>{formatLastSaved(lastSaved)}</span>
-                    {saveValidationError
-                        ? <span className={styles.errorText}>{saveValidationError}</span>
-                        : undefined}
-                    {renderSaveError(saveError, linkedSaveErrorTerms)}
-                    {isScorerBlockingChallengeActions
-                        ? (
-                            <span className={styles.warningText}>
-                                The scorer configuration must be saved and valid before the
-                                {' '}
-                                challenge can be saved or launched.
-                            </span>
-                        )
-                        : undefined}
-                </div>
-
+                <Button
+                    label='Cancel'
+                    onClick={handleCancelClick}
+                    secondary
+                    size='lg'
+                    type='button'
+                />
                 <div className={styles.actions}>
-                    <Button
-                        label='Cancel'
-                        onClick={handleCancelClick}
-                        secondary
-                        size='lg'
-                        type='button'
-                    />
+                    <div className={styles.statusArea}>
+                        {saveStatus === 'error'
+                            ? <span className={styles.statusText}>{getStatusText('error')}</span>
+                            : undefined}
+                        <span className={styles.lastSaved}>{formatLastSaved(lastSaved)}</span>
+                        {saveValidationError
+                            ? <span className={styles.errorText}>{saveValidationError}</span>
+                            : undefined}
+                        {renderSaveError(saveError, linkedSaveErrorTerms)}
+                        {isScorerBlockingChallengeActions
+                            ? (
+                                <span className={styles.warningText}>
+                                    The scorer configuration must be saved and valid before the
+                                    {' '}
+                                    challenge can be saved or launched.
+                                </span>
+                            )
+                            : undefined}
+                    </div>
                     <Button
                         disabled={
-                            (!formState.isDirty || isSaving)
+                            isSaveButtonSaving
+                            || isSavedButtonStateVisible
                             || isScorerBlockingChallengeActions
                             || isManualReviewerConfigurationMissing
                         }
-                        label={submitButtonLabel}
+                        label={displayedSubmitButtonLabel}
                         secondary
                         size='lg'
                         type='submit'


### PR DESCRIPTION
## What was broken

Autosave cleared the form's dirty state, which disabled the manual Save Challenge action and made users unsure whether they could explicitly save. Autosave feedback was separated from Save, Cancel was grouped with the right-side actions, and "Saved just now" could remain visible indefinitely.

## Root cause

The Save button treated React Hook Form's dirty flag as an availability requirement, while the relative timestamp depended on a later render that was never scheduled. The footer layout grouped Cancel with Save and Launch instead of grouping save feedback with the save action.

## What was changed

- Keep manual Save available for unchanged challenges while retaining in-flight and validation blockers.
- Use the Save button as the Saving/Saved status, hold Saved for two seconds, then restore the active save action.
- Show the exact localized last-save time immediately.
- Move Cancel left and group wrapping autosave feedback with Save and Launch.
- Update the challenge editor autosave documentation.

## Any added/updated tests

- Added timestamp formatting coverage for unsaved and immediately saved challenges.
- Added footer grouping, unchanged manual save, and transient Saved-state coverage.
- Updated challenge creation assertions for the transient Saved state.
- `yarn lint` passed.
- `yarn run build` passed with existing project warnings.
- Focused PM-5756 tests passed.
- The full `yarn test:no-watch --runInBand --silent` run passed 923 of 959 tests. Its 36 failures match untouched `origin/dev` assertion-for-assertion and are unrelated to this change.
