### PR TITLE
PM-5858: Require assignment before ticket closure

### DIFF
--- a/src/apps/support/README.md
+++ b/src/apps/support/README.md
@@ -3,7 +3,8 @@
 The Support subapp lets authenticated Topcoder members open requests, follow
 their status, and reply to the Topcoder Support Team. Users with the exact
 `Topcoder Support Team` role can see all tickets, assign themselves, search
-closed tickets, reply to tickets assigned to them, and close resolved requests.
+closed tickets, and reply to or close resolved requests assigned to them.
+Closed ticket details identify the Support Team user who closed the request.
 
 ## Routes
 

--- a/src/apps/support/src/lib/models/support.models.ts
+++ b/src/apps/support/src/lib/models/support.models.ts
@@ -33,6 +33,7 @@ export interface SupportTicketSummary {
     status: SupportTicketStatus
     openedAt: string
     closedAt?: string
+    closedByUserId?: string
     updatedAt: string
     latestActivityAt: string
     responseCount: number

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.spec.tsx
@@ -196,6 +196,49 @@ describe('TicketDetailPage reply access', () => {
             .toBeTruthy()
     })
 
+    it('identifies the support staff member who closed the ticket', () => {
+        mockUseSWR.mockReturnValue({
+            data: {
+                ...closedTicket,
+                assignees: [{
+                    assignedAt: '2026-08-07T00:30:00.000Z',
+                    handle: 'support-agent',
+                    userId: '99999',
+                }],
+                closedByUserId: '99999',
+            },
+            error: undefined,
+            isValidating: false,
+            mutate: mockMutate,
+        })
+
+        render(<TicketDetailPage />)
+
+        expect(screen.getByText((_content, element) => (
+            element?.tagName === 'P'
+            && element.textContent?.includes('Closed') === true
+            && element.textContent?.includes('by support-agent') === true
+        )))
+            .toBeTruthy()
+    })
+
+    it('falls back to the stored closer user ID when no assignee snapshot matches', () => {
+        mockUseSWR.mockReturnValue({
+            data: {
+                ...closedTicket,
+                closedByUserId: 'legacy-staff-1',
+            },
+            error: undefined,
+            isValidating: false,
+            mutate: mockMutate,
+        })
+
+        render(<TicketDetailPage />)
+
+        expect(screen.getByText('legacy-staff-1'))
+            .toBeTruthy()
+    })
+
     it('preserves freshly revalidated assignees when marking a ticket read completes', async () => {
         const markReadRequest = createDeferred<void>()
         mockedMarkRead.mockReturnValue(markReadRequest.promise)
@@ -242,7 +285,7 @@ describe('TicketDetailPage reply access', () => {
             .toBeUndefined()
     })
 
-    it('requires non-owner support staff to assign an open ticket before replying', () => {
+    it('requires non-owner support staff to assign an open ticket before replying or closing it', () => {
         mockProfile = {
             roles: ['Topcoder Support Team'],
             userId: 99999,
@@ -264,9 +307,13 @@ describe('TicketDetailPage reply access', () => {
             .toBeNull()
         expect(screen.getByText('Assign this ticket to yourself before replying.'))
             .toBeTruthy()
+        expect((screen.getByRole('button', {
+            name: 'Close support ticket',
+        }) as HTMLButtonElement).disabled)
+            .toBe(true)
     })
 
-    it('lets assigned support staff reply to an open ticket', () => {
+    it('lets assigned support staff reply to and close an open ticket', () => {
         mockProfile = {
             roles: ['Topcoder Support Team'],
             userId: 99999,
@@ -293,5 +340,9 @@ describe('TicketDetailPage reply access', () => {
             .toBeTruthy()
         expect(screen.queryByText('Assign this ticket to yourself before replying.'))
             .toBeNull()
+        expect((screen.getByRole('button', {
+            name: 'Close support ticket',
+        }) as HTMLButtonElement).disabled)
+            .toBe(false)
     })
 })

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
@@ -106,6 +106,9 @@ export const TicketDetailPage: FC = () => {
         assignee => String(assignee.userId) === currentUserId,
     ))
     const closed = data.status === 'CLOSED'
+    const closedByAssignee = data.closedByUserId
+        ? data.assignees.find(assignee => String(assignee.userId) === String(data.closedByUserId))
+        : undefined
     const ticketOwner = Boolean(currentUserId && String(data.memberUserId) === currentUserId)
     const canReply = ticketOwner || (!closed && (!supportTeam || assignedToCurrentUser))
     const replyContext = `${data.id}-reply-${replyRevision}`
@@ -234,6 +237,21 @@ export const TicketDetailPage: FC = () => {
                             Closed
                             {' '}
                             {formatSupportDate(data.closedAt)}
+                            {data.closedByUserId && (
+                                <>
+                                    {' '}
+                                    by
+                                    {' '}
+                                    <span>
+                                        {closedByAssignee ? (
+                                            <MemberHandle
+                                                color={closedByAssignee.handleColor}
+                                                handle={closedByAssignee.handle}
+                                            />
+                                        ) : data.closedByUserId}
+                                    </span>
+                                </>
+                            )}
                         </p>
                     )}
                 </div>
@@ -247,6 +265,7 @@ export const TicketDetailPage: FC = () => {
                             size='md'
                         />
                         <Button
+                            disabled={updatingAssignment || !assignedToCurrentUser}
                             label='Close support ticket'
                             onClick={() => setConfirmClose(true)}
                             primary


### PR DESCRIPTION
What was broken
Support Team members could close an unassigned ticket, and the closed-ticket detail did not identify who closed it.

Root cause
The close control checked only Support Team membership, and the UI contract omitted the closer ID already stored by the API.

What was changed
Disable closure unless the current Support Team user is assigned, accept the optional closer ID, and display the matching assignee handle with a stored-ID fallback.

Any added/updated tests
Updated TicketDetailPage coverage for unassigned and assigned closure access, closer-handle display, and legacy closer-ID fallback.

Validation
- Focused TicketDetailPage suite: 7/7 passed.
- Lint passed.
- Production build passed.
- Full monorepo suite: 1,082/1,109 tests passed; the 27 failures across 18 unrelated suites reproduce the existing baseline and do not touch the Support app.
