### PR TITLE
PM-5340: Hide Marathon Match scores until system tests finish

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
@@ -94,10 +94,11 @@ const resolveSubmissionReviewScore = (
     submission: SubmissionInfo,
     preferAggregateScore: boolean,
 ): number | undefined => {
-    const aggregateScore = parseScoreValue(submission.aggregateScore)
-    if (preferAggregateScore && aggregateScore !== undefined) {
-        return aggregateScore
+    if (preferAggregateScore) {
+        return parseScoreValue(submission.finalAggregateScore)
     }
+
+    const aggregateScore = parseScoreValue(submission.aggregateScore)
 
     const reviewResultScores = Array.isArray(submission.reviews)
         ? submission.reviews

--- a/src/apps/review/src/lib/components/common/TableColumnRenderers.spec.tsx
+++ b/src/apps/review/src/lib/components/common/TableColumnRenderers.spec.tsx
@@ -38,7 +38,8 @@ jest.mock('~/libs/ui', () => {
 
 const buildMarathonSubmission = (): SubmissionReviewerRow => {
     const submission = {
-        aggregateScore: 88,
+        aggregateScore: 95.86,
+        finalAggregateScore: 88,
         id: 'submission-1',
         memberId: 'member-1',
     }
@@ -65,7 +66,7 @@ const buildMarathonSubmission = (): SubmissionReviewerRow => {
 }
 
 describe('TableColumnRenderers marathon score display', () => {
-    it('renders the aggregate score instead of the scorecard average for Review Score', () => {
+    it('renders the final system aggregate instead of earlier and scorecard scores', () => {
         render(renderReviewScoreCell(buildMarathonSubmission(), {
             canDisplayScores: () => true,
             canViewScorecard: true,
@@ -75,11 +76,13 @@ describe('TableColumnRenderers marathon score display', () => {
 
         expect(screen.getByText('88.00'))
             .toBeTruthy()
+        expect(screen.queryByText('95.86'))
+            .toBeNull()
         expect(screen.queryByText('0.00'))
             .toBeNull()
     })
 
-    it('renders aggregate Score as plain text without a scorecard link', () => {
+    it('renders the final system Score as plain text without a scorecard link', () => {
         const rendered: ReturnType<typeof render> = render(renderScoreCell(
             buildMarathonSubmission(),
             0,
@@ -94,6 +97,35 @@ describe('TableColumnRenderers marathon score display', () => {
         expect(screen.getByText('88.00'))
             .toBeTruthy()
         expect(rendered.container.querySelector('a'))
+            .toBeNull()
+    })
+
+    it('hides Review Score and Score until a final system aggregate is available', () => {
+        const submission = {
+            ...buildMarathonSubmission(),
+            finalAggregateScore: undefined,
+        }
+
+        render(
+            <>
+                {renderReviewScoreCell(submission, {
+                    canDisplayScores: () => true,
+                    canViewScorecard: true,
+                    isAppealsTab: false,
+                    useAggregateScore: true,
+                })}
+                {renderScoreCell(submission, 0, {
+                    canDisplayScores: () => true,
+                    canViewScorecard: true,
+                    isAppealsTab: false,
+                    useAggregateScore: true,
+                })}
+            </>,
+        )
+
+        expect(screen.getAllByText('--'))
+            .toHaveLength(2)
+        expect(screen.queryByText('95.86'))
             .toBeNull()
     })
 })

--- a/src/apps/review/src/lib/components/common/TableColumnRenderers.tsx
+++ b/src/apps/review/src/lib/components/common/TableColumnRenderers.tsx
@@ -213,7 +213,8 @@ export function renderReviewDateCell(submission: SubmissionRow): JSX.Element {
 }
 
 /**
- * Renders the aggregated average score for a submission, honoring visibility rules.
+ * Renders the review score for a submission, using only a terminal final/system
+ * aggregate when Marathon Match aggregate scoring is enabled.
  */
 export function renderReviewScoreCell(
     submission: SubmissionRow,
@@ -236,10 +237,10 @@ export function renderReviewScoreCell(
     }
 
     if (useAggregateScore) {
-        const aggregateScoreDisplay = formatScoreDisplay(submission.aggregateScore)
+        const finalAggregateScoreDisplay = formatScoreDisplay(submission.finalAggregateScore)
 
-        return aggregateScoreDisplay ? (
-            <span>{aggregateScoreDisplay}</span>
+        return finalAggregateScoreDisplay ? (
+            <span>{finalAggregateScoreDisplay}</span>
         ) : (
             <span className={styles.notReviewed}>
                 --
@@ -526,7 +527,8 @@ function createReopenActionButtons(
 }
 
 /**
- * Renders an individual review score, linking to the review detail when allowed.
+ * Renders an individual review score, or a terminal final/system aggregate for
+ * Marathon Match submissions, linking to review detail when allowed.
  */
 export function renderScoreCell(
     submission: SubmissionRow,
@@ -559,12 +561,12 @@ export function renderScoreCell(
     if (useAggregateScore) {
         const isFirstSubmissionRow = !('isFirstReviewerRow' in submission)
             || submission.isFirstReviewerRow !== false
-        const aggregateScoreDisplay = isFirstSubmissionRow
-            ? formatScoreDisplay(submission.aggregateScore)
+        const finalAggregateScoreDisplay = isFirstSubmissionRow
+            ? formatScoreDisplay(submission.finalAggregateScore)
             : undefined
 
-        return aggregateScoreDisplay ? (
-            <span>{aggregateScoreDisplay}</span>
+        return finalAggregateScoreDisplay ? (
+            <span>{finalAggregateScoreDisplay}</span>
         ) : (
             <span className={styles.notReviewed}>
                 --

--- a/src/apps/review/src/lib/components/common/reviewResult.spec.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.spec.ts
@@ -202,7 +202,7 @@ describe('resolveSubmissionReviewResult', () => {
             .toBe('PASS')
     })
 
-    it('prefers the summation aggregate score when requested', () => {
+    it('uses the final system aggregate score when requested', () => {
         const submission = {
             ...buildSubmission([
                 {
@@ -211,7 +211,8 @@ describe('resolveSubmissionReviewResult', () => {
                     status: 'COMPLETED',
                 },
             ], 0),
-            aggregateScore: 88,
+            aggregateScore: 40,
+            finalAggregateScore: 88,
             isPassingReview: true,
         }
 
@@ -222,6 +223,28 @@ describe('resolveSubmissionReviewResult', () => {
 
         expect(result)
             .toBe('PASS')
+    })
+
+    it('defers the Marathon Match result when only an earlier aggregate is available', () => {
+        const submission = {
+            ...buildSubmission([
+                {
+                    finalScore: 95,
+                    resourceId: 'res-1',
+                    status: 'PENDING',
+                },
+            ], 95),
+            aggregateScore: 95,
+            isPassingReview: true,
+        }
+
+        const result = resolveSubmissionReviewResult(submission, {
+            defaultMinimumPassingScore: DEFAULT_PASSING_SCORE,
+            preferAggregateScore: true,
+        })
+
+        expect(result)
+            .toBeUndefined()
     })
 })
 

--- a/src/apps/review/src/lib/components/common/reviewResult.ts
+++ b/src/apps/review/src/lib/components/common/reviewResult.ts
@@ -317,10 +317,27 @@ const resolveAggregateScore = (submission: SubmissionRow): number | undefined =>
 }
 
 /**
+ * Resolves the terminal final/system aggregate score from a submission row.
+ *
+ * @param submission - Submission row that may include a Marathon Match final aggregate score.
+ * @returns Finite final aggregate score, or undefined while final scoring is unavailable.
+ * Used for Marathon Match Review Result decisions so earlier phase scores are not exposed.
+ * @throws This helper does not throw.
+ */
+const resolveFinalAggregateScore = (submission: SubmissionRow): number | undefined => {
+    const finalAggregateScore = submission.finalAggregateScore
+    if (typeof finalAggregateScore === 'number' && Number.isFinite(finalAggregateScore)) {
+        return finalAggregateScore
+    }
+
+    return undefined
+}
+
+/**
  * Resolves the score used for pass/fail decisions.
  *
  * @param submission - Submission row containing review and summation scores.
- * @param preferAggregateScore - True when summation scores should take priority over scorecard scores.
+ * @param preferAggregateScore - True when only a terminal final/system aggregate should be used.
  * @returns Finite score for outcome evaluation, or undefined when no score is available.
  */
 const resolveReviewScore = (
@@ -328,10 +345,7 @@ const resolveReviewScore = (
     preferAggregateScore: boolean,
 ): number | undefined => {
     if (preferAggregateScore) {
-        const aggregateScore = resolveAggregateScore(submission)
-        if (aggregateScore !== undefined) {
-            return aggregateScore
-        }
+        return resolveFinalAggregateScore(submission)
     }
 
     const aggregatedAverage = submission.aggregated?.averageFinalScore
@@ -496,6 +510,9 @@ export function resolveSubmissionReviewResult(
     )
 
     const reviewScore = resolveReviewScore(submission, preferAggregateScore)
+    if (preferAggregateScore && reviewScore === undefined) {
+        return undefined
+    }
 
     const scoreOutcome = resolveScoreOutcome(reviewScore, minimumPassingScore)
 

--- a/src/apps/review/src/lib/components/common/types.ts
+++ b/src/apps/review/src/lib/components/common/types.ts
@@ -84,7 +84,7 @@ export interface ScoreVisibilityConfig {
     canDisplayScores: (submission: SubmissionRow) => boolean
     /** Whether the viewer can navigate to the detailed scorecard for the submission. */
     canViewScorecard: boolean
-    /** True when the table should render the submission aggregate score instead of scorecard links. */
+    /** True when the table should render the Marathon Match final/system aggregate instead of scorecard links. */
     useAggregateScore?: boolean
     /** Tooltip message shown when scorecard access is restricted. */
     viewOwnScorecardTooltip?: string

--- a/src/apps/review/src/lib/models/SubmissionInfo.model.spec.ts
+++ b/src/apps/review/src/lib/models/SubmissionInfo.model.spec.ts
@@ -129,6 +129,60 @@ describe('convertBackendSubmissionToSubmissionInfo', () => {
             .toBeUndefined()
     })
 
+    it('does not expose an in-progress system placeholder or fall back to an earlier score', () => {
+        const result = convertBackendSubmissionToSubmissionInfo(buildBackendSubmission({
+            reviewSummation: [
+                {
+                    aggregateScore: 95.86,
+                    isPassing: true,
+                    metadata: { testType: 'example' },
+                    updatedAt: '2026-06-05T05:10:00.000Z',
+                },
+                {
+                    aggregateScore: 0,
+                    isFinal: true,
+                    isPassing: false,
+                    metadata: {
+                        testProcess: 'system',
+                        testStatus: 'IN PROGRESS',
+                    },
+                    updatedAt: '2026-06-05T05:15:00.000Z',
+                },
+            ],
+        }))
+
+        expect(result.aggregateScore)
+            .toBeUndefined()
+        expect(result.finalAggregateScore)
+            .toBeUndefined()
+        expect(result.isPassingReview)
+            .toBeUndefined()
+    })
+
+    it('keeps a completed zero system score available as a final result', () => {
+        const result = convertBackendSubmissionToSubmissionInfo(buildBackendSubmission({
+            reviewSummation: [
+                {
+                    aggregateScore: 0,
+                    isFinal: true,
+                    isPassing: false,
+                    metadata: {
+                        testProcess: 'system',
+                        testStatus: 'SUCCESS',
+                    },
+                    updatedAt: '2026-06-05T05:15:00.000Z',
+                },
+            ],
+        }))
+
+        expect(result.aggregateScore)
+            .toBe(0)
+        expect(result.finalAggregateScore)
+            .toBe(0)
+        expect(result.isPassingReview)
+            .toBe(false)
+    })
+
     it('uses the review submission id when the backend omits the top-level submission id', () => {
         const result = convertBackendSubmissionToSubmissionInfo(buildBackendSubmission({
             id: undefined,

--- a/src/apps/review/src/lib/models/SubmissionInfo.model.ts
+++ b/src/apps/review/src/lib/models/SubmissionInfo.model.ts
@@ -47,7 +47,7 @@ export interface SubmissionInfo {
      */
     aggregateScore?: number
     /**
-     * Aggregated system/final score from review summations when available.
+     * Aggregated terminal system/final score from review summations when available.
      */
     finalAggregateScore?: number
     /**
@@ -252,13 +252,35 @@ function isFinalReviewSummation(summation: ReviewSummationLike): boolean {
 }
 
 /**
+ * Checks whether a final/system summation is only an active scoring placeholder.
+ *
+ * @param summation - Review summation returned by Review API.
+ * @returns True when Marathon Match system tests are still in progress.
+ * Used before exposing final aggregate scores so the required zero placeholder is not displayed.
+ * @throws This helper does not throw.
+ */
+function isReviewSummationInProgress(summation: ReviewSummationLike): boolean {
+    const metadata = parseSummationMetadata(summation.metadata)
+    const normalizedStatus = typeof metadata.testStatus === 'string'
+        ? metadata.testStatus
+            .trim()
+            .replace(/[_-]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .toUpperCase()
+        : ''
+
+    return normalizedStatus === 'IN PROGRESS'
+}
+
+/**
  * Selects the newest final/system review summation with a usable score.
  *
  * @param reviewSummations - Summations attached to one submission.
- * @returns Preferred final/system summation, or undefined when none exist.
- * Used to populate final-only aggregate scores for Marathon Match winners.
+ * @returns Newest scored final/system summation, or undefined when none exist.
+ * Used to determine whether the latest Marathon Match final score is terminal.
+ * @throws This helper does not throw.
  */
-function findFinalReviewSummation(
+function findLatestFinalReviewSummation(
     reviewSummations: ReviewSummationLike[],
 ): ReviewSummationLike | undefined {
     return reviewSummations
@@ -349,8 +371,14 @@ export function convertBackendSubmissionToSubmissionInfo(
     const reviewSummations: ReviewSummationLike[] = Array.isArray(data.reviewSummation)
         ? data.reviewSummation
         : []
-    const finalSummation = findFinalReviewSummation(reviewSummations)
-    const preferredSummation = finalSummation ?? reviewSummations[0]
+    const latestFinalSummation = findLatestFinalReviewSummation(reviewSummations)
+    const finalSummation = latestFinalSummation
+        && !isReviewSummationInProgress(latestFinalSummation)
+        ? latestFinalSummation
+        : undefined
+    const preferredSummation = latestFinalSummation
+        ? finalSummation
+        : reviewSummations[0]
     const aggregateScore = parseAggregateScore(preferredSummation?.aggregateScore)
     const finalAggregateScore = parseAggregateScore(finalSummation?.aggregateScore)
     const isPassingReviewRaw = preferredSummation?.isPassing


### PR DESCRIPTION
## What was broken

While Marathon Match system tests were running, the Review table displayed an earlier provisional score and then the system test's temporary zero score with a Fail result. This made submissions appear to change score and outcome before final scoring had completed.

## Root cause

The Review UI treated an aggregate summation as display-ready without checking whether the latest final/system summation was still marked IN PROGRESS. Score display, result calculation, and sorting could therefore use an earlier summation or the in-progress zero placeholder.

## What was changed

- Withhold an in-progress final/system summation and do not fall back to an earlier score.
- Use only the terminal final aggregate for Marathon Match Review Score, Score, Review Result, and score sorting.
- Preserve completed zero/failing scores and legacy final summations without status metadata.

## Any added/updated tests

- Added submission conversion coverage for in-progress system placeholders and completed zero scores.
- Updated table-rendering tests to verify earlier scores remain hidden until a terminal final aggregate exists.
- Updated result-resolution tests to verify the outcome is deferred while only an earlier aggregate exists.
- Review app tests: 45 of 45 suites and 165 of 165 tests passed.
- Lint passed.
- Production build passed with existing repository warnings.
- The full monorepo test command continues to report the existing dev baseline failures in 13 unrelated suites (36 tests).
