### PR TITLE
PM-5784: Avoid false Design shortening warnings

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -113,8 +113,9 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - Save create/update/delete: `createChallenge`, `patchChallenge`, `deleteChallenge`.
 - Manual saves for active scheduled challenges refetch the persisted challenge after `patchChallenge`
   before resetting or navigating. Rejected shortening is detected from the submitted and persisted
-  phase lengths, so an API-rejected edit is restored with a partial-save warning while a scheduler
-  timing adjustment that shifts an unchanged phase window does not show a false error.
+  scheduled phase windows, falling back to stored durations when dates are unavailable, so an
+  API-rejected edit is restored with a partial-save warning while scheduler timing and sub-minute
+  duration normalization do not show a false error.
 - Initial create refresh: after `createChallenge`, the form fetches full challenge details with `fetchChallenge` to avoid round-type regressions from sparse create responses and to surface the generated forum link for challenge types that provision a discussion on create.
 - Skills search: `searchSkills`.
 - Tracks fetch: `fetchChallengeTracks`.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -3385,6 +3385,75 @@ describe('ChallengeEditorForm', () => {
             .not.toHaveBeenCalledWith('Challenge saved successfully')
     })
 
+    it('accepts Design phase shortening when the persisted duration rounds up', async () => {
+        const user = userEvent.setup()
+        const activeChallenge = {
+            ...validDraftChallenge,
+            legacy: {
+                reviewType: 'INTERNAL',
+                useSchedulingAPI: true,
+            },
+            phases: [{
+                duration: 11520,
+                isOpen: true,
+                name: 'Registration',
+                phaseId: 'registration-phase-id',
+                scheduledEndDate: '2026-04-19T04:58:51.000Z',
+                scheduledStartDate: '2026-04-11T04:58:41.000Z',
+            }],
+            startDate: '2026-04-11T04:58:41.000Z',
+            status: 'ACTIVE',
+            trackId: 'design-track',
+        } as Challenge
+        const persistedShortenedSchedule = {
+            ...activeChallenge,
+            name: 'Active Design challenge updated',
+            phases: [{
+                ...activeChallenge.phases?.[0],
+                duration: 10081,
+                scheduledEndDate: '2026-04-18T04:58:51.000Z',
+            }],
+        } as Challenge
+
+        mockedUseFetchChallengeTracks.mockReturnValue({
+            isLoading: false,
+            tracks: [{
+                id: 'design-track',
+                name: 'Design',
+                track: 'DESIGN',
+            }],
+        })
+        mockedPatchChallenge.mockResolvedValue(persistedShortenedSchedule)
+        mockedFetchChallenge.mockResolvedValue(persistedShortenedSchedule)
+
+        render(
+            <MemoryRouter initialEntries={['/projects/100578/challenges/12345/edit']}>
+                <LocationDisplay />
+                <ChallengeEditorForm
+                    challenge={activeChallenge}
+                    projectId='100578'
+                />
+            </MemoryRouter>,
+        )
+
+        await user.click(screen.getByTestId('mock-dirty-phase-end'))
+        await user.type(screen.getByLabelText('Challenge Name'), ' updated')
+        await user.click(screen.getByRole('button', { name: 'Update Challenge' }))
+
+        await waitFor(() => {
+            expect(mockedFetchChallenge)
+                .toHaveBeenCalledWith('12345')
+            expect(screen.getByTestId('challenge-schedule-section'))
+                .toHaveAttribute('data-first-phase-end', '2026-04-18T04:58:51.000Z')
+            expect(screen.getByTestId('location-display'))
+                .toHaveTextContent('/projects/100578/challenges/12345/view')
+        })
+        expect(mockedShowErrorToast)
+            .not.toHaveBeenCalledWith('Active phase shortening cannot be saved. Other challenge changes were saved.')
+        expect(mockedShowSuccessToast)
+            .toHaveBeenCalledWith('Challenge saved successfully')
+    })
+
     it('accepts an immediate phase window shifted later with its duration unchanged', async () => {
         const user = userEvent.setup()
         const activeChallenge = {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -1581,7 +1581,9 @@ function getPhaseDateTime(value: Date | string | undefined): number | undefined 
 }
 
 /**
- * Resolves the canonical phase duration used by the schedule form.
+ * Resolves the canonical phase duration in minutes used by the schedule form.
+ * Scheduled dates take precedence so API second precision is rounded consistently
+ * with end-date edits before the stored duration is used as a fallback.
  *
  * @param phase challenge phase containing a duration value.
  * @returns the positive finite duration, or `undefined` when it is unavailable.
@@ -1589,6 +1591,16 @@ function getPhaseDateTime(value: Date | string | undefined): number | undefined 
 function getPhaseDurationValue(
     phase: ChallengePhase | undefined,
 ): number | undefined {
+    const scheduledStartTime = getPhaseDateTime(phase?.scheduledStartDate)
+    const scheduledEndTime = getPhaseDateTime(phase?.scheduledEndDate)
+    if (
+        scheduledStartTime !== undefined
+        && scheduledEndTime !== undefined
+        && scheduledEndTime > scheduledStartTime
+    ) {
+        return Math.round((scheduledEndTime - scheduledStartTime) / 60_000)
+    }
+
     const duration = Number(phase?.duration)
 
     return Number.isFinite(duration) && duration > 0


### PR DESCRIPTION
What was broken

Active Design phase shortening was saved by challenge-api, but Work showed “Active phase shortening cannot be saved” and treated the accepted schedule as rejected.

Root cause (if identifiable)

Post-save verification compared the editor's rounded minute duration with the API duration after second-precision normalization. The same persisted schedule could therefore compare as one minute longer even when its scheduled start and end dates matched the submitted edit.

What was changed

- Derive comparable phase lengths from scheduled start and end dates before falling back to stored durations.
- Preserve genuine rejected-shortening detection and scheduler-shifted immediate phase handling.
- Document the schedule-window verification behavior.

Any added/updated tests

- Added a ChallengeEditorForm regression covering accepted Design shortening with a one-minute normalized-duration difference.
- Passed the new regression plus the existing genuine-rejection and shifted-immediate-window tests.
- `yarn lint` passed.
- `yarn run build` passed with existing repository warnings.
- The full `yarn test:no-watch --runInBand` command was run. It retains unrelated baseline failures: 202 of 215 suites and 953 of 989 tests pass; failures are in existing wallet/review-context module aliases, AI review test mocks, and launch-approval expectations.
