### PR TITLE
PM-5775: gate checkpoint winner indicator by pass result

### DIFF
--- a/src/apps/review/README.md
+++ b/src/apps/review/README.md
@@ -35,4 +35,4 @@ sudo yarn start
 - Canonical `PLACEMENT` winner types are shown. Untyped and contest-submission winner types remain
   supported for legacy challenge records, while checkpoint winner types are excluded.
 - Checkpoint winners remain separate from final placements and are identified by member ID in the
-  Checkpoint Review table.
+  Checkpoint Review table. The winner indicator appears only on rows that passed Checkpoint Review.

--- a/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.spec.tsx
+++ b/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import type { PropsWithChildren, ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import {
     ChallengeDetailContext,
@@ -160,6 +160,14 @@ const secondWinnerRow = {
     submissionId: 'second-winner-submission',
 } as Screening
 
+const failedWinnerRow = {
+    ...winnerRow,
+    result: 'NO PASS',
+    reviewId: 'failed-winner-review',
+    score: '0.00',
+    submissionId: 'failed-winner-submission',
+} as Screening
+
 const challengeInfo = {
     checkpointWinners: [{
         handle: 'checkpointWinner',
@@ -202,7 +210,7 @@ const reviewAppContext = {
 } as ReviewAppContextModel
 
 /**
- * Renders the desktop checkpoint review table with two winner rows and one non-winner.
+ * Renders the desktop checkpoint review table with passing, failing, and non-winner rows.
  *
  * @returns The Testing Library render result for the checkpoint table.
  * @throws This test helper does not throw.
@@ -212,7 +220,7 @@ function renderCheckpointTable(): ReturnType<typeof render> {
         <ReviewAppContext.Provider value={reviewAppContext}>
             <ChallengeDetailContext.Provider value={challengeContext}>
                 <TableCheckpointSubmissions
-                    datas={[winnerRow, secondWinnerRow, nonWinnerRow]}
+                    datas={[winnerRow, secondWinnerRow, failedWinnerRow, nonWinnerRow]}
                     downloadSubmission={jest.fn()}
                     isDownloading={{}}
                     mode='review'
@@ -223,7 +231,7 @@ function renderCheckpointTable(): ReturnType<typeof render> {
 }
 
 describe('TableCheckpointSubmissions checkpoint winner indicator', () => {
-    it('marks only rows whose member id matches a checkpoint winner', () => {
+    it('marks only passing rows whose member id matches a checkpoint winner', () => {
         renderCheckpointTable()
 
         expect(screen.getAllByRole('button', { name: 'Checkpoint winner details' }))
@@ -241,6 +249,12 @@ describe('TableCheckpointSubmissions checkpoint winner indicator', () => {
             .toHaveLength(2)
         expect(screen.getByText('100.00'))
             .toBeTruthy()
+        const failedScoreCell = screen.getByRole('link', { name: '0.00' }).parentElement
+        expect(failedScoreCell)
+            .toBeTruthy()
+        expect(within(failedScoreCell as HTMLElement)
+            .queryByRole('button', { name: 'Checkpoint winner details' }))
+            .toBeNull()
         expect(screen.getByRole('link', { name: '88.89' })
             .getAttribute('href'))
             .toBe('./../reviews/non-winner-submission?reviewId=non-winner-review')

--- a/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.tsx
+++ b/src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.tsx
@@ -610,7 +610,8 @@ export const TableCheckpointSubmissions: FC<Props> = (props: Props) => {
                     renderer: (data: Screening) => {
                         const reviewId = data.reviewId
                         const scoreLabel = data.score ?? 'Pending'
-                        const isCheckpointWinner = checkpointWinnerMemberIds.has(`${data.memberId}`)
+                        const isCheckpointWinner = data.result === 'PASS'
+                            && checkpointWinnerMemberIds.has(`${data.memberId}`)
 
                         return (
                             <span className={styles.scoreCell}>


### PR DESCRIPTION
## What was broken

Platform UI PR #2082 added a checkpoint-winner star and eligibility tooltip by matching checkpoint winner member IDs, and PR #2096 refreshed winner data after Checkpoint Review closed. QA then found that a below-minimum checkpoint-review row for the same winning member also displayed the star and eligibility tooltip.

## Root cause

Challenge checkpoint-winner records identify the member but do not identify a submission. The Review table therefore marked every row for that member and ignored the row's threshold-derived PASS or NO PASS result.

## What was changed

- Require both checkpoint-winner membership and a PASS result on the specific Checkpoint Review row before showing the star and eligibility tooltip.
- Keep repeated passing rows for the winning member marked.
- Leave the independent AI Virus Scan Passed status unchanged.
- Update the Review documentation with the row-level eligibility rule.

## Any added/updated tests

- Add a same-member 0.00 NO PASS checkpoint-review row and verify it has no star or eligibility tooltip.
- Preserve coverage showing repeated passing rows for the winner remain marked.

## Validation

- `yarn test:no-watch --runInBand src/apps/review/src/lib/components/TableCheckpointSubmissions/TableCheckpointSubmissions.spec.tsx` — 1 suite and 1 test passed.
- `yarn test:no-watch --runInBand src/apps/review/src` — 48 suites and 171 tests passed.
- Changed component and spec ESLint validation — passed.
- `yarn run build` — passed with existing repository warnings.
- `yarn lint` was run and is blocked only by a pre-existing `no-confusing-arrow` error in `ReviewViewer.spec.tsx` on the current `dev` baseline; that unrelated file is not changed by this PR.
