### PR TITLE
PM-5757: Show cancel options from edit footer

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
@@ -23,7 +23,10 @@ import {
     type UseFetchChallengeResult,
 } from '../../../lib/hooks'
 import type { WorkAppContextModel } from '../../../lib/models'
-import { deleteChallenge } from '../../../lib/services'
+import {
+    deleteChallenge,
+    patchChallenge,
+} from '../../../lib/services'
 import {
     checkProjectAccess,
     isChallengeCompletedOrCancelled,
@@ -177,6 +180,7 @@ jest.mock('./components', () => {
 
     return {
         ChallengeEditorForm: (props: {
+            footerCancelAction?: ReactNode
             isEditMode?: boolean
             onChallengeCreated?: (challenge: {
                 id: string
@@ -211,6 +215,7 @@ jest.mock('./components', () => {
                     {props.isReadOnly
                         ? 'Challenge View Form'
                         : 'Challenge Editor Form'}
+                    {props.footerCancelAction}
                     <button
                         onClick={function handleChallengeApproval() {
                             props.onChallengeApprovalStatusChange?.('APPROVED')
@@ -264,6 +269,7 @@ const mockedUseFetchProject = useFetchProject as jest.Mock
 const mockedUseFetchResourceRoles = useFetchResourceRoles as jest.Mock
 const mockedUseFetchResources = useFetchResources as jest.Mock
 const mockedDeleteChallenge = deleteChallenge as jest.Mock
+const mockedPatchChallenge = patchChallenge as jest.Mock
 const mockedCheckProjectAccess = checkProjectAccess as jest.Mock
 const mockedIsChallengeCompletedOrCancelled = isChallengeCompletedOrCancelled as jest.Mock
 const mockedGetAssignedTaskMember = getAssignedTaskMember as jest.Mock
@@ -370,16 +376,21 @@ describe('ChallengeEditorPage', () => {
                 .toBeTruthy()
         })
 
-        expect(
-            screen.getByTestId('challenge-editor-form')
-                .getAttribute('data-edit-mode'),
-        )
+        const editorForm = screen.getByTestId('challenge-editor-form')
+        const rightHeader = screen.getByTestId('right-header')
+        const headerCancelButton = within(rightHeader)
+            .getByRole('button', { name: 'Cancel' })
+        const footerCancelButton = within(editorForm)
+            .getByRole('button', { name: 'Cancel' })
+
+        expect(editorForm.getAttribute('data-edit-mode'))
             .toBe('true')
-        expect(screen.getByRole('button', { name: 'Cancel' }))
+        expect(headerCancelButton)
+            .toBeTruthy()
+        expect(footerCancelButton)
             .toBeTruthy()
 
         const titleAction = screen.getByTestId('title-action')
-        const rightHeader = screen.getByTestId('right-header')
         const quickLinks = within(rightHeader)
             .getAllByRole('link')
 
@@ -408,15 +419,72 @@ describe('ChallengeEditorPage', () => {
             .getAttribute('href'))
             .toBe('https://example.com/forum/challenges/456')
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            headerCancelButton
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            footerCancelButton
                 .getAttribute('data-size'),
         )
             .toBe('lg')
+    })
+
+    it('opens cancellation options from the edit footer and applies the selected status', async () => {
+        const user = userEvent.setup()
+        const mutate = jest.fn()
+            .mockResolvedValue(undefined)
+        mockedPatchChallenge.mockResolvedValue({})
+        mockedUseFetchChallenge.mockReturnValue({
+            challenge: {
+                discussions: [],
+                id: '456',
+                name: 'Edit test',
+                prizeSets: [],
+                projectId: '123',
+                status: 'DRAFT',
+            },
+            error: undefined,
+            isLoading: false,
+            mutate,
+        })
+
+        renderPage(
+            '/projects/123/challenges/456/edit',
+            '/projects/:projectId/challenges/:challengeId/edit',
+        )
+
+        const editorForm = await screen.findByTestId('challenge-editor-form')
+        await user.click(within(editorForm)
+            .getByRole('button', { name: 'Cancel' }))
+
+        const cancelStatusOption = screen.getByRole('button', {
+            name: 'Cancelled Failed Review',
+        })
+        expect(cancelStatusOption)
+            .toBeTruthy()
+        expect(screen.getByText('Challenge Editor Form'))
+            .toBeTruthy()
+
+        await user.click(cancelStatusOption)
+
+        expect(screen.getByText('Cancel Challenge'))
+            .toBeTruthy()
+        expect(screen.getByText(
+            'Do you want to cancel challenge Edit test with status Cancelled Failed Review?',
+        ))
+            .toBeTruthy()
+
+        await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+        await waitFor(() => {
+            expect(mockedPatchChallenge)
+                .toHaveBeenCalledWith('456', {
+                    status: 'CANCELLED_FAILED_REVIEW',
+                })
+        })
+        expect(mutate)
+            .toHaveBeenCalled()
     })
 
     it('renders a read-only draft challenge view with header and footer actions', async () => {
@@ -941,28 +1009,33 @@ describe('ChallengeEditorPage', () => {
             '/projects/:projectId/challenges/:challengeId/edit',
         )
 
+        const rightHeader = within(screen.getByTestId('right-header'))
+        const editorForm = within(screen.getByTestId('challenge-editor-form'))
+
         await waitFor(() => {
-            expect(screen.getByRole('button', { name: 'Cancel' }))
+            expect(rightHeader.getByRole('button', { name: 'Cancel' }))
+                .toBeTruthy()
+            expect(editorForm.getByRole('button', { name: 'Cancel' }))
                 .toBeTruthy()
         })
 
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            rightHeader.getByRole('button', { name: 'Cancel' })
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Cancel' })
+            editorForm.getByRole('button', { name: 'Cancel' })
                 .getAttribute('data-size'),
         )
             .toBe('lg')
         expect(
-            screen.getByRole('button', { name: 'Mark Complete' })
+            rightHeader.getByRole('button', { name: 'Mark Complete' })
                 .getAttribute('data-secondary'),
         )
             .toBe('true')
         expect(
-            screen.getByRole('button', { name: 'Mark Complete' })
+            rightHeader.getByRole('button', { name: 'Mark Complete' })
                 .getAttribute('data-size'),
         )
             .toBe('lg')

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
@@ -116,6 +116,7 @@ interface ChallengeEditorContentProps {
     canLaunchChallenge: boolean
     challenge: UseFetchChallengeResult['challenge']
     challengeId?: string
+    footerCancelAction?: JSX.Element
     isExistingChallenge: boolean
     isLaunchDisabled: boolean
     isReadOnly: boolean
@@ -134,6 +135,7 @@ interface ChallengeEditorBodyProps {
     canLaunchChallenge: boolean
     challengeId?: string
     challengeResult: UseFetchChallengeResult
+    footerCancelAction?: JSX.Element
     isProjectAccessDenied: boolean
     isProjectAccessLoading: boolean
     isExistingChallenge: boolean
@@ -970,6 +972,7 @@ const ChallengeEditorContent: FC<ChallengeEditorContentProps> = (
             <ChallengeEditorForm
                 canLaunchChallenge={props.canLaunchChallenge}
                 challenge={props.challenge}
+                footerCancelAction={props.footerCancelAction}
                 isLaunchDisabled={props.isLaunchDisabled}
                 isEditMode={isEditMode}
                 isReadOnly={props.isReadOnly}
@@ -1007,6 +1010,7 @@ const ChallengeEditorContent: FC<ChallengeEditorContentProps> = (
         <ChallengeEditorForm
             canLaunchChallenge={props.canLaunchChallenge}
             challenge={props.challenge}
+            footerCancelAction={props.footerCancelAction}
             isLaunchDisabled={props.isLaunchDisabled}
             isEditMode={isEditMode}
             isReadOnly={props.isReadOnly}
@@ -1063,6 +1067,7 @@ const ChallengeEditorBody: FC<ChallengeEditorBodyProps> = (
                 canLaunchChallenge={props.canLaunchChallenge}
                 challenge={props.challengeResult.challenge}
                 challengeId={props.challengeId}
+                footerCancelAction={props.footerCancelAction}
                 isExistingChallenge={props.isExistingChallenge}
                 isLaunchDisabled={props.isLaunchDisabled}
                 isReadOnly={props.isReadOnly}
@@ -1477,6 +1482,17 @@ export const ChallengeEditorPage: FC = () => {
     const footerActions = isViewMode
         ? renderHeaderAction(challengeActionParams)
         : undefined
+    const footerCancelAction = isEditMode
+        && challengeActionParams.canCancelChallenge
+        && challengeActionParams.challengeId
+        ? (
+            <CancelChallengeAction
+                challengeId={challengeActionParams.challengeId}
+                challengeName={challengeActionParams.challengeName}
+                onCancelled={challengeActionParams.onChallengeUpdated}
+            />
+        )
+        : undefined
     const deleteModal = renderDeleteModal({
         canDeleteChallenge: canRenderChallengeDetails && canDeleteChallenge,
         challengeName: deleteChallengeName,
@@ -1520,6 +1536,7 @@ export const ChallengeEditorPage: FC = () => {
                         canLaunchChallenge={canLaunchChallenge}
                         challengeId={challengeId}
                         challengeResult={challengeResult}
+                        footerCancelAction={footerCancelAction}
                         isProjectAccessDenied={projectAccessState.isDenied}
                         isProjectAccessLoading={projectAccessState.isLoading}
                         isExistingChallenge={isExistingChallenge}

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -136,7 +136,7 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 - After the initial create request succeeds on the `/projects/:projectId/challenges/new` route, the
   page header immediately treats that record as an existing `NEW` challenge so the status pill and
   `Delete` action are available before the route transitions to the regular edit page.
-- `Cancel` is shown on the details tab for existing `DRAFT` challenges on both view and edit routes, and for `ACTIVE` challenges while editing. It uses the shared large secondary button treatment so it matches the footer action styling.
+- `Cancel` is shown on the details tab for existing `DRAFT` challenges on both view and edit routes, and for `ACTIVE` challenges while editing. Eligible edit routes use the same cancellation-status menu and confirmation flow in the header and footer; new or non-cancellable forms retain the footer action that returns to the challenge list.
 - `Mark Complete` is shown on the details tab for existing `ACTIVE` task challenges in both view and edit routes when exactly one assignee can be resolved from the challenge submitter resources. It mirrors the legacy work-manager flow by confirming the task prize and assignee, patching the challenge to `COMPLETED`, and saving that assignee as the sole winner. The button remains hidden for copilots assigned to their own task, and it reuses the same shared large secondary styling as `Cancel`.
 - `Delete` is shown for existing challenges in `NEW` status and requires confirmation.
 - `Edit` is shown in read-only view mode for existing challenges unless the challenge status is `COMPLETED` or any `CANCELLED*` endpoint status, and it uses the same shared large secondary button treatment as the other header actions.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -1311,6 +1311,25 @@ describe('ChallengeEditorForm', () => {
             .toBe('lg')
     })
 
+    it('renders a provided cancellation action in the edit footer', () => {
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm
+                    challenge={draftChallenge}
+                    footerCancelAction={(
+                        <button data-testid='footer-cancel-action' type='button'>
+                            Cancel
+                        </button>
+                    )}
+                    isEditMode
+                />
+            </MemoryRouter>,
+        )
+
+        expect(screen.getByRole('button', { name: 'Cancel' }))
+            .toBe(screen.getByTestId('footer-cancel-action'))
+    })
+
     it('manually saves an unchanged challenge', async () => {
         const user = userEvent.setup()
         mockedPatchChallenge.mockResolvedValue(validDraftChallenge)

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -214,6 +214,7 @@ import styles from './ChallengeEditorForm.module.scss'
 interface ChallengeEditorFormProps {
     canLaunchChallenge?: boolean
     challenge?: Challenge
+    footerCancelAction?: JSX.Element
     isLaunchDisabled?: boolean
     isEditMode?: boolean
     isReadOnly?: boolean
@@ -3820,13 +3821,15 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     const footerSection = !isReadOnly
         ? (
             <div className={styles.footer}>
-                <Button
-                    label='Cancel'
-                    onClick={handleCancelClick}
-                    secondary
-                    size='lg'
-                    type='button'
-                />
+                {props.footerCancelAction || (
+                    <Button
+                        label='Cancel'
+                        onClick={handleCancelClick}
+                        secondary
+                        size='lg'
+                        type='button'
+                    />
+                )}
                 <div className={styles.actions}>
                     <div className={styles.statusArea}>
                         {saveStatus === 'error'


### PR DESCRIPTION
## What was broken

The earlier PM-5757 implementation added mirrored actions to read-only challenge pages. On edit pages, the bottom Cancel button still returned directly to the challenge list instead of showing the cancellation status options, as QA reported.

## Root cause

The previous fix reused the header action renderer only in view mode. Edit mode continued using `ChallengeEditorForm`'s navigation-only footer control, while the header used the full `CancelChallengeAction` workflow.

## What was changed

Injected the existing `CancelChallengeAction` into the edit footer for cancellable persisted challenges, so the footer now opens the status menu and confirmation flow before patching the challenge.

Retained the existing return-to-list footer action for new and non-cancellable forms, and updated the challenge editor documentation.

## Any added/updated tests

Updated `ChallengeEditorPage.spec.tsx` to exercise the edit-footer cancellation flow through status selection, confirmation, PATCH payload, and challenge refresh. Added `ChallengeEditorForm.spec.tsx` coverage that verifies the supplied cancellation action replaces the fallback footer control.

Validation:

- Focused `ChallengeEditorPage` suite: 20 tests passed.
- Targeted `ChallengeEditorForm` assertion: passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- `git diff --check`: passed.
- Full suite: 966 tests passed and 31 pre-existing tests failed across 16 suites. A clean `origin/dev` baseline reproduced the same 31 failures across the same 16 suites, with 964 tests passed before these two tests were added.
