### PR TITLE
PM-5755: Allow selected copilot through reviewer validation

### DIFF
--- a/src/apps/work/src/lib/schemas/challenge-editor.schema.spec.ts
+++ b/src/apps/work/src/lib/schemas/challenge-editor.schema.spec.ts
@@ -376,6 +376,25 @@ describe('challenge-editor schema reviewer slot assignment validation', () => {
             .toBeTruthy()
     })
 
+    it('accepts a persisted member handle while its member id is resolved during save', async () => {
+        await expect(
+            challengeAdvancedOptionsSchema.validate({
+                ...baseFormData,
+                reviewers: [
+                    {
+                        handle: 'TCConnCopilot',
+                        isMemberReview: true,
+                        memberReviewerCount: 1,
+                        scorecardId: 'scorecard-id',
+                        shouldOpenOpportunity: false,
+                    },
+                ],
+            }),
+        )
+            .resolves
+            .toBeTruthy()
+    })
+
     it('rejects reviewer counts above the manual reviewer limit', async () => {
         await expect(
             challengeAdvancedOptionsSchema.validate({

--- a/src/apps/work/src/lib/schemas/challenge-editor.schema.ts
+++ b/src/apps/work/src/lib/schemas/challenge-editor.schema.ts
@@ -441,11 +441,10 @@ export const challengeAdvancedOptionsSchema = yup.object({
                             ? reviewer.additionalMemberIds
                             : []
                         const normalizedAssignedMemberSlots = [
-                            reviewer.memberId,
-                            ...additionalMemberIds,
+                            toNormalizedText(reviewer.memberId) || toNormalizedText(reviewer.handle),
+                            ...additionalMemberIds.map(memberId => toNormalizedText(memberId)),
                         ]
                             .slice(0, reviewerSlots)
-                            .map(memberId => toNormalizedText(memberId))
                         const missingSlotIndex = normalizedAssignedMemberSlots.findIndex(memberId => !memberId)
                         const hasAllAssignments = normalizedAssignedMemberSlots.length === reviewerSlots
                             && missingSlotIndex === -1

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -988,8 +988,8 @@ describe('ChallengeEditorForm', () => {
                 shouldOpenOpportunity: false,
             },
             {
+                handle: 'TCConnCopilot',
                 isMemberReview: true,
-                memberId: '40158994',
                 memberReviewerCount: 1,
                 phaseId: 'checkpoint-review-phase-id',
                 scorecardId: 'checkpoint-review-scorecard-id',
@@ -1004,16 +1004,16 @@ describe('ChallengeEditorForm', () => {
                 shouldOpenOpportunity: false,
             },
             {
+                handle: 'TCConnCopilot',
                 isMemberReview: true,
-                memberId: '40158994',
                 memberReviewerCount: 1,
                 phaseId: 'review-phase-id',
                 scorecardId: 'review-scorecard-id',
                 shouldOpenOpportunity: false,
             },
             {
+                handle: 'TCConnCopilot',
                 isMemberReview: true,
-                memberId: '40158994',
                 memberReviewerCount: 1,
                 phaseId: 'approval-phase-id',
                 scorecardId: 'approval-scorecard-id',
@@ -4518,6 +4518,30 @@ describe('ChallengeEditorForm', () => {
             expect(screen.getByTestId('location-display'))
                 .toHaveTextContent('/projects/100578/challenges/12345/view')
         })
+    })
+
+    it('shows the concrete schema error when saving an invalid draft', async () => {
+        const user = userEvent.setup()
+
+        render(
+            <MemoryRouter>
+                <ChallengeEditorForm
+                    challenge={{
+                        ...validNewChallenge,
+                        description: '',
+                    }}
+                />
+            </MemoryRouter>,
+        )
+
+        await user.click(screen.getByRole('button', { name: 'Save as Draft' }))
+
+        expect(await screen.findByText('Public specification must be at least 10 characters'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Please fix validation errors before saving.'))
+            .not.toBeInTheDocument()
+        expect(mockedPatchChallenge)
+            .not.toHaveBeenCalled()
     })
 
     it('saves a new design draft before screening members are assigned', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -495,6 +495,45 @@ function normalizeTextValue(value: unknown): string {
 }
 
 /**
+ * Finds the first user-facing message in React Hook Form's nested validation errors.
+ *
+ * @param errors field-error tree supplied to the invalid-submit callback.
+ * @returns the first non-empty validation message, or `undefined` when none is available.
+ * @remarks Nested and array fields, including hidden reviewer rows, do not expose a root-level
+ * message. The save footer uses this helper so every rejected submit explains what must be fixed.
+ * @throws Does not throw; cyclic field references are ignored.
+ */
+function getFirstFormValidationMessage(errors: unknown): string | undefined {
+    const visitedValues = new Set<object>()
+
+    function findMessage(value: unknown): string | undefined {
+        if (!value || typeof value !== 'object' || visitedValues.has(value)) {
+            return undefined
+        }
+
+        visitedValues.add(value)
+
+        const message = normalizeTextValue((value as { message?: unknown }).message)
+        if (message) {
+            return message
+        }
+
+        for (const [key, childValue] of Object.entries(value)) {
+            if (key !== 'ref') {
+                const childMessage = findMessage(childValue)
+                if (childMessage) {
+                    return childMessage
+                }
+            }
+        }
+
+        return undefined
+    }
+
+    return findMessage(errors)
+}
+
+/**
  * Normalizes challenge term form values into term ids.
  *
  * The challenge editor usually stores terms as string ids, but persisted challenge payloads may
@@ -3967,13 +4006,15 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
         ],
     )
 
-    const onInvalidSubmit = useCallback((): void => {
+    const onInvalidSubmit = useCallback((errors: unknown): void => {
         if (!validateDesignReviewCopilotSelection(getValues())) {
             return
         }
 
         setSaveStatus('idle')
-        setSaveValidationError(SAVE_VALIDATION_ERROR_MESSAGE)
+        setSaveValidationError(
+            getFirstFormValidationMessage(errors) || SAVE_VALIDATION_ERROR_MESSAGE,
+        )
     }, [
         getValues,
         validateDesignReviewCopilotSelection,


### PR DESCRIPTION
## Summary

- accept a persisted reviewer handle as the first assigned slot while the save flow resolves it to a Topcoder member ID
- preserve the existing pre-serialization member-ID resolution for private Design Challenge reviewer rows
- show the first concrete React Hook Form/Yup validation message in the save footer instead of the generic "Please fix validation errors" message
- add regressions for handle-only copilot reviewers and actionable invalid-submit feedback

## Root cause

The simplified Design Challenge review flow introduced in #2157 stores the selected copilot handle on the hidden Checkpoint Review, Review, and Approval rows. The Yup resolver runs before `onSubmit`, but its private-reviewer slot rule accepted only `memberId`. It therefore rejected all three hidden rows before the save handler could resolve `TCConnCopilot` to member ID `40158994`.

Because those errors belonged to hidden nested reviewer fields and the invalid-submit callback discarded the actual error tree, the page displayed only the generic validation message.

## Impact

A valid two-round Design Challenge can now pass pre-submit validation with a selected copilot handle. The save path then resolves the handle to a member ID, serializes the private reviewer rows, and synchronizes the Checkpoint Reviewer, Reviewer, and Approver resources as intended.

If any other schema rule blocks saving, the footer displays its actual message so the user knows what to fix.

The reported dev challenge was also checked directly: its five private reviewer rows and screener/copilot resources are present, confirming this was a client-side pre-submit validation failure rather than missing persisted assignments.

## Validation

- `yarn test:no-watch --runInBand src/apps/work/src/lib/schemas/challenge-editor.schema.spec.ts src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx` — 108 tests passed
- `yarn lint` — passed
- `yarn run build` — passed (existing repository warnings remain)

Follow-up to #2157.
