### PR TITLE
PM-5850: restore support rich text formatting

### DIFF
--- a/src/apps/support/src/lib/components/MarkdownContent/MarkdownContent.module.scss
+++ b/src/apps/support/src/lib/components/MarkdownContent/MarkdownContent.module.scss
@@ -1,6 +1,59 @@
+@import '@libs/ui/styles/includes';
+
 .markdown {
     line-height: 1.55;
     overflow-wrap: anywhere;
+
+    a,
+    a:hover {
+        color: $link-blue-dark;
+        text-decoration: underline;
+    }
+
+    strong {
+        font-weight: $font-weight-bold;
+    }
+
+    em {
+        font-style: italic;
+    }
+
+    h1,
+    h2,
+    h3 {
+        font-weight: $font-weight-bold;
+        margin: $sp-4 0 $sp-2;
+    }
+
+    h1 {
+        font-size: 24px;
+        line-height: 28px;
+    }
+
+    h2 {
+        font-size: 20px;
+        line-height: 24px;
+    }
+
+    h3 {
+        font-size: 18px;
+        line-height: 22px;
+    }
+
+    ol,
+    ul {
+        list-style-position: outside;
+        margin: $sp-3 0;
+        padding-left: $sp-6;
+    }
+
+    ol {
+        list-style-type: decimal;
+    }
+
+    ul {
+        list-style-type: disc;
+    }
 
     > :first-child {
         margin-top: 0;

--- a/src/apps/support/src/lib/components/MarkdownContent/MarkdownContent.spec.tsx
+++ b/src/apps/support/src/lib/components/MarkdownContent/MarkdownContent.spec.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import { readFileSync } from 'fs'
+import { render, screen } from '@testing-library/react'
+import remarkBreaks from 'remark-breaks'
+import remarkGfm from 'remark-gfm'
+
+import { MarkdownContent } from './MarkdownContent'
+
+interface MarkdownRendererProps {
+    children: string
+    remarkPlugins: unknown[]
+    skipHtml: boolean
+}
+
+const mockReactMarkdown = jest.fn()
+
+jest.mock('react-markdown', () => ({
+    __esModule: true,
+    default: (props: MarkdownRendererProps): JSX.Element => {
+        mockReactMarkdown(props)
+        return <div data-testid='markdown-source'>{props.children}</div>
+    },
+}))
+
+jest.mock('remark-breaks', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}))
+
+jest.mock('remark-gfm', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}))
+
+const markdownStyles = readFileSync(`${__dirname}/MarkdownContent.module.scss`, 'utf8')
+const ticketDetailStyles = readFileSync(
+    `${__dirname}/../../../pages/ticket-details/TicketDetailPage.module.scss`,
+    'utf8',
+)
+
+describe('MarkdownContent', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('passes rich formatting and uploaded-file Markdown to the safe GFM renderer', () => {
+        const markdown = [
+            '# Request heading',
+            '**Bold text** and *italic text*',
+            '[sample.zip](https://example.test/sample.zip)',
+            '- First item',
+            '1. First step',
+        ].join('\n\n')
+
+        render(<MarkdownContent markdown={markdown} />)
+
+        expect(screen.getByTestId('markdown-source').textContent)
+            .toBe(markdown)
+        expect(mockReactMarkdown)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                children: markdown,
+                remarkPlugins: [remarkGfm, remarkBreaks],
+                skipHtml: true,
+            }))
+    })
+
+    it('keeps Markdown formatting visible after the platform style reset', () => {
+        expect(markdownStyles)
+            .toMatch(/a,[\s\S]*a:hover \{[\s\S]*color: \$link-blue-dark;[\s\S]*text-decoration: underline;/)
+        expect(markdownStyles)
+            .toMatch(/strong \{[\s\S]*font-weight: \$font-weight-bold;/)
+        expect(markdownStyles)
+            .toMatch(/em \{[\s\S]*font-style: italic;/)
+        expect(markdownStyles)
+            .toMatch(/h1,[\s\S]*h2,[\s\S]*h3 \{[\s\S]*font-weight: \$font-weight-bold;/)
+        expect(markdownStyles)
+            .toMatch(/ol \{[\s\S]*list-style-type: decimal;/)
+        expect(markdownStyles)
+            .toMatch(/ul \{[\s\S]*list-style-type: disc;/)
+    })
+
+    it('limits conversation timeline styling to top-level messages', () => {
+        expect(ticketDetailStyles)
+            .toMatch(/\.timeline \{[\s\S]*> li \{/)
+        expect(ticketDetailStyles)
+            .toMatch(/\.timeline > li \{/)
+        expect(ticketDetailStyles)
+            .not.toMatch(/\.timeline li \{/)
+    })
+})

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.module.scss
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.module.scss
@@ -107,7 +107,7 @@
     margin: 0;
     padding: 0;
 
-    li {
+    > li {
         border-left: 3px solid #9acfd3;
         padding: 0 0 $sp-5 $sp-5;
         position: relative;
@@ -182,7 +182,7 @@
         flex-direction: column;
     }
 
-    .timeline li {
+    .timeline > li {
         padding-left: $sp-4;
     }
 


### PR DESCRIPTION
## What was broken

Support ticket descriptions and replies displayed headings, bold and italic text, links, uploaded filenames, and lists with plain reset styling. Nested Markdown list items also inherited the conversation timeline rail and dot.

## Root cause

The platform CSS reset removes default heading, link, and list presentation, while the Support Markdown renderer did not restore scoped styles. The ticket timeline selector targeted every descendant list item instead of only top-level messages. Uploaded files were already valid Markdown links, but the reset made them look like plain text.

## What was changed

- Added scoped Support Markdown styles for headings, bold and italic text, links, and ordered and unordered lists.
- Limited timeline styling to direct conversation children so nested Markdown lists render normally.
- Preserved the existing safe Markdown and Filestack upload pipeline; uploaded filenames now appear as visibly clickable attachment links.

## Any added/updated tests

- Added `MarkdownContent` regression coverage for safe GFM configuration, attachment Markdown, required presentation rules, and direct-child timeline scoping.
- `yarn lint` passed.
- All Support tests passed: 8 suites and 22 tests.
- `yarn run build` passed with existing repository warnings.
- The full `yarn test:no-watch` run has 19 failing suites and 38 failing tests in unrelated areas. An untouched `origin/dev` worktree reproduced the same 19 failing suites and 38 failing tests; this branch adds one passing suite and three passing tests without adding failures.
