### PR TITLE
PM-5844: Require assignment before support replies

### DIFF
--- a/src/apps/support/README.md
+++ b/src/apps/support/README.md
@@ -3,7 +3,7 @@
 The Support subapp lets authenticated Topcoder members open requests, follow
 their status, and reply to the Topcoder Support Team. Users with the exact
 `Topcoder Support Team` role can see all tickets, assign themselves, search
-closed tickets, reply, and close resolved requests.
+closed tickets, reply to tickets assigned to them, and close resolved requests.
 
 ## Routes
 

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
@@ -110,7 +110,7 @@ const closedTicket: SupportTicketDetail = {
     updatedAt: '2026-08-07T01:00:00.000Z',
 }
 
-describe('TicketDetailPage closed reply access', () => {
+describe('TicketDetailPage reply access', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockProfile = {
@@ -172,5 +172,58 @@ describe('TicketDetailPage closed reply access', () => {
             .toBeNull()
         expect(screen.getByText('This ticket is closed and cannot receive more replies.'))
             .toBeTruthy()
+    })
+
+    it('requires non-owner support staff to assign an open ticket before replying', () => {
+        mockProfile = {
+            roles: ['Topcoder Support Team'],
+            userId: 99999,
+        }
+        mockUseSWR.mockReturnValue({
+            data: {
+                ...closedTicket,
+                closedAt: undefined,
+                status: 'OPEN',
+            },
+            error: undefined,
+            isValidating: false,
+            mutate: mockMutate,
+        })
+
+        render(<TicketDetailPage />)
+
+        expect(screen.queryByLabelText('Reply'))
+            .toBeNull()
+        expect(screen.getByText('Assign this ticket to yourself before replying.'))
+            .toBeTruthy()
+    })
+
+    it('lets assigned support staff reply to an open ticket', () => {
+        mockProfile = {
+            roles: ['Topcoder Support Team'],
+            userId: 99999,
+        }
+        mockUseSWR.mockReturnValue({
+            data: {
+                ...closedTicket,
+                assignees: [{
+                    assignedAt: '2026-08-07T00:30:00.000Z',
+                    handle: 'support-agent',
+                    userId: '99999',
+                }],
+                closedAt: undefined,
+                status: 'OPEN',
+            },
+            error: undefined,
+            isValidating: false,
+            mutate: mockMutate,
+        })
+
+        render(<TicketDetailPage />)
+
+        expect(screen.getByLabelText('Reply'))
+            .toBeTruthy()
+        expect(screen.queryByText('Assign this ticket to yourself before replying.'))
+            .toBeNull()
     })
 })

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
@@ -105,7 +105,7 @@ export const TicketDetailPage: FC = () => {
     ))
     const closed = data.status === 'CLOSED'
     const ticketOwner = Boolean(currentUserId && String(data.memberUserId) === currentUserId)
-    const canReply = !closed || ticketOwner
+    const canReply = ticketOwner || (!closed && (!supportTeam || assignedToCurrentUser))
     const replyContext = `${data.id}-reply-${replyRevision}`
 
     /**
@@ -332,7 +332,11 @@ export const TicketDetailPage: FC = () => {
                     </div>
                 </section>
             ) : (
-                <p className={styles.closedNotice}>This ticket is closed and cannot receive more replies.</p>
+                <p className={styles.closedNotice}>
+                    {closed
+                        ? 'This ticket is closed and cannot receive more replies.'
+                        : 'Assign this ticket to yourself before replying.'}
+                </p>
             )}
 
             <BaseModal


### PR DESCRIPTION
## What was broken

Support Team members could open the reply editor and submit a response without first assigning the ticket to themselves.

## Root cause

The ticket detail page allowed replies based only on ticket status and ownership, ignoring the current support user's assignment.

## What was changed

The reply editor is now hidden from unassigned, non-owner support users and replaced with a prompt to assign the ticket first. Ticket owners retain their existing reply and reopen behavior, including owners who also have the Support Team role. The Support app documentation now reflects the assignment requirement.

## Any added/updated tests

Added component tests proving that unassigned support users cannot access the reply editor and assigned support users can. The focused Support test suite, lint, and production build pass. The full monorepo test run retains the same 19 unrelated failing suites present on the untouched dev baseline.
