### PR TITLE
PM-5748: allow iterative reviewers to view submissions

### DIFF
--- a/src/apps/review/src/lib/hooks/useRolePermissions.spec.tsx
+++ b/src/apps/review/src/lib/hooks/useRolePermissions.spec.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import type { FC, PropsWithChildren } from 'react'
+import { renderHook } from '@testing-library/react'
+import type { RenderHookResult } from '@testing-library/react'
+
+import {
+    ChallengeDetailContext,
+    ReviewAppContext,
+} from '../contexts'
+import type {
+    ChallengeDetailContextModel,
+    ReviewAppContextModel,
+} from '../models'
+
+import {
+    useRolePermissions,
+    UseRolePermissionsResult,
+} from './useRolePermissions'
+
+jest.mock('../contexts', () => {
+    const React: typeof import('react') = jest.requireActual('react')
+
+    return {
+        ChallengeDetailContext: React.createContext({}),
+        ReviewAppContext: React.createContext({}),
+    }
+})
+
+jest.mock('~/libs/core', () => ({
+    UserRole: {
+        administrator: 'administrator',
+        projectManager: 'project manager',
+    },
+}), { virtual: true })
+
+const challengeContext = {
+    challengeId: 'completed-design-f2f',
+    myResources: [{
+        id: 'iterative-reviewer-resource',
+        memberId: 'iterative-reviewer-member',
+        roleName: 'Iterative Reviewer',
+    }],
+    myRoles: ['Iterative Reviewer'],
+} as unknown as ChallengeDetailContextModel
+
+const reviewAppContext = {
+    loginUserInfo: {
+        roles: [],
+        userId: 'iterative-reviewer-member',
+    },
+} as unknown as ReviewAppContextModel
+
+/**
+ * Supplies the challenge and login contexts for an Iterative Reviewer.
+ *
+ * @param props React children rendered by the hook test.
+ * @returns Context providers containing an Iterative Reviewer assignment.
+ * @throws Never.
+ */
+const ContextWrapper: FC<PropsWithChildren> = props => (
+    <ReviewAppContext.Provider value={reviewAppContext}>
+        <ChallengeDetailContext.Provider value={challengeContext}>
+            {props.children}
+        </ChallengeDetailContext.Provider>
+    </ReviewAppContext.Provider>
+)
+
+describe('useRolePermissions', () => {
+    it('lets an Iterative Reviewer view all submissions without regular Reviewer permissions', () => {
+        const { result }: RenderHookResult<
+            UseRolePermissionsResult,
+            unknown
+        > = renderHook(
+            () => useRolePermissions(),
+            { wrapper: ContextWrapper },
+        )
+
+        expect(result.current.hasReviewerRole)
+            .toBe(false)
+        expect(result.current.canViewAllSubmissions)
+            .toBe(true)
+    })
+})

--- a/src/apps/review/src/lib/hooks/useRolePermissions.ts
+++ b/src/apps/review/src/lib/hooks/useRolePermissions.ts
@@ -61,6 +61,11 @@ export function useRolePermissions(): UseRolePermissionsResult {
         [normalizedRoles],
     )
 
+    const hasIterativeReviewerRole = useMemo<boolean>(
+        () => normalizedRoles.some(role => role.includes('iterative reviewer')),
+        [normalizedRoles],
+    )
+
     const isProjectManager = useMemo<boolean>(
         () => (loginUserInfo?.roles?.some(
             role => typeof role === 'string'
@@ -104,12 +109,22 @@ export function useRolePermissions(): UseRolePermissionsResult {
             isAdmin
             || hasCopilotRole
             || hasReviewerRole
+            || hasIterativeReviewerRole
             || hasManagerRole
             || hasScreenerRole
             || hasApproverRole
             || isProjectManager
         ),
-        [hasCopilotRole, isAdmin, isProjectManager, hasReviewerRole, hasManagerRole, hasScreenerRole, hasApproverRole],
+        [
+            hasApproverRole,
+            hasCopilotRole,
+            hasIterativeReviewerRole,
+            hasManagerRole,
+            hasReviewerRole,
+            hasScreenerRole,
+            isAdmin,
+            isProjectManager,
+        ],
     )
 
     return {


### PR DESCRIPTION
What was broken

Iterative Reviewers were not counted as users who can view all submissions. Completed Design challenge tables that relied on this permission treated them like unprivileged members and disabled downloads when submissions were not publicly viewable.

Root cause

The shared role permission hook recognized standard reviewer assignments but omitted the Iterative Reviewer role from `canViewAllSubmissions`, even though submission fetching and Review API download authorization already recognized that role.

What was changed

Included Iterative Reviewer assignments in the submission visibility permission. The change is deliberately limited to submission visibility and does not grant standard Reviewer actions such as appeal responses.

Any added/updated tests

Added a hook regression test that verifies an Iterative Reviewer can view all submissions while `hasReviewerRole` remains false.

The focused Review regression suites pass: 2 suites and 3 tests. `yarn lint` and `yarn run build` also pass. The full `yarn test:no-watch` run reports 36 failures in 13 unrelated Work, Engagements, and Wallet Admin suites; an untouched `origin/dev` worktree reproduces the same 36 failures in the same 13 suites.
