### PR TITLE
PM-5845: Refresh support ticket assignments

### DIFF
--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
@@ -18,6 +18,25 @@ const mockMutate = jest.fn()
 const mockUseSWR = jest.fn()
 let mockProfile: { roles: string[]; userId: number | string }
 
+interface Deferred<T> {
+    promise: Promise<T>
+    resolve: (value: T) => void
+}
+
+/**
+ * Creates a promise whose completion can be controlled by the test.
+ *
+ * @returns deferred promise and its resolver.
+ * @throws Does not throw.
+ */
+function createDeferred<T>(): Deferred<T> {
+    let resolve: (value: T) => void = () => undefined
+    const promise = new Promise<T>(promiseResolve => {
+        resolve = promiseResolve
+    })
+    return { promise, resolve }
+}
+
 jest.mock('swr', () => ({
     __esModule: true,
     default: (...args: unknown[]) => mockUseSWR(...args),
@@ -138,6 +157,9 @@ describe('TicketDetailPage closed reply access', () => {
         async () => {
             render(<TicketDetailPage />)
 
+            expect(mockUseSWR.mock.calls[0][2])
+                .toEqual({ revalidateOnFocus: true, shouldRetryOnError: false })
+
             const challengeLink = screen.getByRole('link', { name: 'View challenge' })
             expect(challengeLink.getAttribute('href'))
                 .toBe('https://www.example.test/challenges/challenge%2Fid')
@@ -172,5 +194,51 @@ describe('TicketDetailPage closed reply access', () => {
             .toBeNull()
         expect(screen.getByText('This ticket is closed and cannot receive more replies.'))
             .toBeTruthy()
+    })
+
+    it('preserves freshly revalidated assignees when marking a ticket read completes', async () => {
+        const markReadRequest = createDeferred<void>()
+        mockedMarkRead.mockReturnValue(markReadRequest.promise)
+        mockUseSWR.mockReturnValue({
+            data: { ...closedTicket, hasUnread: true },
+            error: undefined,
+            isValidating: false,
+            mutate: mockMutate,
+        })
+
+        render(<TicketDetailPage />)
+        markReadRequest.resolve(undefined)
+
+        await waitFor(() => {
+            expect(mockMutate)
+                .toHaveBeenCalledWith(expect.any(Function), false)
+        })
+
+        const updateCachedTicket = mockMutate.mock.calls[0][0] as (
+            ticket?: SupportTicketDetail,
+        ) => SupportTicketDetail | undefined
+        const freshlyRevalidatedTicket: SupportTicketDetail = {
+            ...closedTicket,
+            assignees: [{
+                assignedAt: '2026-08-07T01:30:00.000Z',
+                handle: 'support-staff',
+                userId: '67890',
+            }],
+            hasUnread: true,
+            responseCount: 1,
+            responses: [{
+                createdAt: '2026-08-07T01:30:00.000Z',
+                id: 'response-1',
+                markdown: 'We are investigating.',
+                readBy: [],
+                userHandle: 'support-staff',
+                userId: '67890',
+            }],
+        }
+
+        expect(updateCachedTicket(freshlyRevalidatedTicket))
+            .toEqual({ ...freshlyRevalidatedTicket, hasUnread: false })
+        expect(updateCachedTicket(undefined))
+            .toBeUndefined()
     })
 })

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
@@ -67,7 +67,7 @@ export const TicketDetailPage: FC = () => {
     const { data, error, isValidating, mutate } = useSWR<SupportTicketDetail>(
         requestKey,
         () => getSupportTicket(ticketId as string),
-        { revalidateOnFocus: false, shouldRetryOnError: false },
+        { revalidateOnFocus: true, shouldRetryOnError: false },
     )
 
     useEffect(() => {
@@ -75,7 +75,9 @@ export const TicketDetailPage: FC = () => {
 
         markedReadTicket.current = data.id
         markSupportTicketRead(data.id)
-            .then(() => mutate({ ...data, hasUnread: false }, false))
+            .then(() => mutate(current => (current
+                ? { ...current, hasUnread: false }
+                : current), false))
             .catch(() => undefined)
     }, [data, mutate])
 

--- a/src/apps/support/src/pages/tickets/TicketsPage.spec.tsx
+++ b/src/apps/support/src/pages/tickets/TicketsPage.spec.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render } from '@testing-library/react'
+
+import { OpenTicketsPage } from './TicketsPage'
+
+const mockUseSWR = jest.fn()
+
+jest.mock('swr', () => ({
+    __esModule: true,
+    default: (...args: unknown[]) => mockUseSWR(...args),
+}))
+
+jest.mock('react-router-dom', () => ({
+    useNavigate: () => jest.fn(),
+    useSearchParams: () => [new URLSearchParams(), jest.fn()],
+}))
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: { API: { V6: 'https://api.example.test/v6' } },
+}), { virtual: true })
+
+jest.mock('~/libs/core', () => ({
+    useProfileContext: () => ({
+        profile: { roles: ['Topcoder User'], userId: 12345 },
+    }),
+    UserRole: { topcoderSupportTeam: 'Topcoder Support Team' },
+}), { virtual: true })
+
+jest.mock('~/libs/ui', () => ({
+    Button: () => <></>,
+}), { virtual: true })
+
+jest.mock('../../config/routes.config', () => ({
+    buildSupportPath: (...segments: string[]) => `/support/${segments.join('/')}`,
+}))
+
+jest.mock('../../lib/components', () => ({
+    MemberHandleAutocomplete: () => <></>,
+    OpenSupportRequestModal: () => <></>,
+    SupportEmpty: () => <></>,
+    SupportError: () => <></>,
+    SupportLoading: () => <></>,
+    SupportTabs: () => <></>,
+    TicketsTable: () => <></>,
+}))
+
+jest.mock('../../lib/services', () => ({
+    assignSupportTicketToMe: jest.fn(),
+    buildTicketListUrl: () => 'support-tickets',
+    getSupportTickets: jest.fn(),
+}))
+
+describe('TicketsPage cache freshness', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUseSWR.mockReturnValue({
+            data: undefined,
+            error: undefined,
+            isValidating: true,
+            mutate: jest.fn(),
+        })
+    })
+
+    it('refreshes ticket assignments when the requester returns to the page', () => {
+        render(<OpenTicketsPage />)
+
+        expect(mockUseSWR.mock.calls[0][2])
+            .toEqual({ revalidateOnFocus: true, shouldRetryOnError: false })
+    })
+})

--- a/src/apps/support/src/pages/tickets/TicketsPage.tsx
+++ b/src/apps/support/src/pages/tickets/TicketsPage.tsx
@@ -114,7 +114,7 @@ const TicketsPage: FC<TicketsPageProps> = props => {
     const { data, error, isValidating, mutate } = useSWR(
         requestKey,
         () => getSupportTickets(query),
-        { revalidateOnFocus: false, shouldRetryOnError: false },
+        { revalidateOnFocus: true, shouldRetryOnError: false },
     )
 
     /**


### PR DESCRIPTION
## What was broken

Ticket raisers could continue seeing `Unassigned` and stale ticket content after support staff assigned themselves or added a response.

Jira: [PM-5845](https://topcoder.atlassian.net/browse/PM-5845)

## Root cause

The ticket list and detail views explicitly disabled SWR focus revalidation. The detail page's asynchronous mark-read completion also wrote a captured ticket snapshot back to the cache, which could overwrite newly fetched assignees and responses.

## What was changed

- Enabled focus revalidation for ticket list and detail data.
- Changed mark-read cache handling to update only `hasUnread` on the latest cached ticket.
- Kept the API contract and assignment behavior unchanged.

## Any added/updated tests

- Added `TicketsPage` coverage for assignment refresh on focus.
- Extended `TicketDetailPage` coverage for focus refresh and the mark-read/revalidation race.
- All 8 Support app suites pass (21 tests); lint and the production build pass.
- The complete monorepo test command was run. Its 19 failing suites and 38 failing tests are identical on untouched `origin/dev`, so this change introduces no new full-suite failures.


[PM-5845]: https://topcoder.atlassian.net/browse/PM-5845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ