### PR TITLE
PM-5703: correct dashboard range and display formatting

### DIFF
--- a/src/apps/reports/src/pages/dashboards/DashboardChart.spec.tsx
+++ b/src/apps/reports/src/pages/dashboards/DashboardChart.spec.tsx
@@ -5,6 +5,7 @@ import {
     screen,
     within,
 } from '@testing-library/react'
+import Highcharts from 'highcharts'
 
 import {
     MemberPaymentByCustomerDashboard,
@@ -100,6 +101,13 @@ const countTooltipValue = `<b>${pointValueToken}</b>`
 const currencyTooltipValue = `<b>$${pointValueToken}</b>`
 
 describe('DashboardChart', () => {
+    it('formats tooltip thousands with commas', () => {
+        expect(Highcharts.getOptions().lang?.thousandsSep)
+            .toBe(',')
+        expect(Highcharts.numberFormat(9_189, 0))
+            .toBe('9,189')
+    })
+
     it('renders API-ordered customer series as currency data', () => {
         render(<DashboardChart response={customerPaymentResponse} />)
 

--- a/src/apps/reports/src/pages/dashboards/DashboardChart.tsx
+++ b/src/apps/reports/src/pages/dashboards/DashboardChart.tsx
@@ -16,6 +16,12 @@ import {
 } from './dashboard.utils'
 import styles from './Dashboards.module.scss'
 
+Highcharts.setOptions({
+    lang: {
+        thousandsSep: ',',
+    },
+})
+
 type DashboardChartProps = {
     compact?: boolean
     response: DashboardResponse

--- a/src/apps/reports/src/pages/dashboards/DashboardDetailPage.spec.tsx
+++ b/src/apps/reports/src/pages/dashboards/DashboardDetailPage.spec.tsx
@@ -217,7 +217,7 @@ describe('Dashboard detail page', () => {
         expect(mockedDownloadBlobFile)
             .toHaveBeenCalledWith(
                 expect.any(Blob),
-                'new-signups-2025-08-01-to-2026-02-01.csv',
+                'new-signups-2025-08-01-to-2026-01-31.csv',
             )
     })
 
@@ -275,7 +275,7 @@ describe('Dashboard detail page', () => {
         expect(mockedDownloadBlobFile)
             .toHaveBeenCalledWith(
                 expect.any(Blob),
-                'new-signups-2025-07-01-to-2026-07-01.csv',
+                'new-signups-2025-07-01-to-2026-06-30.csv',
             )
 
         fireEvent.click(screen.getByRole('button', { name: 'Previous Period' }))
@@ -380,7 +380,7 @@ describe('Dashboard detail page', () => {
         expect(mockedDownloadBlobFile)
             .toHaveBeenCalledWith(
                 expect.any(Blob),
-                'member-payment-by-customer-2026-02-01-to-2026-08-01.csv',
+                'member-payment-by-customer-2026-02-01-to-2026-07-31.csv',
             )
     })
 

--- a/src/apps/reports/src/pages/dashboards/Dashboards.module.scss
+++ b/src/apps/reports/src/pages/dashboards/Dashboards.module.scss
@@ -74,6 +74,7 @@
         font-size: 16px;
         font-weight: 700;
         line-height: 22px;
+        text-transform: none;
     }
 
     p {
@@ -173,6 +174,10 @@
 
 .detailHeading {
     min-width: 260px;
+
+    h1 {
+        text-transform: none;
+    }
 }
 
 .rangePanel {

--- a/src/apps/reports/src/pages/dashboards/DashboardsPage.spec.tsx
+++ b/src/apps/reports/src/pages/dashboards/DashboardsPage.spec.tsx
@@ -249,7 +249,7 @@ describe('Dashboards landing page', () => {
         expect(mockedDownloadBlobFile)
             .toHaveBeenCalledWith(
                 expect.any(Blob),
-                'reports-dashboards-2026-02-01-to-2026-08-01.csv',
+                'reports-dashboards-2026-02-01-to-2026-07-31.csv',
             )
     })
 })

--- a/src/apps/reports/src/pages/dashboards/dashboard.utils.spec.ts
+++ b/src/apps/reports/src/pages/dashboards/dashboard.utils.spec.ts
@@ -201,7 +201,7 @@ describe('dashboard labels and metric formatting', () => {
 })
 
 describe('dashboard CSV filenames', () => {
-    it('combines a normalized slug with the exact API request range', () => {
+    it('shows the inclusive final date instead of the exclusive API boundary', () => {
         expect(buildDashboardCsvFileName(
             'Challenge Registrants / Submitters',
             {
@@ -209,7 +209,7 @@ describe('dashboard CSV filenames', () => {
                 startDate: '2026-02-01',
             },
         ))
-            .toBe('challenge-registrants-submitters-2026-02-01-to-2026-08-01.csv')
+            .toBe('challenge-registrants-submitters-2026-02-01-to-2026-07-31.csv')
     })
 
     it('uses the reports dashboard stem for the landing-page aggregate', () => {
@@ -220,7 +220,7 @@ describe('dashboard CSV filenames', () => {
                 startDate: '2026-02-01',
             },
         ))
-            .toBe('reports-dashboards-2026-02-01-to-2026-08-01.csv')
+            .toBe('reports-dashboards-2026-02-01-to-2026-07-31.csv')
     })
 
     it('rejects empty slugs and invalid ranges', () => {

--- a/src/apps/reports/src/pages/dashboards/dashboard.utils.ts
+++ b/src/apps/reports/src/pages/dashboards/dashboard.utils.ts
@@ -526,24 +526,26 @@ export function formatPercentage(percentage: number): string {
  * Pass `all` for the landing-page aggregate export.
  * @param range Dashboard request range with an exclusive `endDate`.
  * @returns A normalized filename such as
- * `new-signups-2026-02-01-to-2026-08-01.csv`. The `all` slug produces a
+ * `new-signups-2026-02-01-to-2026-07-31.csv`. The `all` slug produces a
  * `reports-dashboards-...csv` filename.
  * @throws RangeError when the slug or range dates are invalid, or the range is empty.
  *
- * Detail dashboard downloads use the filename alongside the same date range
- * supplied to the CSV endpoint.
+ * Detail dashboard downloads keep the API's half-open request range while the
+ * filename presents both boundaries as inclusive calendar dates.
  */
 export function buildDashboardCsvFileName(
     dashboardSlug: string,
     range: DashboardRange,
 ): string {
     formatDashboardRangeLabel(range)
+    const inclusiveEndDate = parseDashboardIsoDate(range.endDate)
+    inclusiveEndDate.setUTCDate(inclusiveEndDate.getUTCDate() - 1)
 
     return [
         normalizeDashboardSlug(dashboardSlug),
         range.startDate,
         'to',
-        range.endDate,
+        toIsoDate(inclusiveEndDate),
     ].join('-')
         .concat('.csv')
 }


### PR DESCRIPTION
What was broken

Dashboard CSV filenames displayed the API's exclusive next-month boundary instead of the last included date. Chart tooltips grouped thousands with spaces, and chart names were forced to uppercase on both landing cards and detail pages.

Root cause

The filename builder copied the half-open `endDate` directly. Highcharts used its default space thousands separator, while the shared heading typography applied `text-transform: uppercase` globally.

What was changed

- Show the inclusive final calendar day in CSV filenames while preserving the same half-open API request range.
- Configure dashboard charts to group thousands with commas.
- Override uppercase transformation only for dashboard card and detail chart titles.

Any added/updated tests

- Updated CSV filename utility and landing/detail download expectations.
- Added a Highcharts number-format regression assertion.
- `yarn test:no-watch --runInBand src/apps/reports/src` — 12 suites, 52 tests passed.
- `yarn lint` — passed.
- `yarn run build` — passed with existing repository warnings.
