### PR TITLE
PM-5773: restore copilot scorecard editing

### DIFF
--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.spec.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.spec.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import ReviewViewer from './ReviewViewer'
+
+const mockUseChallengeDetailsContext = jest.fn()
+const mockUseFetchSubmissionReviews = jest.fn()
+const mockUseRole = jest.fn()
+
+jest.mock('swr', () => ({
+    mutate: jest.fn(),
+}))
+
+jest.mock('react-router-dom', () => ({
+    useSearchParams: () => [new URLSearchParams()],
+}))
+
+jest.mock('~/apps/review/src/lib/components/ChallengeLinksForAdmin', () => ({
+    ChallengeLinksForAdmin: (props: {
+        canEditScorecard?: boolean
+        isManagerEdit?: boolean
+        onToggleManagerEdit?: () => void
+    }) => props.canEditScorecard ? (
+        <button
+            type='button'
+            onClick={props.onToggleManagerEdit}
+        >
+            {props.isManagerEdit ? 'Exit Edit Mode' : 'Edit Scorecard'}
+        </button>
+    ) : <></>,
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/components/Scorecard', () => ({
+    ScorecardViewer: (props: {
+        autoOpenManagerComment?: boolean
+        isManagerEdit?: boolean
+    }) => (
+        <div>
+            <span data-testid='manager-edit'>{String(Boolean(props.isManagerEdit))}</span>
+            <span data-testid='auto-open-manager-comment'>
+                {String(Boolean(props.autoOpenManagerComment))}
+            </span>
+        </div>
+    ),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/hooks', () => ({
+    useAppNavigate: () => jest.fn(),
+    useFetchSubmissionReviews: () => mockUseFetchSubmissionReviews(),
+    useReviewEditAccess: () => ({
+        isEdit: false,
+        reviewPhaseType: 'review',
+    }),
+    useRole: () => mockUseRole(),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib', () => ({
+    ChallengeLinks: () => <></>,
+    ConfirmModal: () => <></>,
+    useChallengeDetailsContext: () => mockUseChallengeDetailsContext(),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/lib/hooks/useIsEditReview', () => ({
+    useIsEditReview: () => ({ isEdit: false }),
+}), { virtual: true })
+
+jest.mock('~/apps/review/src/config/routes.config', () => ({
+    rootRoute: '/review',
+}), { virtual: true })
+
+jest.mock('../../ReviewsContext', () => ({
+    useReviewsContext: () => ({
+        reviewId: 'review-1',
+        reviewStatus: undefined,
+        setActionButtons: jest.fn(),
+        setReviewStatus: jest.fn(),
+        workflow: undefined,
+    }),
+}))
+
+jest.mock('./ReviewScorecardHeader', () => ({
+    ReviewScorecardHeader: () => <></>,
+}))
+
+describe('ReviewViewer scorecard manager editing', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUseChallengeDetailsContext.mockReturnValue({
+            challengeInfo: {
+                id: 'challenge-1',
+                status: 'ACTIVE',
+                track: {
+                    name: 'Design',
+                },
+            },
+        })
+        mockUseFetchSubmissionReviews.mockReturnValue({
+            addAppeal: jest.fn(),
+            addAppealResponse: jest.fn(),
+            addManagerComment: jest.fn(),
+            doDeleteAppeal: jest.fn(),
+            isLoading: false,
+            isSavingAppeal: false,
+            isSavingAppealResponse: false,
+            isSavingManagerComment: false,
+            isSavingReview: false,
+            isSubmitterPhaseLocked: false,
+            mappingAppeals: {},
+            reviewInfo: {
+                committed: true,
+                id: 'review-1',
+            },
+            saveReviewInfo: jest.fn(),
+            scorecardInfo: {
+                scorecardGroups: [],
+            },
+        })
+        mockUseRole.mockReturnValue({
+            actionChallengeRole: 'Copilot',
+            hasReviewerRole: false,
+            myChallengeResources: [
+                {
+                    roleName: 'Copilot',
+                },
+            ],
+            myChallengeRoles: ['Copilot'],
+        })
+    })
+
+    it('lets an assigned copilot enter scorecard edit mode for a committed active review', () => {
+        render(<ReviewViewer />)
+
+        expect(screen.getByRole('button', { name: 'Edit Scorecard' }))
+            .toBeTruthy()
+        expect(screen.getByTestId('manager-edit').textContent)
+            .toBe('false')
+        expect(screen.getByTestId('auto-open-manager-comment').textContent)
+            .toBe('false')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit Scorecard' }))
+
+        expect(screen.getByRole('button', { name: 'Exit Edit Mode' }))
+            .toBeTruthy()
+        expect(screen.getByTestId('manager-edit').textContent)
+            .toBe('true')
+        expect(screen.getByTestId('auto-open-manager-comment').textContent)
+            .toBe('true')
+    })
+})

--- a/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
+++ b/src/apps/review/src/pages/reviews/components/ReviewViewer/ReviewViewer.tsx
@@ -72,6 +72,13 @@ const ReviewViewer: FC = () => {
         [myChallengeResources],
     )
 
+    const hasChallengeCopilotRole = useMemo(
+        () => myChallengeResources.some(
+            resource => resource.roleName?.toLowerCase() === COPILOT.toLowerCase(),
+        ),
+        [myChallengeResources],
+    )
+
     const canManagerEdit = useMemo(
         () => hasChallengeAdminRole
         || hasTopcoderAdminRole
@@ -211,11 +218,13 @@ const ReviewViewer: FC = () => {
             reviewInfo?.committed
             && (hasChallengeAdminRole
                 || hasTopcoderAdminRole
-                || hasChallengeManagerRole),
+                || hasChallengeManagerRole
+                || hasChallengeCopilotRole),
         )
     }, [
         challengeInfo?.status,
         hasChallengeAdminRole,
+        hasChallengeCopilotRole,
         hasChallengeManagerRole,
         hasTopcoderAdminRole,
         reviewInfo?.committed,


### PR DESCRIPTION
## What was broken

An assigned challenge copilot viewing a committed review could see Reopen but not Edit Scorecard, leaving no way to enter the score-override flow. The earlier PM-5773 fix auto-opened the per-item score and required-comment controls after edit mode began, but it did not cover entry into edit mode.

## Root cause

ReviewViewer excluded the challenge Copilot resource from its canEditScorecard eligibility gate. The earlier regression test mocked manager-edit mode directly, so it did not render or exercise the missing Edit Scorecard button.

## What was changed

Restored challenge-scoped Copilot eligibility for Edit Scorecard. Existing restrictions remain unchanged for appeal-response mode and standalone manager comments; normal scorecard editing continues to use the existing score-change flow that requires a manager comment.

## Any added/updated tests

Added ReviewViewer regression coverage for a committed active review with an assigned Copilot resource. The test verifies that Edit Scorecard is visible and that clicking it enters manager edit mode with the score/comment controls set to auto-open.

Validation completed:

- Focused ReviewViewer regression: 1 suite and 1 test passed.
- Review app suite: 47 suites and 167 tests passed.
- Lint passed.
- Build passed with existing warnings only.
- Diff check passed.
- The full monorepo suite retains 16 unrelated failing suites with 31 failing tests; an untouched origin/dev worktree reproduced the identical failure counts. This branch adds one passing suite and one passing test without adding failures.
