### PR TITLE
PM-5435: Prefer the completed provisional test process

### DIFF
--- a/src/apps/work/src/lib/utils/challenge.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.spec.ts
@@ -115,6 +115,36 @@ describe('challenge utils', () => {
                     status: 'SUCCESS',
                 })
         })
+
+        it('prefers a completed provisional process over a later example process', () => {
+            expect(getSubmissionTestProgress({
+                reviewSummation: [
+                    {
+                        isExample: true,
+                        metadata: {
+                            testProgress: 1,
+                            testStatus: 'SUCCESS',
+                            testType: 'example',
+                        },
+                        updatedAt: '2026-07-30T05:09:59.950Z',
+                    },
+                    {
+                        isProvisional: true,
+                        metadata: {
+                            testProcess: 'provisional',
+                            testProgress: 1,
+                            testStatus: 'SUCCESS',
+                        },
+                        updatedAt: '2026-07-30T05:05:34.045Z',
+                    },
+                ],
+            }))
+                .toEqual({
+                    process: 'provisional',
+                    progressPercent: '100%',
+                    status: 'SUCCESS',
+                })
+        })
     })
 
     describe('getSubmissionProvisionalScore', () => {

--- a/src/apps/work/src/lib/utils/challenge.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge.utils.ts
@@ -305,8 +305,8 @@ function normalizeTestProgress(value: unknown): number | undefined {
 /**
  * Assigns a stable ordering weight for marathon test processes.
  * @param process Normalized marathon test process.
- * @returns Numeric priority used to break ties between progress records.
- * Used by `toSubmissionTestProgressCandidate` after timestamp and status ordering.
+ * @returns Numeric priority used to select the furthest completed process.
+ * Used by `getSubmissionTestProgress` before timestamps are used to break ties.
  */
 function getTestProcessPriority(process: MarathonMatchScoreProcess | undefined): number {
     if (process === 'system') {
@@ -324,7 +324,7 @@ function getTestProcessPriority(process: MarathonMatchScoreProcess | undefined):
  * Resolves the best timestamp available for ordering test progress summations.
  * @param entry Review summation containing marathon metadata.
  * @returns Epoch milliseconds or 0 when no parseable timestamp exists.
- * Used by `getSubmissionTestProgress` to choose the latest non-running process.
+ * Used by `getSubmissionTestProgress` to choose the latest record for a process.
  */
 function getTestProgressUpdatedAt(entry: ReviewSummation): number {
     const updatedAt = entry.metadata?.testProgressDetails?.updatedAt
@@ -384,7 +384,7 @@ function toSubmissionTestProgressCandidate(
 /**
  * Returns display-ready marathon match test progress for one submission.
  * @param submission Submission-like object containing Review API summations.
- * @returns Current process, status, and percent text when present in summation metadata.
+ * @returns Active progress, or the furthest completed process, with its status and percent text.
  * Used by `SubmissionsTable` to render marathon-only test progress columns.
  */
 export function getSubmissionTestProgress(
@@ -395,8 +395,8 @@ export function getSubmissionTestProgress(
         .filter((entry): entry is SubmissionTestProgressCandidate => !!entry)
         .sort((first, second) => (
             second.inProgressPriority - first.inProgressPriority
-            || second.updatedAt - first.updatedAt
             || second.processPriority - first.processPriority
+            || second.updatedAt - first.updatedAt
             || second.statusPriority - first.statusPriority
         ))
 


### PR DESCRIPTION
What was broken

Marathon Match submissions could show Example as the current test process and display the Example score even after Provisional testing completed. This caused Work Manager to disagree with the Community App's provisional score for timing-dependent submissions.

Root cause (if identifiable)

The Work UI ranked completed test-process summations by update timestamp before phase priority. Because Example and Provisional callbacks finish independently, a later Example update could mask the more advanced Provisional result.

What was changed

Kept active runs first, then ranked completed phases as System, Provisional, and Example. Timestamps now choose only among records for the same phase. Updated the helper documentation to describe the selection rule.

Any added/updated tests

Added a regression test using the affected ordering: a completed Example result updated after a completed Provisional result. The test verifies that Provisional, 100% progress, and SUCCESS are selected.

Validation:

- `yarn test:no-watch --runInBand src/apps/work/src/lib/utils/challenge.utils.spec.ts src/apps/work/src/lib/components/SubmissionsTable/SubmissionsTable.spec.tsx` — passed, 27 tests.
- `yarn lint` — passed.
- `yarn run build` — passed with existing repository warnings.
- `yarn test:no-watch --runInBand` — completed with 201 suites and 965 tests passing; 16 unrelated baseline suites fail on `dev` because of existing alias-resolution and stale-mock issues.
