### PR TITLE
PM-5784: Honor Design phase shortening

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -114,9 +114,9 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - Save create/update/delete: `createChallenge`, `patchChallenge`, `deleteChallenge`.
 - Manual saves for active scheduled challenges refetch the persisted challenge after `patchChallenge`
   before resetting or navigating. Rejected shortening is detected from the submitted and persisted
-  scheduled phase windows, falling back to stored durations when dates are unavailable, so an
-  API-rejected edit is restored with a partial-save warning while scheduler timing and sub-minute
-  duration normalization do not show a false error.
+  scheduled phase windows for tracks that disallow active shortening, falling back to stored
+  durations when dates are unavailable, so an API-rejected edit is restored with a partial-save
+  warning while permitted Design shortening and scheduler normalization do not show a false error.
 - Initial create refresh: after `createChallenge`, the form fetches full challenge details with `fetchChallenge` to avoid round-type regressions from sparse create responses and to surface the generated forum link for challenge types that provision a discussion on create.
 - Skills search: `searchSkills`.
 - Tracks fetch: `fetchChallengeTracks`.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -398,6 +398,7 @@ jest.mock('./ChallengeScheduleSection', () => ({
                 <div
                     data-disabled={props.disabled === true ? 'true' : 'false'}
                     data-first-phase-end={phases?.[0]?.scheduledEndDate || ''}
+                    data-second-phase-end={phases?.[1]?.scheduledEndDate || ''}
                     data-testid='challenge-schedule-section'
                 />
                 <button
@@ -406,6 +407,32 @@ jest.mock('./ChallengeScheduleSection', () => ({
                     type='button'
                 >
                     Mock Dirty Phase End
+                </button>
+                <button
+                    data-testid='mock-dirty-design-phase-ends'
+                    onClick={() => {
+                        const currentPhases = formContext.getValues('phases') as typeof phases
+                        const shortenedEndDates = [
+                            '2026-07-31T11:17:00.000Z',
+                            '2026-08-01T11:17:00.000Z',
+                        ]
+
+                        formContext.setValue('phases', (currentPhases || []).map((phase, index) => (
+                            shortenedEndDates[index]
+                                ? {
+                                    ...phase,
+                                    duration: index === 0 ? 1438 : 2878,
+                                    scheduledEndDate: shortenedEndDates[index],
+                                }
+                                : phase
+                        )), {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                        })
+                    }}
+                    type='button'
+                >
+                    Mock Dirty Design Phase Ends
                 </button>
                 <button
                     data-testid='mock-clean-form'
@@ -3480,7 +3507,7 @@ describe('ChallengeEditorForm', () => {
             .not.toHaveBeenCalledWith('Challenge saved successfully')
     })
 
-    it('accepts Design phase shortening when the persisted duration rounds up', async () => {
+    it('accepts multi-phase Design shortening after persisted windows normalize later', async () => {
         const user = userEvent.setup()
         const activeChallenge = {
             ...validDraftChallenge,
@@ -3488,26 +3515,43 @@ describe('ChallengeEditorForm', () => {
                 reviewType: 'INTERNAL',
                 useSchedulingAPI: true,
             },
-            phases: [{
-                duration: 11520,
-                isOpen: true,
-                name: 'Registration',
-                phaseId: 'registration-phase-id',
-                scheduledEndDate: '2026-04-19T04:58:51.000Z',
-                scheduledStartDate: '2026-04-11T04:58:41.000Z',
-            }],
-            startDate: '2026-04-11T04:58:41.000Z',
+            phases: [
+                {
+                    duration: 4320,
+                    isOpen: true,
+                    name: 'Registration',
+                    phaseId: 'registration-phase-id',
+                    scheduledEndDate: '2026-08-02T11:17:00.000Z',
+                    scheduledStartDate: '2026-07-30T11:18:55.496Z',
+                },
+                {
+                    duration: 4320,
+                    isOpen: true,
+                    name: 'Submission',
+                    phaseId: 'submission-phase-id',
+                    scheduledEndDate: '2026-08-02T11:17:00.000Z',
+                    scheduledStartDate: '2026-07-30T11:18:55.496Z',
+                },
+            ],
+            startDate: '2026-07-30T11:18:55.496Z',
             status: 'ACTIVE',
             trackId: 'design-track',
         } as Challenge
         const persistedShortenedSchedule = {
             ...activeChallenge,
             name: 'Active Design challenge updated',
-            phases: [{
-                ...activeChallenge.phases?.[0],
-                duration: 10081,
-                scheduledEndDate: '2026-04-18T04:58:51.000Z',
-            }],
+            phases: [
+                {
+                    ...activeChallenge.phases?.[0],
+                    duration: 86258,
+                    scheduledEndDate: '2026-07-31T11:17:33.000Z',
+                },
+                {
+                    ...activeChallenge.phases?.[1],
+                    duration: 172658,
+                    scheduledEndDate: '2026-08-01T11:17:33.000Z',
+                },
+            ],
         } as Challenge
 
         mockedUseFetchChallengeTracks.mockReturnValue({
@@ -3531,7 +3575,7 @@ describe('ChallengeEditorForm', () => {
             </MemoryRouter>,
         )
 
-        await user.click(screen.getByTestId('mock-dirty-phase-end'))
+        await user.click(screen.getByTestId('mock-dirty-design-phase-ends'))
         await user.type(screen.getByLabelText('Challenge Name'), ' updated')
         await user.click(screen.getByRole('button', { name: 'Update Challenge' }))
 
@@ -3539,7 +3583,9 @@ describe('ChallengeEditorForm', () => {
             expect(mockedFetchChallenge)
                 .toHaveBeenCalledWith('12345')
             expect(screen.getByTestId('challenge-schedule-section'))
-                .toHaveAttribute('data-first-phase-end', '2026-04-18T04:58:51.000Z')
+                .toHaveAttribute('data-first-phase-end', '2026-07-31T11:17:33.000Z')
+            expect(screen.getByTestId('challenge-schedule-section'))
+                .toHaveAttribute('data-second-phase-end', '2026-08-01T11:17:33.000Z')
             expect(screen.getByTestId('location-display'))
                 .toHaveTextContent('/projects/100578/challenges/12345/view')
         })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -3298,6 +3298,7 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                     resolvedProjectBillingAccount,
                 )
                 const wasActivePhaseShorteningRejected = shouldVerifyPersistedSchedule
+                    && !isDesignTrackSelected
                     && hasRejectedActivePhaseShortening(
                         formDataWithProjectBilling.phases,
                         persistedFormData.phases,
@@ -3380,6 +3381,7 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
             currentChallengeId,
             fallbackProjectId,
             hydratePersistedSavedFormData,
+            isDesignTrackSelected,
             isEditMode,
             isTaskSingleAssignmentChallenge,
             navigate,


### PR DESCRIPTION
What was broken

Active Design phase shortening was persisted by challenge-api, but Work could still show “Active phase shortening cannot be saved” after refetching scheduler-normalized Registration and Submission windows.

Root cause (if identifiable)

The earlier fix normalized duration comparison, but the post-save rejection heuristic remained track-agnostic. It could therefore interpret normal scheduler adjustments as a rejected shortening even though Design explicitly permits active phases to be shortened.

What was changed

- Skip the rejected-shortening heuristic for Design challenges while retaining the canonical post-save refetch.
- Keep genuine rejected-shortening detection unchanged for tracks that disallow it.
- Document the track-aware schedule verification behavior.

Any added/updated tests

- Expanded the ChallengeEditorForm regression to shorten both Registration and Submission in a single-round Design schedule.
- Covered persisted scheduler seconds that would otherwise make a shortened window compare as longer.
- Confirmed the Design save, genuine non-Design rejection, and shifted immediate-window cases pass.
- `yarn lint` passed.
- `yarn run build` passed with existing repository warnings.
- The full suite was run; 201 of 217 suites and 964 of 995 tests pass. The remaining failures are unrelated baseline module-alias, UI-icon mock, and launch-approval expectation failures.
