### PR TITLE
PM-5773: expose score override controls

### DIFF
--- a/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardQuestion/ReviewResponse/ReviewManagerComment/ReviewManagerComment.spec.tsx
+++ b/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardQuestion/ReviewResponse/ReviewManagerComment/ReviewManagerComment.spec.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render, screen, waitFor } from '@testing-library/react'
+
+import type {
+    ReviewItemInfo,
+    ScorecardQuestion,
+} from '../../../../../../models'
+import type { ScorecardViewerContextValue } from '../../../ScorecardViewer.context'
+
+import ReviewManagerComment from './ReviewManagerComment'
+
+const mockUseScorecardViewerContext = jest.fn()
+
+jest.mock('../../../ScorecardViewer.context', () => ({
+    useScorecardViewerContext: () => mockUseScorecardViewerContext(),
+}))
+
+jest.mock('~/apps/review/src/lib/assets/icons', () => ({
+    IconPhaseReview: () => <span />,
+}), { virtual: true })
+
+jest.mock('../../../../../../utils', () => {
+    const Yup: typeof import('yup') = jest.requireActual('yup')
+
+    return {
+        formManagerCommentSchema: Yup.object({
+            finalScore: Yup.string()
+                .required(),
+            response: Yup.string()
+                .required(),
+        }),
+        getScoreResponseOptions: () => [
+            {
+                label: '9',
+                value: '9',
+            },
+        ],
+    }
+})
+
+jest.mock('../../../../../FieldMarkdownEditor', () => ({
+    FieldMarkdownEditor: () => <textarea aria-label='Manager comment response' />,
+}))
+
+jest.mock('../../../../../MarkdownReview', () => ({
+    MarkdownReview: (props: { value: string }) => <div>{props.value}</div>,
+}))
+
+const reviewItem = {
+    createdAt: '2026-07-29T00:00:00.000Z',
+    id: 'review-item-1',
+    initialAnswer: '9',
+    reviewItemComments: [],
+    scorecardQuestionId: 'question-1',
+} as ReviewItemInfo
+
+const scorecardQuestion = {
+    description: 'Submission Place',
+    guidelines: '',
+    id: 'question-1',
+    requiresUpload: false,
+    scaleMax: 10,
+    scaleMin: 1,
+    sortOrder: 1,
+    type: 'SCALE',
+    weight: 100,
+} as ScorecardQuestion
+
+/**
+ * Builds the manager-edit context used to test score override visibility.
+ *
+ * @param autoOpenManagerComment Whether scorecard edit mode should open the form.
+ * @param isManagerEdit Whether manager editing controls are enabled.
+ * @returns The scorecard viewer context for the requested editing state.
+ * @throws This test helper does not throw.
+ */
+const managerContext = (
+    autoOpenManagerComment: boolean,
+    isManagerEdit = true,
+): ScorecardViewerContextValue => ({
+    addManagerComment: jest.fn(),
+    autoOpenManagerComment,
+    canAddManagerComment: true,
+    isManagerEdit,
+    isSavingManagerComment: false,
+} as unknown as ScorecardViewerContextValue)
+
+describe('ReviewManagerComment score override form', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('opens for scorecard editing but remains collapsed for appeal response mode', async () => {
+        mockUseScorecardViewerContext.mockReturnValue(managerContext(false))
+        const rendered = render(
+            <ReviewManagerComment
+                reviewItem={reviewItem}
+                scorecardQuestion={scorecardQuestion}
+            />,
+        )
+
+        expect(screen.getByRole('button', { name: 'Add a Manager Comment' }))
+            .toBeTruthy()
+        expect(screen.queryByRole('combobox'))
+            .toBeNull()
+
+        mockUseScorecardViewerContext.mockReturnValue(managerContext(true))
+        rendered.rerender(
+            <ReviewManagerComment
+                reviewItem={reviewItem}
+                scorecardQuestion={scorecardQuestion}
+            />,
+        )
+
+        await waitFor(() => {
+            expect(screen.getByRole('combobox'))
+                .toBeTruthy()
+        })
+        expect(screen.getByRole('button', { name: 'Submit Response' }))
+            .toBeTruthy()
+
+        mockUseScorecardViewerContext.mockReturnValue(managerContext(false, false))
+        rendered.rerender(
+            <ReviewManagerComment
+                reviewItem={reviewItem}
+                scorecardQuestion={scorecardQuestion}
+            />,
+        )
+
+        await waitFor(() => {
+            expect(screen.queryByRole('combobox'))
+                .toBeNull()
+        })
+    })
+})

--- a/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardQuestion/ReviewResponse/ReviewManagerComment/ReviewManagerComment.tsx
+++ b/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardQuestion/ReviewResponse/ReviewManagerComment/ReviewManagerComment.tsx
@@ -30,6 +30,7 @@ interface ReviewManagerCommentProps {
 const ReviewManagerComment: FC<ReviewManagerCommentProps> = props => {
     const {
         isManagerEdit,
+        autoOpenManagerComment,
         canAddManagerComment,
         isSavingManagerComment,
         addManagerComment,
@@ -74,6 +75,10 @@ const ReviewManagerComment: FC<ReviewManagerCommentProps> = props => {
             setComment(props.managerComment)
         }
     }, [props.managerComment])
+
+    useEffect(() => {
+        setShowCommentForm(Boolean(autoOpenManagerComment))
+    }, [autoOpenManagerComment])
 
     const handleShowCommentForm = useCallback(() => {
         setShowCommentForm(true)

--- a/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardViewer.context.tsx
+++ b/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardViewer.context.tsx
@@ -26,6 +26,7 @@ export interface ScorecardViewerContextProps {
     reviewInfo?: ReviewInfo
     isEdit?: boolean
     isManagerEdit?: boolean
+    autoOpenManagerComment?: boolean
     actionChallengeRole?: string
     mappingAppeals?: MappingAppeal
     isSavingReview?: boolean
@@ -73,6 +74,7 @@ export type ScorecardViewerContextValue = {
     reviewInfo?: ReviewInfo
     isEdit?: boolean
     isManagerEdit?: boolean
+    autoOpenManagerComment?: boolean
     actionChallengeRole?: string
     mappingAppeals?: MappingAppeal
     isSavingReview?: boolean
@@ -144,6 +146,7 @@ export const ScorecardViewerContextProvider: FC<ScorecardViewerContextProps> = p
         addAppealResponse: props.addAppealResponse,
         addManagerComment: props.addManagerComment,
         aiFeedbackItems: props.aiFeedbackItems,
+        autoOpenManagerComment: props.autoOpenManagerComment,
         canAddManagerComment: props.canAddManagerComment,
         doDeleteAppeal: props.doDeleteAppeal,
         form: reviewFormCtx.form,
@@ -168,6 +171,7 @@ export const ScorecardViewerContextProvider: FC<ScorecardViewerContextProps> = p
         props.reviewInfo,
         props.isEdit,
         props.isManagerEdit,
+        props.autoOpenManagerComment,
         props.actionChallengeRole,
         props.mappingAppeals,
         props.isSavingReview,

--- a/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardViewer.tsx
+++ b/src/apps/review/src/lib/components/Scorecard/ScorecardViewer/ScorecardViewer.tsx
@@ -38,6 +38,7 @@ interface ScorecardViewerProps {
     reviewInfo?: ReviewInfo
     isEdit?: boolean
     isManagerEdit?: boolean
+    autoOpenManagerComment?: boolean
     actionChallengeRole?: string
     mappingAppeals?: MappingAppeal
     isSavingReview?: boolean
@@ -349,6 +350,7 @@ const ScorecardViewer: FC<ScorecardViewerProps> = props => (
         reviewInfo={props.reviewInfo}
         isEdit={props.isEdit}
         isManagerEdit={props.isManagerEdit}
+        autoOpenManagerComment={props.autoOpenManagerComment}
         actionChallengeRole={props.actionChallengeRole}
         mappingAppeals={props.mappingAppeals}
         isSavingReview={props.isSavingReview}

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
@@ -269,6 +269,7 @@ const ReviewViewer: FC = () => {
                             setIsChanged={setIsChanged}
                             isLoading={isLoading}
                             isManagerEdit={isManagerEdit}
+                            autoOpenManagerComment={isManagerEdit && !respondToAppeals}
                             isSavingReview={isSavingReview}
                             isSavingAppeal={isSavingAppeal}
                             isSavingAppealResponse={isSavingAppealResponse}


### PR DESCRIPTION
## What was broken

Copilot managers who clicked Edit Scorecard only saw a collapsed Add a Manager Comment action, so the score selector was not presented when edit mode began.

## Root cause

Manager edit mode revealed the existing score override component but left its combined score and required-comment form collapsed. The same manager mode is also used for appeal responses, so it could not safely be treated as the reviewer bulk-edit form.

## What was changed

Pass a scorecard-edit-specific auto-open flag through the scorecard viewer context and open the existing per-item score/comment form immediately for normal Edit Scorecard actions. Appeal-response mode remains collapsed and continues using the existing review-item PATCH flow.

## Any added/updated tests

Added a ReviewManagerComment regression test covering collapsed appeal mode, automatic score-control display in scorecard edit mode, and closing the form when edit mode ends.

Validation passed for the focused regression test, all review app tests (39 suites and 142 tests), lint, and build. The full monorepo test command still reports 13 unrelated baseline suites with 36 failing tests; an untouched origin/dev worktree reproduces the same suite and test failure counts.
