### PR TITLE
PM-5165: show budget approve/reject actions right after saving a New challenge

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.spec.tsx
@@ -512,9 +512,36 @@ jest.mock('./ChallengePrivateDescriptionField', () => ({
         />
     ),
 }))
-jest.mock('./ChallengePrizesField', () => ({
-    ChallengePrizesField: () => <></>,
-}))
+jest.mock('./ChallengePrizesField', () => {
+    const reactHookForm: typeof import('react-hook-form') = jest.requireActual('react-hook-form')
+
+    return {
+        ChallengePrizesField: function ChallengePrizesField() {
+            const formContext = reactHookForm.useFormContext()
+            const handleSetPlacementPrize = (): void => {
+                formContext.setValue('prizeSets', [{
+                    prizes: [{
+                        type: 'USD',
+                        value: 500,
+                    }],
+                    type: 'PLACEMENT',
+                }], {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                })
+            }
+
+            return (
+                <button
+                    onClick={handleSetPlacementPrize}
+                    type='button'
+                >
+                    Mock Set Placement Prize
+                </button>
+            )
+        },
+    }
+})
 jest.mock('./ChallengeSkillsField', () => ({
     ChallengeSkillsField: () => <></>,
 }))
@@ -1428,6 +1455,59 @@ describe('ChallengeEditorForm', () => {
             .toBeNull()
         expect(screen.queryByRole('button', { name: 'Reject Budget' }))
             .toBeNull()
+    })
+
+    it('shows budget approval actions after saving a new challenge without persisted prizes', async () => {
+        const user = userEvent.setup()
+        const managerContextValue: WorkAppContextModel = {
+            ...copilotContextValue,
+            isManager: true,
+            userRoles: ['manager'],
+        }
+        // Challenges in 'New' status are created before the prizes section is available, so the
+        // fetched challenge snapshot still has no persisted prize sets while the form is edited.
+        const newChallengeWithoutPrizes = {
+            ...validNewChallenge,
+            approvalStatus: 'PENDING_APPROVAL',
+            prizeSets: undefined,
+        } as Challenge
+        const renderForm = (isReadOnly: boolean): React.ReactElement => (
+            <MemoryRouter initialEntries={['/projects/3001/challenges/12345/edit']}>
+                <WorkAppContext.Provider value={managerContextValue}>
+                    <ChallengeEditorForm
+                        challenge={newChallengeWithoutPrizes}
+                        isEditMode={!isReadOnly}
+                        isReadOnly={isReadOnly}
+                    />
+                </WorkAppContext.Provider>
+            </MemoryRouter>
+        )
+
+        mockedPatchChallenge.mockResolvedValue({
+            ...validNewChallenge,
+            approvalStatus: 'PENDING_APPROVAL',
+            status: 'DRAFT',
+        })
+
+        const renderResult = render(renderForm(false))
+
+        await user.click(screen.getByRole('button', { name: 'Mock Set Placement Prize' }))
+        await user.click(screen.getByRole('button', { name: 'Save as Draft' }))
+
+        await waitFor(() => {
+            expect(mockedPatchChallenge)
+                .toHaveBeenCalledWith('12345', expect.objectContaining({
+                    status: 'DRAFT',
+                }))
+        })
+
+        // The saved form stays mounted while the successful save redirects to the read-only view.
+        renderResult.rerender(renderForm(true))
+
+        expect(screen.getByRole('button', { name: 'Approve Budget' }))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Reject Budget' }))
+            .toBeInTheDocument()
     })
 
     it('hides the editable timeline section for task challenges in edit mode', () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ChallengeEditorForm.tsx
@@ -54,6 +54,7 @@ import {
     ChallengeEditorFormData,
     ChallengePhase,
     ChallengeType,
+    PrizeSet,
     Resource,
     ResourceRole,
     Reviewer,
@@ -1887,6 +1888,19 @@ function getApprovalStatusText(approvalStatus: string | undefined): string {
     return 'Pending Approval'
 }
 
+/**
+ * Detects whether a persisted challenge snapshot already stores at least one prize.
+ *
+ * @param prizeSets prize sets returned by challenge-api for the challenge.
+ * @returns `true` when any prize set contains at least one prize.
+ * @remarks Used by the budget approval actions so approvers only act on prizes
+ * that challenge-api already persisted.
+ */
+function hasPrizeSetWithPrizes(prizeSets: PrizeSet[] | undefined): boolean {
+    return Array.isArray(prizeSets)
+        && prizeSets.some(prizeSet => Array.isArray(prizeSet?.prizes) && prizeSet.prizes.length > 0)
+}
+
 interface TaskLaunchValidationParams {
     assignedMemberId?: unknown
     currentStatus?: unknown
@@ -2056,6 +2070,11 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     const [scorerHasError, setScorerHasError] = useState<boolean>(false)
     const [isUpdatingApproval, setIsUpdatingApproval] = useState<boolean>(false)
     const [rejectionReasonInput, setRejectionReasonInput] = useState<string>('')
+    // Tracks the prize sets challenge-api has stored so budget approval actions can appear
+    // right after a save instead of waiting for the challenge prop to be refetched.
+    const [persistedPrizeSets, setPersistedPrizeSets] = useState<PrizeSet[] | undefined>(
+        props.challenge?.prizeSets,
+    )
     const [showApproveBudgetModal, setShowApproveBudgetModal] = useState<boolean>(false)
     const [showRejectBudgetModal, setShowRejectBudgetModal] = useState<boolean>(false)
     const [resolvedPaymentCreator, setResolvedPaymentCreator] = useState<ResolvedPaymentCreator | undefined>()
@@ -2316,10 +2335,8 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
         projectResult.project,
     )
     const hasPersistedPrizeSets = useMemo(
-        () => Array.isArray(props.challenge?.prizeSets)
-            && props.challenge?.prizeSets
-                .some(prizeSet => Array.isArray(prizeSet?.prizes) && prizeSet.prizes.length > 0),
-        [props.challenge?.prizeSets],
+        () => hasPrizeSetWithPrizes(persistedPrizeSets),
+        [persistedPrizeSets],
     )
     const hasUnsavedPrizeSetChanges = useMemo(
         () => {
@@ -2908,6 +2925,10 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
     useEffect(() => {
         challengeRef.current = props.challenge
     }, [props.challenge])
+
+    useEffect(() => {
+        setPersistedPrizeSets(props.challenge?.prizeSets)
+    }, [props.challenge?.prizeSets])
 
     useEffect(() => {
         currentChallengeIdRef.current = currentChallengeId
@@ -3611,6 +3632,8 @@ export const ChallengeEditorForm: FC<ChallengeEditorFormProps> = (
                         savedChallengeSnapshot = savedChallenge
                     }
                 }
+
+                setPersistedPrizeSets(savedChallengeSnapshot.prizeSets)
 
                 const persistedFormData = applyProjectBillingToChallengeFormData(
                     transformChallengeToFormData(savedChallengeSnapshot),


### PR DESCRIPTION
## What was broken

In Work Manager, for challenges in **'New'** status, the Budget **Approve/Reject** buttons were not displayed for TM/Admin users immediately after saving the challenge. The buttons only appeared after refreshing the page.

## Root cause

The budget approval actions in the challenge editor are gated on `hasPersistedPrizeSets`, which was derived from the `challenge` prop (`ChallengeEditorForm.tsx`). That prop comes from the page's SWR challenge fetch, which is not revalidated after a save, so it keeps the pre-save snapshot.

Challenges are created in 'New' status before the Prizes & Billing section is rendered at all (`createChallenge` sends no `prizeSets`), so a 'New' challenge never has persisted prize sets. Entering prizes and saving persists them and moves the challenge to Draft, but the stale `challenge` prop still reported "no persisted prizes", so the approval actions remained hidden until a refresh refetched the challenge.

## What was changed

- `ChallengeEditorForm` now tracks the persisted prize sets in local state: seeded from the `challenge` prop, kept in sync when that prop changes, and advanced with the prize sets returned by challenge-api after a successful save. The approval-action gate reads that state, so the Approve/Reject buttons render as soon as the save response confirms the prizes were stored.
- Extracted the prize-set check into a documented `hasPrizeSetWithPrizes` helper.

No API changes were required; the PATCH `/challenges/:id` response already includes `prizeSets`.

## Added/updated tests

- Added `shows budget approval actions after saving a new challenge without persisted prizes` to `ChallengeEditorForm.spec.tsx`. It saves a 'New' challenge whose fetched snapshot has no prize sets and asserts the Approve/Reject Budget buttons appear once the form switches to read-only view mode, without the `challenge` prop being refetched. The test fails on `dev` and passes with this fix.
- Expanded the `ChallengePrizesField` test mock so specs can set a placement prize on the form.

### Validation

- `CI=true npx craco test --watchAll=false --testPathPattern "ChallengeEditorForm.spec|ChallengeEditorPage.spec|BudgetApprovalsPage"` → 124 passed.
- `yarn lint` → clean.
- `yarn build` → succeeds.
- Pre-existing, unrelated failures on `dev` (unchanged by this PR): `AiReviewTab.spec.tsx`, `ReviewContextTab.spec.tsx`, `ReviewContextEditor.spec.tsx`, `ChallengePrizesField.spec.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
