### PR TITLE
PM-5851: Scope unread indicators to assigned support tickets

### DIFF
--- a/src/apps/support/src/lib/components/TicketsTable/TicketsTable.spec.tsx
+++ b/src/apps/support/src/lib/components/TicketsTable/TicketsTable.spec.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
 import {
     fireEvent,
     render,
@@ -108,5 +109,68 @@ describe('TicketsTable challenge links', () => {
 
         expect(screen.queryByRole('link', { name: 'View challenge' }))
             .toBeNull()
+    })
+})
+
+describe('TicketsTable unread indicators', () => {
+    const unreadTicket: SupportTicketSummary = {
+        ...baseTicket,
+        assignees: [{
+            assignedAt: '2026-08-07T00:00:00.000Z',
+            handle: 'support-member',
+            userId: 'staff-1',
+        }],
+        hasUnread: true,
+        status: 'CLOSED',
+    }
+
+    it('shows unread indicators to the assigned support team member', () => {
+        render(
+            <TicketsTable
+                currentUserId='staff-1'
+                isSupportTeam
+                onAssign={jest.fn()}
+                onOpen={jest.fn()}
+                tickets={[unreadTicket]}
+            />,
+        )
+
+        expect(screen.getAllByText('Unread'))
+            .toHaveLength(2)
+        expect(screen.getByLabelText('Unread ticket: Unable to submit'))
+            .toHaveClass('unread')
+    })
+
+    it('hides unread indicators from support team members who are not assigned', () => {
+        render(
+            <TicketsTable
+                currentUserId='staff-2'
+                isSupportTeam
+                onAssign={jest.fn()}
+                onOpen={jest.fn()}
+                tickets={[unreadTicket]}
+            />,
+        )
+
+        expect(screen.queryByText('Unread'))
+            .toBeNull()
+        expect(screen.getByLabelText('Read ticket: Unable to submit'))
+            .not.toHaveClass('unread')
+    })
+
+    it('preserves unread indicators for an ordinary member', () => {
+        render(
+            <TicketsTable
+                isSupportTeam={false}
+                onAssign={jest.fn()}
+                onOpen={jest.fn()}
+                tickets={[{ ...unreadTicket, assignees: [] }]}
+            />,
+        )
+
+        expect(screen.getAllByText('Unread'))
+            .toHaveLength(2)
+        expect(screen.getByLabelText('Unread ticket: Unable to submit'))
+            .toHaveClass('unread')
     })
 })

--- a/src/apps/support/src/lib/components/TicketsTable/TicketsTable.tsx
+++ b/src/apps/support/src/lib/components/TicketsTable/TicketsTable.tsx
@@ -70,11 +70,11 @@ const Assignees = ({ ticket }: { ticket: SupportTicketSummary }): JSX.Element =>
 /**
  * Renders an accessible unread indicator that does not rely on color.
  *
- * @param ticket ticket summary.
+ * @param unread whether the ticket should appear unread to the current viewer.
  * @returns unread badge when required.
  * @throws Does not throw.
  */
-const UnreadBadge = ({ ticket }: { ticket: SupportTicketSummary }): JSX.Element => (ticket.hasUnread
+const UnreadBadge = ({ unread }: { unread: boolean }): JSX.Element => (unread
     ? (
         <span className={styles.unreadBadge}>
             <span aria-hidden='true'>●</span>
@@ -189,17 +189,18 @@ export const TicketsTable: FC<TicketsTableProps> = props => {
                     <tbody>
                         {props.tickets.map(ticket => {
                             const assigned = isTicketAssignedToUser(ticket, props.currentUserId)
+                            const unread = ticket.hasUnread && (!props.isSupportTeam || assigned)
                             return (
                                 <tr
-                                    aria-label={`${ticket.hasUnread ? 'Unread' : 'Read'} ticket: ${preview(ticket)}`}
-                                    className={classNames(ticket.hasUnread && styles.unread)}
+                                    aria-label={`${unread ? 'Unread' : 'Read'} ticket: ${preview(ticket)}`}
+                                    className={classNames(unread && styles.unread)}
                                     key={ticket.id}
                                     onClick={() => props.onOpen(ticket)}
                                     onKeyDown={event => handleKeyDown(event, ticket)}
                                     tabIndex={0}
                                 >
                                     <td>
-                                        <UnreadBadge ticket={ticket} />
+                                        <UnreadBadge unread={unread} />
                                         <span>{preview(ticket)}</span>
                                     </td>
                                     {props.isSupportTeam && (
@@ -236,12 +237,13 @@ export const TicketsTable: FC<TicketsTableProps> = props => {
             <div className={styles.mobile}>
                 {props.tickets.map(ticket => {
                     const assigned = isTicketAssignedToUser(ticket, props.currentUserId)
+                    const unread = ticket.hasUnread && (!props.isSupportTeam || assigned)
                     return (
                         <article
-                            className={classNames(styles.card, ticket.hasUnread && styles.unread)}
+                            className={classNames(styles.card, unread && styles.unread)}
                             key={ticket.id}
                         >
-                            <UnreadBadge ticket={ticket} />
+                            <UnreadBadge unread={unread} />
                             <h2>{preview(ticket)}</h2>
                             {props.isSupportTeam && (
                                 <p>


### PR DESCRIPTION
## What was broken

Support Team members saw unread badges and styling for tickets that were not assigned to them, including closed tickets.

## Root cause

The ticket table applied the API's per-viewer `hasUnread` value directly without considering whether a Support Team viewer was assigned to the ticket.

## What was changed

The displayed unread state now requires current-user assignment for Support Team viewers. That state is applied consistently to desktop and mobile badges, styling, and the desktop accessibility label, while ordinary members retain their existing unread behavior.

## Any added/updated tests

Added three `TicketsTable` regression cases covering the assigned Support Team member, another Support Team member viewing a closed ticket, and an ordinary member.

The focused suite passes all 5 tests. Lint passes and the production build completes successfully. The full repository suite has the same pre-existing 19 failing suites and 38 failing tests on `origin/dev`; this branch adds 3 passing tests (1,065 passing versus the baseline's 1,062).
