### PR TITLE
PM-5767: Show submission download preloader

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/ChallengeDetailsContent.spec.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/ChallengeDetailsContent.spec.tsx
@@ -1,0 +1,123 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import type { ComponentProps } from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { ChallengeDetailsContent } from './ChallengeDetailsContent'
+
+const mockUseDownloadSubmission = jest.fn()
+
+jest.mock('~/libs/ui', () => ({
+    LoadingSpinner: (props: { message?: string; overlay?: boolean }) => (
+        <div data-overlay={String(props.overlay)}>
+            {props.message}
+        </div>
+    ),
+}), { virtual: true })
+
+jest.mock('../../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({
+            aiReviewConfig: undefined,
+            challengeInfo: undefined,
+            myResources: [],
+        }),
+    }
+})
+
+jest.mock('../../hooks', () => ({
+    useDownloadSubmission: () => mockUseDownloadSubmission(),
+    useRole: () => ({
+        actionChallengeRole: undefined,
+    }),
+    useSubmissionDownloadAccess: () => ({
+        currentMemberId: undefined,
+    }),
+}))
+
+jest.mock('../../hooks/useFetchChallengeResults', () => ({
+    useFetchChallengeResults: () => ({
+        isLoading: false,
+        projectResults: [],
+    }),
+}))
+
+jest.mock('./TabContentAiApproval', () => () => undefined)
+jest.mock('./TabContentApproval', () => () => undefined)
+jest.mock('./TabContentCheckpoint', () => () => undefined)
+jest.mock('./TabContentIterativeReview', () => () => undefined)
+jest.mock('./TabContentRegistration', () => ({
+    __esModule: true,
+    default: () => <div>Registration content</div>,
+}))
+jest.mock('./TabContentReview', () => () => undefined)
+jest.mock('./TabContentScreening', () => () => undefined)
+jest.mock('./TabContentSubmissions', () => () => undefined)
+jest.mock('./TabContentWinners', () => () => undefined)
+jest.mock('../TableNoRecord', () => ({
+    TableNoRecord: (noRecordProps: { message?: string }) => (
+        <div>{noRecordProps.message}</div>
+    ),
+}))
+
+const props: ComponentProps<typeof ChallengeDetailsContent> = {
+    approvalMinimumPassingScore: undefined,
+    approvalReviews: [],
+    checkpoint: [],
+    checkpointReview: [],
+    checkpointReviewMinimumPassingScore: undefined,
+    checkpointScreeningMinimumPassingScore: undefined,
+    isActiveChallenge: true,
+    isLoadingSubmission: false,
+    mappingReviewAppeal: {},
+    postMortemMinimumPassingScore: undefined,
+    postMortemReviews: [],
+    review: [],
+    reviewMinimumPassingScore: undefined,
+    screening: [],
+    screeningMinimumPassingScore: undefined,
+    selectedTab: 'Registration',
+    submissions: [],
+    submitterReviews: [],
+}
+
+describe('ChallengeDetailsContent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUseDownloadSubmission.mockReturnValue({
+            downloadSubmission: jest.fn(),
+            isLoading: {},
+            isLoadingBool: false,
+        })
+    })
+
+    it('shows download-starting feedback only while a submission request is pending', () => {
+        mockUseDownloadSubmission.mockReturnValue({
+            downloadSubmission: jest.fn(),
+            isLoading: {
+                'submission-1': true,
+            },
+            isLoadingBool: true,
+        })
+
+        const renderResult: ReturnType<typeof render>
+            = render(<ChallengeDetailsContent {...props} />)
+
+        const indicator = screen.getByText('Download starting')
+        expect(indicator.dataset.overlay)
+            .toBe('true')
+
+        mockUseDownloadSubmission.mockReturnValue({
+            downloadSubmission: jest.fn(),
+            isLoading: {
+                'submission-1': false,
+            },
+            isLoadingBool: false,
+        })
+        renderResult.rerender(<ChallengeDetailsContent {...props} />)
+
+        expect(screen.queryByText('Download starting'))
+            .toBeNull()
+    })
+})

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/ChallengeDetailsContent.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/ChallengeDetailsContent.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable complexity */
 /**
- * Challenge Details Content.
+ * Renders the selected challenge phase and submission-download feedback.
  */
 import { FC, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { toast } from 'react-toastify'
 
-import { ActionLoading } from '~/apps/admin/src/lib'
+import { LoadingSpinner } from '~/libs/ui'
 
 import { ChallengeDetailContext } from '../../contexts'
 import {
@@ -599,7 +599,9 @@ export const ChallengeDetailsContent: FC<Props> = (props: Props) => {
                 renderSelectedTab()
             )}
 
-            {isDownloadingSubmissionBool && <ActionLoading />}
+            {isDownloadingSubmissionBool && (
+                <LoadingSpinner overlay message='Download starting' />
+            )}
         </>
     )
 }


### PR DESCRIPTION
## What was broken

Submission downloads provided no clear in-view feedback while the browser waited for the file response on slower connections.

## Root cause

The review app tracked pending downloads correctly, but rendered an unlabelled action spinner at the bottom of the phase content where it could be outside the viewport.

## What was changed

Replaced the local action spinner with the shared full-viewport loading overlay and the text “Download starting”. The existing pending state clears the indicator when the browser download begins or the request fails.

## Any added/updated tests

Added `ChallengeDetailsContent.spec.tsx` coverage for showing the overlay while a submission request is pending and removing it after the pending state clears.

- Focused PM-5767 test: passed (1 test).
- Review app suite: passed (39 suites, 142 tests).
- Lint: passed.
- Production build: passed with existing warnings.
- Full monorepo test command: 195 suites and 920 tests passed; 13 suites and 36 tests failed in unrelated existing work, engagements, and wallet-admin coverage. None of those failures imports or references the PM-5767 files.
