### PR TITLE
PM-5787: Preserve reviewer assignments without screener

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
@@ -631,6 +631,76 @@ describe('HumanReviewTab', () => {
         })
     })
 
+    it('keeps a Reviewer resource on Review when Screening has no assigned Screener', async () => {
+        mockedUseFetchResourceRoles.mockReturnValue({
+            resourceRoles: [
+                {
+                    id: 'role-screener',
+                    name: 'Screener',
+                },
+                {
+                    id: 'role-reviewer',
+                    name: 'Reviewer',
+                },
+            ],
+        })
+        mockedUseFetchResources.mockReturnValue({
+            isLoading: false,
+            mutate: jest.fn()
+                .mockResolvedValue(undefined),
+            resources: [
+                {
+                    memberId: 'member-reviewer',
+                    roleId: 'role-reviewer',
+                },
+            ],
+        })
+
+        render(
+            <TestHarness
+                defaultValues={{
+                    phases: [
+                        {
+                            id: 'screening-instance',
+                            name: 'Screening',
+                            phaseId: 'phase-screening',
+                        },
+                        {
+                            id: 'review-instance',
+                            name: 'Review',
+                            phaseId: 'phase-review',
+                        },
+                    ],
+                    reviewers: [
+                        {
+                            additionalMemberIds: [],
+                            isMemberReview: true,
+                            memberReviewerCount: 1,
+                            phaseId: 'phase-screening',
+                            shouldOpenOpportunity: false,
+                        },
+                        {
+                            additionalMemberIds: [],
+                            isMemberReview: true,
+                            memberReviewerCount: 1,
+                            phaseId: 'phase-review',
+                            shouldOpenOpportunity: false,
+                        },
+                    ],
+                }}
+            />,
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('reviewers.0.memberId')
+                .getAttribute('data-value'))
+                .toBe('')
+            expect(screen.getByTestId('reviewers.1.memberId')
+                .getAttribute('data-value'))
+                .toBe('member-reviewer')
+        })
+    })
+
     it('restores iterative reviewer member ids from the generic reviewer role fallback', async () => {
         mockedUseFetchResourceRoles.mockReturnValue({
             resourceRoles: [

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewerAssignments.utils.spec.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewerAssignments.utils.spec.ts
@@ -9,6 +9,60 @@ import {
 } from './reviewerAssignments.utils'
 
 describe('buildAssignedResourcesByReviewer', () => {
+    it('reserves generic reviewer resources for Review rows before Screening fallbacks', () => {
+        const resourceRoles: ResourceRole[] = [
+            {
+                id: 'role-screener',
+                name: 'Screener',
+            },
+            {
+                id: 'role-reviewer',
+                name: 'Reviewer',
+            },
+        ]
+        const resources: Resource[] = [
+            {
+                challengeId: 'challenge-1',
+                memberHandle: 'reviewer-one',
+                roleId: 'role-reviewer',
+            },
+        ]
+        const reviewers: Reviewer[] = [
+            {
+                memberReviewerCount: 1,
+                phaseId: 'phase-screening',
+                roleId: 'role-reviewer',
+            },
+            {
+                memberReviewerCount: 1,
+                phaseId: 'phase-review',
+            },
+        ]
+        const assignedResourcesByReviewer = buildAssignedResourcesByReviewer({
+            getReviewerCount: reviewer => Number(reviewer.memberReviewerCount || 1),
+            phaseNameById: new Map([
+                [
+                    'phase-screening',
+                    'Screening',
+                ],
+                [
+                    'phase-review',
+                    'Review',
+                ],
+            ]),
+            resourceRoles,
+            resources,
+            reviewers,
+        })
+
+        expect(assignedResourcesByReviewer.map(assignedResources => assignedResources
+            .map(resource => resource.memberHandle)))
+            .toEqual([
+                [],
+                ['reviewer-one'],
+            ])
+    })
+
     it('continues into the generic reviewer pool when a specific role runs out of resources', () => {
         const resourceRoles: ResourceRole[] = [
             {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewerAssignments.utils.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewerAssignments.utils.ts
@@ -111,6 +111,7 @@ function resourceMatchesReviewerRole(
 }
 
 interface ReviewerRoleMatchGroup {
+    isFallback: boolean
     key: string
     roleId?: string
     roleNames: string[]
@@ -133,11 +134,19 @@ function getReviewerRoleMatchGroups(
     const seenKeys = new Set<string>()
     const explicitRoleId = normalizeReviewerText(reviewer.roleId)
     const phaseName = phaseNameById.get(normalizeReviewerText(reviewer.phaseId))
+    const roleNameGroups = getReviewerRoleNameGroupsForPhaseName(phaseName)
 
     if (explicitRoleId) {
         const explicitRoleKey = `id:${explicitRoleId}`
+        const explicitRoleName = resourceRoles.find(
+            role => normalizeReviewerText(role.id) === explicitRoleId,
+        )?.name
+        const isGenericFallback = roleNameGroups.length > 1
+            && normalizeReviewerRoleKey(explicitRoleName)
+                === normalizeReviewerRoleKey(GENERIC_REVIEWER_ROLE_NAMES[0])
 
         groups.push({
+            isFallback: isGenericFallback,
             key: explicitRoleKey,
             roleId: explicitRoleId,
             roleNames: [],
@@ -145,8 +154,8 @@ function getReviewerRoleMatchGroups(
         seenKeys.add(explicitRoleKey)
     }
 
-    getReviewerRoleNameGroupsForPhaseName(phaseName)
-        .forEach(roleNames => {
+    roleNameGroups
+        .forEach((roleNames, groupIndex) => {
             const resolvedRoleId = roleNames
                 .map(roleName => resourceRoles.find(
                     role => normalizeReviewerRoleKey(role.name) === normalizeReviewerRoleKey(roleName),
@@ -162,6 +171,7 @@ function getReviewerRoleMatchGroups(
             }
 
             groups.push({
+                isFallback: groupIndex > 0,
                 key: nextKey,
                 roleId: resolvedRoleId,
                 roleNames,
@@ -185,10 +195,13 @@ interface BuildAssignedResourcesByReviewerParams {
  *
  * Reviewer assignments are stored per role rather than per reviewer row. This helper
  * mirrors Work Manager by consuming resources sequentially for repeated rows that share
- * the same role pool, while still honoring persisted `reviewer.roleId` values first and
- * falling back to the generic `Reviewer` role when legacy design drafts were saved that way.
- * If a phase-specific role pool is partially or fully exhausted, allocation continues into
- * later fallback groups so mixed legacy resource layouts still show every assigned reviewer.
+ * the same role pool, while still honoring persisted phase-specific `reviewer.roleId` values
+ * and falling back to the generic `Reviewer` role when legacy design drafts were saved that way.
+ * Primary role pools are allocated across all rows before legacy fallbacks so an empty specific
+ * role, such as Screener, cannot consume a generic resource needed by a later Review row, even if
+ * the specialized row persisted the generic role id. If a phase-specific role pool is partially or
+ * fully exhausted, remaining resources are then allocated from fallback groups so mixed legacy
+ * resource layouts still show every assigned reviewer.
  *
  * @param params reviewer rows, resources, resource roles, and a reviewer-count resolver.
  * @returns a row-aligned list of matching persisted resources for each reviewer row.
@@ -197,46 +210,52 @@ export function buildAssignedResourcesByReviewer(
     params: BuildAssignedResourcesByReviewerParams,
 ): Resource[][] {
     const roleOffsets = new Map<string, number>()
-
-    return params.reviewers.map(reviewer => {
-        const reviewerCount = Math.max(1, params.getReviewerCount(reviewer))
-        const roleMatchGroups = getReviewerRoleMatchGroups(
+    const reviewerAllocations = params.reviewers.map(reviewer => ({
+        assignedResources: [] as Resource[],
+        reviewerCount: Math.max(1, params.getReviewerCount(reviewer)),
+        roleMatchGroups: getReviewerRoleMatchGroups(
             reviewer,
             params.phaseNameById,
             params.resourceRoles,
-        )
-        const assignedResources: Resource[] = []
+        ),
+    }))
 
-        for (const roleMatchGroup of roleMatchGroups) {
-            const matchingResources = params.resources
-                .filter(resource => resourceMatchesReviewerRole(
-                    resource,
-                    roleMatchGroup.roleId,
-                    roleMatchGroup.roleNames,
-                ))
+    for (const isFallbackPass of [
+        false,
+        true,
+    ]) {
+        reviewerAllocations.forEach(allocation => {
+            allocation.roleMatchGroups
+                .filter(roleMatchGroup => roleMatchGroup.isFallback === isFallbackPass)
+                .forEach(roleMatchGroup => {
+                    if (allocation.assignedResources.length >= allocation.reviewerCount) {
+                        return
+                    }
 
-            if (matchingResources.length) {
-                const roleOffset = roleOffsets.get(roleMatchGroup.key) || 0
+                    const matchingResources = params.resources
+                        .filter(resource => resourceMatchesReviewerRole(
+                            resource,
+                            roleMatchGroup.roleId,
+                            roleMatchGroup.roleNames,
+                        ))
+                    const roleOffset = roleOffsets.get(roleMatchGroup.key) || 0
 
-                if (roleOffset < matchingResources.length) {
-                    const remainingReviewerSlots = reviewerCount - assignedResources.length
-                    const allocatedResources = matchingResources.slice(
-                        roleOffset,
-                        roleOffset + remainingReviewerSlots,
-                    )
+                    if (roleOffset < matchingResources.length) {
+                        const remainingReviewerSlots = allocation.reviewerCount
+                            - allocation.assignedResources.length
+                        const allocatedResources = matchingResources.slice(
+                            roleOffset,
+                            roleOffset + remainingReviewerSlots,
+                        )
 
-                    if (allocatedResources.length) {
-                        roleOffsets.set(roleMatchGroup.key, roleOffset + allocatedResources.length)
-                        assignedResources.push(...allocatedResources)
-
-                        if (assignedResources.length >= reviewerCount) {
-                            break
+                        if (allocatedResources.length) {
+                            roleOffsets.set(roleMatchGroup.key, roleOffset + allocatedResources.length)
+                            allocation.assignedResources.push(...allocatedResources)
                         }
                     }
-                }
-            }
-        }
+                })
+        })
+    }
 
-        return assignedResources
-    })
+    return reviewerAllocations.map(allocation => allocation.assignedResources)
 }


### PR DESCRIPTION
## What was broken

The first PM-5787 fix made the standard Screening member optional and taught Autopilot to wait for a Screener, but QA found a reload regression: when Screening was left empty, the member assigned to Review appeared under Screening and Review became blank.

## Root cause

The challenge stores reviewer members as role-based resources and reconstructs the reviewer rows during hydration. The shared allocator processed Screening first and immediately used its legacy generic `Reviewer` fallback, consuming the resource that belonged to the later Review row. A legacy generic role id already persisted on Screening could produce the same result.

## What was changed

- Allocate phase-specific and other primary role pools across all reviewer rows before using generic fallbacks.
- Treat an explicit generic `Reviewer` role on a specialized phase as a fallback, so previously affected drafts are handled too.
- Preserve the existing sequential generic fallback behavior for legacy challenges after primary assignments are reserved.
- Keep the merged Autopilot waiting behavior unchanged because it does not create or remap reviewer resources.

## Any added/updated tests

- Added allocator coverage for empty Screening plus assigned Review, including a generic role id already persisted on Screening.
- Added editable reviewer hydration coverage confirming Screening remains empty and Review retains its member.
- PM-5787-focused tests pass: 2 suites, 28 tests.
- `yarn lint` and `yarn run build` pass; the build retains existing repository warnings.
- The full repository command was run: 220 suites and 1,063 tests passed. The same documented baseline of 18 unrelated suites still fails because of stale budget-approval fixtures, missing mocks, and unresolved test aliases.
