### PR TITLE
PM-5194: Allow Fun challenges to launch without approval

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx
@@ -592,6 +592,41 @@ describe('ChallengeEditorPage', () => {
             .toBe(true)
     })
 
+    it('keeps launch enabled for a fun challenge without budget approval', async () => {
+        mockedUseFetchChallenge.mockReturnValue({
+            challenge: {
+                approvalStatus: 'PENDING_APPROVAL',
+                discussions: [{
+                    url: 'https://example.com/forum/challenges/456',
+                }],
+                funChallenge: true,
+                id: '456',
+                name: 'Fun challenge',
+                prizeSets: [],
+                status: 'DRAFT',
+            },
+            error: undefined,
+            isLoading: false,
+            mutate: jest.fn(),
+        })
+
+        renderPage(
+            '/projects/123/challenges/456/view',
+            '/projects/:projectId/challenges/:challengeId/view',
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText('Challenge View Form'))
+                .toBeTruthy()
+        })
+
+        expect(screen.getAllByRole('button', { name: 'Launch' }))
+            .toHaveLength(2)
+        expect(screen.getAllByRole('button', { name: 'Launch' })
+            .every(button => !(button as HTMLButtonElement).disabled))
+            .toBe(true)
+    })
+
     it('keeps launch enabled when challenge budget is approved', async () => {
         mockedUseFetchChallenge.mockReturnValue({
             challenge: {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.tsx
@@ -1287,7 +1287,10 @@ export const ChallengeEditorPage: FC = () => {
     const isBudgetApproved = isBudgetApprovedForLaunch(
         challengeApprovalStatus || headerChallenge?.approvalStatus,
     )
-    const isLaunchDisabled = isLaunching || isSavingChallenge || !isBudgetApproved
+    const requiresBudgetApproval = headerChallenge?.funChallenge !== true
+    const isLaunchDisabled = isLaunching
+        || isSavingChallenge
+        || (requiresBudgetApproval && !isBudgetApproved)
     const handleSavingChange = useCallback((isSaving: boolean): void => {
         setIsSavingChallenge(isSaving)
     }, [])

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -134,6 +134,8 @@ The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/cha
 ## Header Actions
 
 - `Launch` is shown on the details tab for `DRAFT` challenges in the header for both view and edit routes, and again in the footer beside `Save Challenge` while editing.
+- Fun challenges bypass the manual budget-approval launch gate; other challenge types require an
+  approved budget before launch.
 - Read-only view routes repeat the available `Edit`, `Launch`, `Cancel`, and `Mark Complete` actions at the bottom of the page. Challenge quick links remain in the header only.
 - The work app blocks launch attempts when the parent project billing account is inactive, expired, or has insufficient remaining funds, matching the legacy work-manager launch restriction.
 - Task challenges cannot be launched until `Assigned Member` is set, which ensures the task is assigned before it becomes publicly visible.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -838,6 +838,7 @@ describe('ChallengeEditorForm', () => {
     } as Challenge
     const validDraftChallenge = {
         ...draftChallenge,
+        approvalStatus: 'APPROVED',
         description: 'Valid public specification for the attachment save regression test.',
         prizeSets: [{
             prizes: [{
@@ -959,7 +960,11 @@ describe('ChallengeEditorForm', () => {
             },
         })
         mockedUseFetchProjectBillingAccount.mockReturnValue({
-            billingAccount: undefined,
+            billingAccount: {
+                active: true,
+                id: '80001063',
+                totalBudgetRemaining: 500,
+            },
             isLoading: false,
         })
         mockedUseFetchResourceRoles.mockImplementation(() => ({
@@ -1181,7 +1186,10 @@ describe('ChallengeEditorForm', () => {
             <MemoryRouter>
                 <WorkAppContext.Provider value={managerContextValue}>
                     <ChallengeEditorForm
-                        challenge={validDraftChallenge}
+                        challenge={{
+                            ...validDraftChallenge,
+                            approvalStatus: 'PENDING_APPROVAL',
+                        }}
                         isReadOnly
                     />
                 </WorkAppContext.Provider>
@@ -1848,6 +1856,60 @@ describe('ChallengeEditorForm', () => {
                     status: 'ACTIVE',
                 }))
         })
+    })
+
+    it('launches a fun challenge without budget approval', async () => {
+        let launchAction: (() => Promise<void>) | undefined
+
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: {
+                active: true,
+                id: '80001063',
+                totalBudgetRemaining: 500,
+            },
+            isLoading: false,
+        })
+        mockedPatchChallenge.mockResolvedValue({
+            ...validDraftChallenge,
+            approvalStatus: 'APPROVED',
+            funChallenge: true,
+            status: 'ACTIVE',
+        })
+
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm
+                    challenge={{
+                        ...validDraftChallenge,
+                        approvalStatus: 'PENDING_APPROVAL',
+                        funChallenge: true,
+                    }}
+                    isReadOnly
+                    onRegisterLaunchAction={action => {
+                        launchAction = action
+                    }}
+                />
+            </MemoryRouter>,
+        )
+
+        await waitFor(() => {
+            expect(launchAction)
+                .toEqual(expect.any(Function))
+        })
+
+        await act(async () => {
+            await launchAction?.()
+        })
+
+        await waitFor(() => {
+            expect(mockedPatchChallenge)
+                .toHaveBeenCalledWith('12345', expect.objectContaining({
+                    funChallenge: true,
+                    status: 'ACTIVE',
+                }))
+        })
+        expect(mockedShowErrorToast)
+            .not.toHaveBeenCalledWith('Challenge launch is blocked until budget approval is Approved.')
     })
 
     it('launches a design draft before a screener member is assigned', async () => {
@@ -3378,6 +3440,11 @@ describe('ChallengeEditorForm', () => {
     it('blocks launch with a clear reason when the project has no billing account', async () => {
         let launchAction: (() => Promise<void>) | undefined
         let launchError: Error | undefined
+
+        mockedUseFetchProjectBillingAccount.mockReturnValue({
+            billingAccount: undefined,
+            isLoading: false,
+        })
 
         mockedUseFetchChallengeTracks.mockReturnValue({
             isLoading: false,

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -3220,6 +3220,7 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
 
             if (
                 isChallengeBeingActivated
+                && formData.funChallenge !== true
                 && normalizeStatus(formData.approvalStatus) !== CHALLENGE_APPROVAL_STATUS.APPROVED
             ) {
                 setSaveStatus('idle')


### PR DESCRIPTION
## What was broken

Fun challenges stayed unable to launch in platform-ui while their budget approval was pending. Both visible Launch controls were disabled, and the form save path separately rejected activation.

## Root cause

The challenge editor's page-level and form-level launch gates applied the manual budget-approval requirement to every challenge without considering the Fun challenge flag.

## What was changed

Fun challenges now bypass only the UI budget-approval gates. Existing billing-account, funds, task-assignment, and other launch validations remain unchanged. The challenge editor documentation now records the exception.

## Any added/updated tests

- Added a page regression confirming both Launch controls remain enabled for a pending Fun challenge.
- Added a form regression confirming launch sends an Active update without showing the approval-block error.
- Updated shared launch fixtures to explicitly satisfy the existing approval and billing prerequisites.
- `yarn test:no-watch --runTestsByPath src/apps/work/src/pages/challenges/ChallengeEditorPage/ChallengeEditorPage.spec.tsx src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx --silent`: 111 passed.
- `yarn lint`: passed.
- `yarn run build`: passed with existing project warnings.

The repository-wide `yarn test:no-watch` command was also attempted. It remains blocked by pre-existing Jest configuration failures, including unresolved shared aliases and an existing ESM dependency transform issue; the alias failure was reproduced from the untouched checkout.
