### PR TITLE
PM-5896: keep empty tags array in challenge update payload

### DIFF
--- a/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.spec.ts
@@ -633,6 +633,22 @@ describe('challenge-editor utils design work type mapping', () => {
 })
 
 describe('challenge-editor utils terms mapping', () => {
+    it('keeps an empty tags array in API payloads to clear tags on update', () => {
+        const formData: Record<string, unknown> = {
+            description: 'Public specification',
+            name: 'Design challenge',
+            skills: [],
+            tags: [],
+            trackId: 'track-id',
+            typeId: 'type-id',
+        }
+
+        const result = transformFormDataToChallenge(formData as any)
+
+        expect(result.tags)
+            .toEqual([])
+    })
+
     it('keeps an empty groups array in API payloads to clear groups on update', () => {
         const formData: Record<string, unknown> = {
             description: 'Public specification',

--- a/src/apps/work/src/lib/utils/challenge-editor.utils.ts
+++ b/src/apps/work/src/lib/utils/challenge-editor.utils.ts
@@ -55,6 +55,7 @@ const MILESTONE_METADATA_NAMES = {
 const MILESTONE_METADATA_KEYS: readonly string[] = Object.values(MILESTONE_METADATA_NAMES)
 const ALLOW_EMPTY_ARRAY_PAYLOAD_KEYS = new Set<string>([
     'groups',
+    'tags',
     'terms',
 ])
 


### PR DESCRIPTION
Jira: PM-5896

## What was broken
In the work app challenge editor, removing tags from a challenge did not
persist. Clearing the Tags field and saving showed "Challenge saved
successfully", but the removed tags were still present after the save and on
reload.

## Root cause
transformFormDataToChallenge() passes the payload through removeEmptyValues(),
which drops empty arrays unless the key is listed in
ALLOW_EMPTY_ARRAY_PAYLOAD_KEYS. Only "groups" and "terms" were listed, so
clearing every tag produced tags: [] which was stripped from the PATCH body.
With no tags key in the request, the challenge API left the stored tags
untouched. Verified against api.topcoder-dev.com that PATCH
/v6/challenges/{id} with {"tags": []} does clear the tags, confirming the
defect is in the UI payload and not in the API.

## What was changed
Added "tags" to ALLOW_EMPTY_ARRAY_PAYLOAD_KEYS in
src/apps/work/src/lib/utils/challenge-editor.utils.ts so an empty tags array
is sent to the API and clears the challenge tags, matching the existing
behavior for groups and terms.

## Any added/updated tests
Added a unit test in challenge-editor.utils.spec.ts asserting that
transformFormDataToChallenge keeps an empty tags array in the API payload. The
test fails without the fix and passes with it.
