### PR TITLE
PM-5827: Align Copilot pill with member stats

### DIFF
--- a/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.module.scss
+++ b/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.module.scss
@@ -127,6 +127,14 @@
     }
 }
 
+@include gtexl {
+    @container (min-width: 656px) {
+        .roleCard + .roleCard {
+            margin-left: $sp-10;
+        }
+    }
+}
+
 @container (max-width: 420px) {
     .roleCard {
         min-height: 58px;

--- a/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.spec.tsx
+++ b/src/apps/profiles/src/components/tc-achievements/TcSpecialRolesBanner/TcSpecialRolesBanner.spec.tsx
@@ -44,6 +44,16 @@ describe('TcSpecialRolesBanner styles', () => {
         expect(tcSpecialRolesBannerStyles).not
             .toMatch(/font-size: 22px;/)
     })
+
+    it('aligns the second role card with member stats on desktop', () => {
+        expect(tcSpecialRolesBannerStyles)
+            .toMatch(new RegExp(
+                '@include gtexl \\{[\\s\\S]*?'
+                + '@container \\(min-width: 656px\\) \\{[\\s\\S]*?'
+                + '\\.roleCard \\+ \\.roleCard \\{[\\s\\S]*?'
+                + 'margin-left: \\$sp-10;',
+            ))
+    })
 })
 
 /**


### PR DESCRIPTION
## What was broken

On desktop profiles with reviewer and copilot roles, the Copilot pill began 40px to the left of the Member Stats card.

## Root cause (if identifiable)

The role pills use an equal grid with a 16px gap, while TCO and Member Stats use an asymmetric flex row with a 32px gap. The independent layouts produced different second-column offsets.

## What was changed

Inset only the second role card by 40px when both the desktop and two-column container thresholds are met. This preserves the shared right edge and leaves single-role and stacked layouts unchanged.

## Any added/updated tests

Added a stylesheet regression assertion for the desktop and container guards plus the second-card offset.

- `yarn test:no-watch --runInBand --silent src/apps/profiles/src`: passed, 16 suites and 80 tests.
- `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- `yarn test:no-watch`: run; 211 suites and 1,021 tests passed, while 18 unrelated suites and 32 tests failed in Engagements, Payments, Wallet Admin, and Challenge Editor areas untouched by this ticket.
