### PR TITLE
PM-5562: Count rating-only history subtrack wins in track totals

### DIFF
--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -5,7 +5,9 @@ import {
     getMemberChallengePoints,
     getSubTrackDisplaySubmissionCount,
     getSubTrackSummaryStats,
+    getTrackSummaryStats,
     MemberStatsTrack,
+    SubTrackSummaryStats,
 } from './useFetchActiveTracks'
 
 jest.mock('~/libs/core', () => ({
@@ -592,5 +594,146 @@ describe('getSubTrackSummaryStats', () => {
                 submissions: 2,
                 wins: 2,
             })
+    })
+})
+
+describe('getTrackSummaryStats', () => {
+    const statsOnlyHistoryStats = {
+        DEVELOP: {
+            subTracks: [
+                {
+                    challenges: 231,
+                    name: 'Task',
+                    submissions: {
+                        submissions: 231,
+                    },
+                    wins: 231,
+                },
+                {
+                    challenges: 18,
+                    name: 'Challenge',
+                    submissions: {
+                        submissions: 18,
+                    },
+                    wins: 17,
+                },
+                {
+                    challenges: 21,
+                    name: 'CONTENT_CREATION',
+                    submissions: {
+                        submissions: 17,
+                    },
+                    wins: 8,
+                },
+                {
+                    challenges: 71,
+                    name: 'First2Finish',
+                    submissions: {
+                        submissions: 66,
+                    },
+                    wins: 64,
+                },
+                {
+                    challenges: 37,
+                    name: 'CODE',
+                    submissions: {
+                        submissions: 24,
+                    },
+                    wins: 10,
+                },
+            ],
+        },
+    } as unknown as UserStats
+    const statsOnlyHistory = {
+        DEVELOP: {
+            subTracks: [
+                {
+                    history: [
+                        {
+                            challengeId: 'task-1',
+                            challengeName: 'Task 1',
+                            placement: 1,
+                            ratingDate: 1781237773026,
+                        },
+                        {
+                            challengeId: 'task-2',
+                            challengeName: 'Task 2',
+                            placement: 1,
+                            ratingDate: 1781237773027,
+                        },
+                    ],
+                    name: 'Task',
+                },
+                {
+                    history: [
+                        {
+                            challengeId: 'challenge-1',
+                            challengeName: 'Challenge 1',
+                            placement: 1,
+                            ratingDate: 1781237773028,
+                        },
+                        {
+                            challengeId: 'challenge-2',
+                            challengeName: 'Challenge 2',
+                            placement: 36,
+                            ratingDate: 1781237773029,
+                        },
+                    ],
+                    name: 'Challenge',
+                },
+                {
+                    history: [
+                        {
+                            challengeId: 30040681,
+                            newRating: 1333,
+                            ratingDate: 1393405500000,
+                        },
+                    ],
+                    name: 'CONTENT_CREATION',
+                },
+            ],
+        },
+    } as unknown as UserStatsHistory
+
+    it('adds aggregate wins for subtracks whose history has no placements', () => {
+        const developmentTrack: MemberStatsTrack | undefined = getActiveTracks(
+            statsOnlyHistoryStats,
+            statsOnlyHistory,
+        )
+            .find(track => track.name === 'Development')
+        const subTrackWins: number = developmentTrack?.subTracks.reduce((wins, subTrack) => {
+            const trackHistory = statsOnlyHistory.DEVELOP?.subTracks
+                ?.find(historyEntry => historyEntry.name === subTrack.name)
+                ?.history ?? []
+            const summaryStats: SubTrackSummaryStats = getSubTrackSummaryStats(subTrack, trackHistory)
+
+            return wins + summaryStats.wins
+        }, 0) ?? 0
+
+        // 2 Task placements + 1 Challenge placement + 8 CONTENT_CREATION + 64 First2Finish + 10 CODE
+        expect(developmentTrack?.wins)
+            .toEqual(85)
+        expect(developmentTrack?.wins)
+            .toEqual(subTrackWins)
+    })
+
+    it('keeps aggregate wins when no subtrack history has placements', () => {
+        const summaryStats = getTrackSummaryStats(
+            [
+                {
+                    challenges: 21,
+                    name: 'CONTENT_CREATION',
+                    path: 'DEVELOP.subTracks',
+                    submissions: {
+                        submissions: 17,
+                    },
+                    wins: 8,
+                } as unknown as MemberStats,
+            ],
+            statsOnlyHistory,
+        )
+
+        expect(summaryStats.wins)
+            .toEqual(8)
     })
 })

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -189,6 +189,19 @@ interface SubTrackHistorySummary {
     subTrack: MemberStats
 }
 
+/**
+ * Checks whether the subtrack history carries placement information.
+ *
+ * Some history rows only record rating changes, so their win counts still come
+ * from the aggregate stats payload instead of placement rows.
+ *
+ * @param {SubTrackHistorySummary} summary - The subtrack history summary to inspect.
+ * @returns {boolean} Whether any history row includes a placement.
+ */
+const hasPlacementHistory = (summary: SubTrackHistorySummary): boolean => (
+    summary.history.some(history => getFiniteNumber(history.placement) !== undefined)
+)
+
 const getSubTrackHistorySummaries = (
     subTracks: MemberStats[],
     statsHistory?: UserStatsHistory,
@@ -216,6 +229,11 @@ const getFallbackTrackSummaryStats = (summaries: SubTrackHistorySummary[]): Trac
  * Development can show the same AI challenge under both `Challenge` and
  * `AI Engineering`. When history rows are available, duplicate challenge ids are
  * counted once for the parent totals while each child card keeps its own stats.
+ *
+ * Subtracks whose history only carries rating changes have no placement rows, so
+ * their cards fall back to the aggregate win counter. Those wins are added to the
+ * parent total as well, otherwise the summary drops them and no longer matches the
+ * sum of the subtrack cards.
  *
  * @param {MemberStats[]} subTracks - Active subtracks included in the parent track.
  * @param {UserStatsHistory | undefined} statsHistory - Optional stats-history payload for the same member.
@@ -267,15 +285,22 @@ export const getTrackSummaryStats = (
         0,
         summary.stats.submissions - summary.history.length,
     ))
+    const placementHistorySummaries = historySummaries.filter(hasPlacementHistory)
     const uniqueHistoryWins = uniqueHistory.filter(history => history.placement === 1).length
     const historyStatsWins = hasDuplicateHistory
-        ? Math.max(...historySummaries.map(summary => summary.stats.wins))
-        : sumBy(historySummaries, summary => summary.stats.wins)
+        ? Math.max(0, ...placementHistorySummaries.map(summary => summary.stats.wins))
+        : sumBy(placementHistorySummaries, summary => summary.stats.wins)
+    const statsOnlyHistoryWins = sumBy(
+        historySummaries.filter(summary => !hasPlacementHistory(summary)),
+        summary => summary.stats.wins,
+    )
 
     return {
         challenges: uniqueHistory.length + historyChallengeExtras + noHistorySummaryStats.challenges,
         submissions: uniqueHistory.length + historySubmissionExtras + noHistorySummaryStats.submissions,
-        wins: (uniqueHistoryWins > 0 ? uniqueHistoryWins : historyStatsWins) + noHistorySummaryStats.wins,
+        wins: (uniqueHistoryWins > 0 ? uniqueHistoryWins : historyStatsWins)
+            + statsOnlyHistoryWins
+            + noHistorySummaryStats.wins,
     }
 }
 


### PR DESCRIPTION
What was broken
The "Development Stats" win total on the member profile stats page did not
match the sum of the wins shown on the Development subtrack cards. On prod,
sdgun showed 321 wins while the cards summed to 329, and standlove showed
738 wins while the cards summed to 978. The total was correct on first paint
and then changed to the wrong value a few seconds later, once the stats
history request resolved.

Root cause
getTrackSummaryStats aggregates the parent track totals from stats history so
that a challenge appearing under two subtracks is only counted once. A subtrack
card falls back to the aggregate `wins` counter when its history rows carry no
placement data (rating-only rows), but the parent total only counted history
rows with `placement === 1`. Any subtrack that had history without placements
was therefore treated as having zero wins in the total while its card still
displayed the aggregate count, so those wins silently disappeared from the
summary once stats history loaded.

For sdgun, CONTENT_CREATION has a single rating-only history row and 8
aggregate wins, which is exactly the 329 - 321 = 8 difference. For standlove,
ARCHITECTURE (68), DESIGN (147) and DEVELOPMENT (25) are all rating-only and
account for the 978 - 738 = 240 difference.

What was changed
- src/apps/profiles/src/hooks/useFetchActiveTracks.tsx: added a
  `hasPlacementHistory` helper and split the history summaries into
  placement-bearing rows and rating-only rows. Placement-bearing rows keep the
  existing de-duplicated unique-history win count, while rating-only rows now
  contribute their aggregate wins to the parent total, the same way subtracks
  with no history at all already did. The `historyStatsWins` fallback is now
  computed from placement-bearing summaries only so those wins are not counted
  twice, and its `Math.max` is seeded with 0 to avoid `-Infinity`.
- Challenge and submission totals are untouched; only the win aggregation
  changed.

Any added/updated tests
- src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx: new
  `getTrackSummaryStats` suite with two cases, modeled on the sdgun payload:
  one asserting the Development total equals the sum of the subtrack card wins
  when a subtrack has rating-only history (fails with 77 vs 85 before this
  change), and one asserting aggregate wins are preserved when no subtrack
  history has placements.
- Verified against the live prod payloads for both members reported in the
  ticket: Development totals now come out as 329 for sdgun and 978 for
  standlove, matching the sum of the subtrack cards in both cases, with
  challenge and submission totals unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
