### PR TITLE
PM-5839: Render SFDC payment dates consistently

### DIFF
--- a/src/apps/reports/src/pages/reports/ReportsPage.spec.tsx
+++ b/src/apps/reports/src/pages/reports/ReportsPage.spec.tsx
@@ -17,9 +17,13 @@ import {
     useLocation,
 } from 'react-router-dom'
 
-import { fetchReportsIndex } from '../../lib/services'
+import {
+    fetchReportJson,
+    fetchReportsIndex,
+    SfdcBillingAccountPaymentRow,
+} from '../../lib/services'
 
-import { ReportsPage } from './ReportsPage'
+import { BillingAccountsPage, ReportsPage } from './ReportsPage'
 
 type MockSelectProps = {
     disabled?: boolean
@@ -86,6 +90,8 @@ jest.mock('../../lib/utils', () => ({
 }))
 
 const mockedFetchReportsIndex = fetchReportsIndex as jest.Mock
+const mockedFetchReportJson = fetchReportJson as jest.Mock
+const originalTimezone = process.env.TZ
 
 const LocationProbe = (): JSX.Element => {
     const { pathname }: { pathname: string } = useLocation()
@@ -107,6 +113,15 @@ describe('Reports page navigation', () => {
                 }],
             },
         })
+    })
+
+    afterEach(() => {
+        if (originalTimezone) {
+            process.env.TZ = originalTimezone
+            return
+        }
+
+        delete process.env.TZ
     })
 
     it('opens Bulk Member Lookup from the Reports app root', async () => {
@@ -136,5 +151,65 @@ describe('Reports page navigation', () => {
 
         expect(screen.getByTestId('location'))
             .toHaveTextContent('/reports/bulk-member-lookup')
+    })
+
+    it('renders SFDC payment dates in America/New_York', async () => {
+        process.env.TZ = 'Asia/Colombo'
+        const paymentDate = '2026-07-31T18:53:33.383-04:00'
+        const payment: SfdcBillingAccountPaymentRow = {
+            billingAccountId: '80000001',
+            category: 'CHALLENGE_PAYMENT',
+            challengeFee: '0.00',
+            challengeId: 'challenge-id',
+            challengeName: 'July payment',
+            challengeStatus: 'Completed',
+            isTask: false,
+            paymentAmount: '100.00',
+            paymentDate,
+            paymentId: 'payment-id',
+            paymentStatus: 'PAID',
+            winnerFirstName: 'Ada',
+            winnerHandle: 'ada',
+            winnerId: '123',
+            winnerLastName: 'Lovelace',
+        }
+        mockedFetchReportJson.mockResolvedValue([payment])
+
+        render(
+            <MemoryRouter initialEntries={['/reports/sfdc-payments']}>
+                <BillingAccountsPage />
+            </MemoryRouter>,
+        )
+
+        expect(await screen.findByText('July payment'))
+            .toBeInTheDocument()
+        const parsedPaymentDate = new Date(paymentDate)
+        const displayedDate = parsedPaymentDate
+            .toLocaleString(undefined, { timeZone: 'America/New_York' })
+        const browserDisplayedDate = parsedPaymentDate
+            .toLocaleString()
+
+        expect(screen.getByText(displayedDate))
+            .toBeInTheDocument()
+        expect(parsedPaymentDate.getUTCDate())
+            .toBe(31)
+        expect(parsedPaymentDate.getDate())
+            .toBe(1)
+        expect(displayedDate)
+            .not.toBe(browserDisplayedDate)
+
+        mockedFetchReportJson.mockResolvedValueOnce({
+            billingAccount: {
+                budget: '1000.00',
+                markup: '0.00',
+                name: 'Boundary account',
+                startDate: paymentDate,
+                status: 'Active',
+            },
+        })
+        fireEvent.click(screen.getByRole('button', { name: '80000001' }))
+
+        expect(await screen.findByText(browserDisplayedDate))
+            .toBeInTheDocument()
     })
 })

--- a/src/apps/reports/src/pages/reports/ReportsPage.tsx
+++ b/src/apps/reports/src/pages/reports/ReportsPage.tsx
@@ -178,6 +178,22 @@ const formatPaymentDate = (iso: string): string => {
         .toLocaleString()
 }
 
+/**
+ * Formats an SFDC payment timestamp in the report's America/New_York timezone.
+ * The input is an ISO date-time string and the returned value is used in payment table cells.
+ * Invalid inputs are returned unchanged, so this function does not throw parsing errors.
+ */
+const formatSfdcPaymentDate = (iso: string): string => {
+    const parsed = Date.parse(iso)
+
+    if (Number.isNaN(parsed)) {
+        return iso
+    }
+
+    return new Date(parsed)
+        .toLocaleString(undefined, { timeZone: 'America/New_York' })
+}
+
 const PAYMENT_TABLE_COLUMNS: { key: keyof SfdcBillingAccountPaymentRow; label: string }[] = [
     { key: 'paymentId', label: 'Payment ID' },
     { key: 'paymentDate', label: 'Payment date' },
@@ -431,7 +447,7 @@ const BillingAccountReportResults = (
         const value = row[colKey]
 
         if (colKey === 'paymentDate') {
-            return formatPaymentDate(String(value))
+            return formatSfdcPaymentDate(String(value))
         }
 
         if (colKey === 'billingAccountId') {


### PR DESCRIPTION
## What was broken

Late July 31 SFDC payments could render as August 1 for users whose browser timezone is ahead of America/New_York.

## Root cause

The payment table formatted SFDC timestamps in the browser's local timezone even though the report and Salesforce integration use America/New_York calendar dates.

## What was changed

Render only SFDC payment-table timestamps explicitly in America/New_York. Billing-account profile dates retain their existing browser-local formatting.

## Any added/updated tests

- Added a Reports page regression using the reported July 31 boundary under Asia/Colombo.
- Verified the payment remains July 31 while the same instant is August 1 in the browser timezone.
- Verified billing-account profile dates keep their existing formatting.
- Focused Reports page tests passed: 2 tests.
- yarn lint and yarn build passed.
- The full suite reports 1,081 passing and 27 failing tests. All failures are outside the Reports app; no PM-5839 regression failed.
