### PR TITLE
Fix member profile rating chart

### DIFF
--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.module.scss
@@ -204,6 +204,7 @@
     transform: translateX(-50%);
     width: 0;
     z-index: 2;
+    left: 50%;
 
     &::after {
         background: currentColor;
@@ -217,11 +218,9 @@
 }
 
 .markerBadge {
-    align-items: center;
-    display: flex;
-    gap: $sp-2;
+    flex-shrink: 0;
     position: relative;
-    transform: translateX(34px);
+    width: 32px;
     z-index: 1;
 }
 
@@ -230,10 +229,10 @@
         top: $sp-14;
     }
 
-    .markerBadge {
-        flex-direction: column;
-        gap: $sp-1;
-        transform: translateX(0);
+    .markerRating {
+        left: 50%;
+        top: calc(100% + #{$sp-1});
+        transform: translateX(-50%);
     }
 }
 
@@ -274,7 +273,12 @@
     font-family: $font-roboto;
     font-size: 13px;
     font-weight: $font-weight-bold;
+    left: calc(100% + #{$sp-2});
     line-height: 18px;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
 }
 
 .axisLabels {

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.spec.tsx
@@ -53,6 +53,18 @@ const expandedTailRatingDistribution = {
     },
 }
 
+const cappedRatingDistribution = {
+    ...ratingDistribution,
+    distribution: {
+        ratingRange0To899: 10,
+        ratingRange900To1199: 20,
+        ratingRange1200To1499: 30,
+        ratingRange1500To2199: 40,
+        ratingRange2200To2999: 5,
+        ratingRange3000To3999: 2,
+    },
+}
+
 jest.mock('~/libs/core', () => ({
     getRatingColor: jest.fn(),
 }), {
@@ -154,8 +166,50 @@ describe('MemberRatingInfoModal', () => {
         expect(marker)
             .toHaveStyle('color: #616BD5')
         expect(parseFloat(marker.style.left))
-            .toBeLessThan(80)
+            .toBeCloseTo((5.5 / 6) * 100)
         expect(marker)
             .toHaveClass('memberMarkerStacked')
+    })
+
+    it('centers the marker on the final module bar when the rating exceeds the distribution', () => {
+        render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={0.1}
+                profile={baseProfile}
+                rating={4051}
+                ratingDistribution={cappedRatingDistribution}
+            />,
+        )
+
+        const marker = screen.getByTestId('rating-member-marker')
+
+        expect(parseFloat(marker.style.left))
+            .toBeCloseTo((5.5 / 6) * 100)
+        expect(marker)
+            .toHaveClass('memberMarkerStacked')
+    })
+
+    it('removes trailing empty buckets so the histogram spans the chart', () => {
+        render(
+            <MemberRatingInfoModal
+                audienceLabel='developers'
+                onClose={jest.fn()}
+                percentile={15}
+                profile={baseProfile}
+                rating={1646}
+                ratingDistribution={expandedTailRatingDistribution}
+            />,
+        )
+
+        const marker = screen.getByTestId('rating-member-marker')
+        const bars = document.querySelector('[class*="bars"]') as HTMLElement
+
+        expect(bars)
+            .not
+            .toHaveAttribute('style')
+        expect(parseFloat(marker.style.left))
+            .toBeCloseTo((3.5 / 6) * 100)
     })
 })

--- a/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
+++ b/src/apps/profiles/src/member-profile/about-me/MemberRatingCard/MemberRatingInfoModal/MemberRatingInfoModal.tsx
@@ -180,42 +180,116 @@ const getDistributionRanges = (
 )
 
 /**
- * Returns the chart end rating used for marker and axis positioning.
- *
- * Used by MemberRatingInfoModal to align labels with the rendered distribution range.
+ * Trims trailing empty rating buckets so the histogram can span the chart width.
  *
  * @param {RatingDistributionRange[]} ranges - Parsed rating distribution ranges.
- * @returns {number} The maximum rating represented by the chart.
+ * @returns {RatingDistributionRange[]} Ranges through the last populated bucket.
  */
-const getChartEndRating = (ranges: RatingDistributionRange[]): number => {
+const getVisibleDistributionRanges = (
+    ranges: RatingDistributionRange[],
+): RatingDistributionRange[] => {
     if (ranges.length === 0) {
-        return 3999
+        return ranges
     }
 
-    return ranges[ranges.length - 1].end
+    let lastPopulatedIndex = -1
+    for (let index = ranges.length - 1; index >= 0; index -= 1) {
+        if (ranges[index].value > 0) {
+            lastPopulatedIndex = index
+            break
+        }
+    }
+
+    if (lastPopulatedIndex < 0) {
+        return ranges
+    }
+
+    return ranges.slice(0, lastPopulatedIndex + 1)
 }
 
 /**
- * Calculates a horizontal chart position for a rating value.
+ * Returns the histogram bar index for a rating value.
  *
- * Used by MemberRatingInfoModal for the member marker and static x-axis labels.
- *
- * @param {number} rating - The rating value to position.
- * @param {RatingDistributionRange[]} ranges - Parsed rating distribution ranges.
- * @returns {number} A clamped percentage from 0 to 100.
+ * @param {number} rating - The rating value to locate.
+ * @param {RatingDistributionRange[]} ranges - Visible rating distribution ranges.
+ * @returns {number} Zero-based bar index, clamped to the visible range.
  */
-const getChartPosition = (rating: number, ranges: RatingDistributionRange[]): number => {
-    const chartStart = ranges[0]?.start ?? 0
-    const chartEnd = getChartEndRating(ranges)
-    const chartSpan = chartEnd - chartStart
-
-    if (chartSpan <= 0) {
+const getBarIndexForRating = (
+    rating: number,
+    ranges: RatingDistributionRange[],
+): number => {
+    if (ranges.length === 0) {
         return 0
     }
 
-    const clampedRating = Math.max(chartStart, Math.min(rating, chartEnd))
+    const matchingIndex = ranges.findIndex((range: RatingDistributionRange) => (
+        rating >= range.start && rating <= range.end
+    ))
 
-    return ((clampedRating - chartStart) / chartSpan) * 100
+    if (matchingIndex >= 0) {
+        return matchingIndex
+    }
+
+    if (rating < ranges[0].start) {
+        return 0
+    }
+
+    return ranges.length - 1
+}
+
+/**
+ * Returns the horizontal center position of the histogram bar for a rating.
+ *
+ * Used by MemberRatingInfoModal so the marker sits on the module bar itself
+ * instead of interpolating across a separate rating-percentage scale.
+ *
+ * @param {number} rating - The rating value to position.
+ * @param {RatingDistributionRange[]} ranges - Visible rating distribution ranges.
+ * @returns {number} Center position of the matching bar as a percentage from 0 to 100.
+ */
+const getMarkerPosition = (
+    rating: number,
+    ranges: RatingDistributionRange[],
+): number => {
+    if (ranges.length === 0) {
+        return 0
+    }
+
+    const barIndex = getBarIndexForRating(rating, ranges)
+
+    return ((barIndex + 0.5) / ranges.length) * 100
+}
+
+/**
+ * Returns the horizontal start position of the histogram bar for an axis label.
+ *
+ * @param {number} rating - The axis label rating value.
+ * @param {RatingDistributionRange[]} ranges - Visible rating distribution ranges.
+ * @returns {number} Start position of the matching bar as a percentage from 0 to 100.
+ */
+const getAxisLabelPosition = (
+    rating: number,
+    ranges: RatingDistributionRange[],
+): number => {
+    if (ranges.length === 0) {
+        return 0
+    }
+
+    const matchingIndex = ranges.findIndex((range: RatingDistributionRange) => (
+        rating >= range.start && rating <= range.end
+    ))
+
+    if (matchingIndex >= 0) {
+        return (matchingIndex / ranges.length) * 100
+    }
+
+    const nextIndex = ranges.findIndex((range: RatingDistributionRange) => range.start >= rating)
+
+    if (nextIndex >= 0) {
+        return (nextIndex / ranges.length) * 100
+    }
+
+    return 100
 }
 
 /**
@@ -268,14 +342,16 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
     const ratingColor: string = getRatingColor(props.rating)
     const selectedRatingTier: RatingTier = getRatingTier(props.rating)
     const distributionRanges: RatingDistributionRange[] = useMemo(() => (
-        getDistributionRanges(props.ratingDistribution?.distribution)
+        getVisibleDistributionRanges(
+            getDistributionRanges(props.ratingDistribution?.distribution),
+        )
     ), [props.ratingDistribution])
     const maxDistributionValue: number = Math.max(
         1,
         ...distributionRanges.map((range: RatingDistributionRange) => range.value),
     )
     const markerPosition: number = props.rating !== undefined
-        ? getChartPosition(props.rating, distributionRanges)
+        ? getMarkerPosition(props.rating, distributionRanges)
         : 0
     const shouldStackMarkerRating: boolean = props.rating !== undefined && (
         markerPosition >= stackedMarkerPositionThreshold
@@ -397,7 +473,12 @@ const MemberRatingInfoModal: FC<MemberRatingInfoModalProps> = (props: MemberRati
                                 {chartAxisLabels.map((axisLabel: { label: string, value: number }) => (
                                     <span
                                         key={axisLabel.label}
-                                        style={{ left: `${getChartPosition(axisLabel.value, distributionRanges)}%` }}
+                                        style={{
+                                            left: `${getAxisLabelPosition(
+                                                axisLabel.value,
+                                                distributionRanges,
+                                            )}%`,
+                                        }}
                                     >
                                         {axisLabel.label}
                                     </span>


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-5464
https://topcoder.atlassian.net/browse/PM-5465
https://topcoder.atlassian.net/browse/PM-5466

<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
Updates the rating graph to remove any empty trailing buckets 
Also center aigns the marker to the column
And increases the chart limit to accommodate larger ratings. The limit was 3999 right now and tourist on prod has a rating of  4051