### PR TITLE
PM-5853: Rename active challenge label

### DIFF
--- a/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.spec.tsx
+++ b/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.spec.tsx
@@ -144,7 +144,7 @@ describe('OpenSupportRequestModal', () => {
         expect(screen.getByRole('dialog')
             .getAttribute('data-size'))
             .toBe('body')
-        const challengeSelect = screen.getByLabelText('Challenge (if applicable)') as HTMLSelectElement
+        const challengeSelect = screen.getByLabelText('Active Challenge (if applicable)') as HTMLSelectElement
         expect(challengeSelect.options[0].text)
             .toBe('Select challenge')
         expect(mockUseSWR.mock.calls[0][0])
@@ -155,7 +155,7 @@ describe('OpenSupportRequestModal', () => {
         expect(mockedGetActiveChallenges)
             .toHaveBeenCalledWith('12345')
 
-        fireEvent.change(screen.getByLabelText('Challenge (if applicable)'), {
+        fireEvent.change(screen.getByLabelText('Active Challenge (if applicable)'), {
             target: { value: 'challenge-2' },
         })
         fireEvent.change(screen.getByLabelText('Description'), {
@@ -209,7 +209,7 @@ describe('OpenSupportRequestModal', () => {
             />,
         )
 
-        fireEvent.change(screen.getByLabelText('Challenge (if applicable)'), {
+        fireEvent.change(screen.getByLabelText('Active Challenge (if applicable)'), {
             target: { value: 'challenge-2' },
         })
         mockUseSWR.mockReturnValue({

--- a/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.tsx
+++ b/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.tsx
@@ -192,7 +192,7 @@ export const OpenSupportRequestModal: FC<OpenSupportRequestModalProps> = props =
         >
             <div className={styles.form}>
                 <div className={styles.challengeField}>
-                    <label htmlFor='support-challenge-id'>Challenge (if applicable)</label>
+                    <label htmlFor='support-challenge-id'>Active Challenge (if applicable)</label>
                     <Select<ChallengeOption, false>
                         aria-describedby={challengeError ? 'support-challenge-error' : undefined}
                         className={styles.challengeSelect}


### PR DESCRIPTION
## What was broken

The Open support request modal labeled its challenge picker as "Challenge (if applicable)", even though the picker only offers active challenges.

## Root cause

The field label did not reflect the active-status filter already applied when loading challenge options.

## What was changed

Renamed the picker label to "Active Challenge (if applicable)" so the modal accurately describes the available choices.

## Any added/updated tests

Updated the existing OpenSupportRequestModal tests to query and verify the new accessible label.

Validation completed:

- Focused modal suite: 3 tests passed.
- Lint: passed.
- Production build: passed with existing warnings.
- Full suite: 222 suites passed and 18 unrelated suites failed on the current dev baseline; the same result was reproduced serially, and none of the failures involve the support app.
