### PR TITLE
PM-5954 - show actions in review tab for copilots & reviewers

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentReview.tsx
@@ -42,6 +42,7 @@ import {
     SUBMITTER,
 } from '../../../config/index.config'
 import {
+    isAiFailedReviewSubmission,
     isContestReviewPhaseSubmission,
     shouldIncludeInReviewPhase,
 } from '../../utils/reviewPhaseGuards'
@@ -171,10 +172,6 @@ const sortSubmissionsByReviewScoreDesc = (
 
     return entries.map(entry => entry.submission)
 }
-
-const isAiFailedReviewSubmission = (submission?: SubmissionInfo): boolean => (
-    (submission?.status || '').toUpperCase() === 'AI_FAILED_REVIEW'
-)
 
 const mergeSubmissionsById = (
     primary: SubmissionInfo[],

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/iterativeReviewFiltering.ts
@@ -4,7 +4,10 @@ import {
     BackendResource,
     SubmissionInfo,
 } from '../../models'
-import { shouldIncludeInReviewPhase } from '../../utils/reviewPhaseGuards'
+import {
+    isAiFailedReviewSubmission,
+    shouldIncludeInReviewPhase,
+} from '../../utils/reviewPhaseGuards'
 
 interface FilterIterativeReviewRowsArgs {
     aiReviewDecisionsBySubmissionId?: Record<string, AiReviewDecision>
@@ -26,10 +29,6 @@ interface IterativePlaceholderRowArgs {
 
 interface LimitFirst2FinishIterativeRowsOptions {
     forceSingleRow?: boolean
-}
-
-function isAiFailedReviewSubmission(submission: SubmissionInfo): boolean {
-    return (submission.status ?? '').toUpperCase() === 'AI_FAILED_REVIEW'
 }
 
 function isAiLockedByDecision(

--- a/src/apps/review/src/lib/components/TableReview/TableReview.tsx
+++ b/src/apps/review/src/lib/components/TableReview/TableReview.tsx
@@ -83,7 +83,10 @@ import {
     isSubmissionReviewerActionRow,
     resolveSubmissionReviewResult,
 } from '../common/reviewResult'
-import { shouldIncludeInReviewPhase } from '../../utils/reviewPhaseGuards'
+import {
+    isAiFailedReviewSubmission,
+    shouldIncludeInReviewPhase,
+} from '../../utils/reviewPhaseGuards'
 import { CollapsibleAiReviewsRow } from '../CollapsibleAiReviewsRow'
 
 import { EscalationModals } from './EscalationModals'
@@ -149,9 +152,11 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
 
     const isTablet = useMemo<boolean>(() => screenWidth <= 744, [screenWidth])
     const reviewPhaseDatas = useMemo<SubmissionInfo[]>(
-        () => datas.filter(submission => shouldIncludeInReviewPhase(
-            submission,
-            challengeInfo?.phases,
+        () => datas.filter(submission => (
+            // AI-locked submissions may carry no Review-phase review yet, but reviewers and
+            // copilots still need the row to escalate, verify, or unlock them.
+            isAiFailedReviewSubmission(submission)
+            || shouldIncludeInReviewPhase(submission, challengeInfo?.phases)
         )),
         [challengeInfo?.phases, datas],
     )
@@ -278,7 +283,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
                     return true
                 }
 
-                return (submission.status ?? '').toUpperCase() === 'AI_FAILED_REVIEW'
+                return isAiFailedReviewSubmission(submission)
             },
         ),
         [props.screeningOutcome.failingSubmissionIds],
@@ -370,7 +375,7 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
         submission: SubmissionReviewerRow,
         decision?: AiReviewEscalationDecision,
     ): boolean => {
-        if (submission.status !== 'AI_FAILED_REVIEW') {
+        if (!isAiFailedReviewSubmission(submission)) {
             return false
         }
 
@@ -840,13 +845,10 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
         }
 
         appendAction(buildPrimaryAction(), 'primary')
-        if (submission.isFirstReviewerRow) {
-            appendAction(buildEscalateAction(), 'escalate')
-            appendAction(buildVerifyAction(), 'verify')
-            appendAction(buildUnlockAction(), 'unlock')
-            appendAction(buildHistoryAction(), 'history')
-        }
-
+        appendAction(buildEscalateAction(), 'escalate')
+        appendAction(buildVerifyAction(), 'verify')
+        appendAction(buildUnlockAction(), 'unlock')
+        appendAction(buildHistoryAction(), 'history')
         appendAction(buildReopenAction(), 'reopen')
 
         if (!actionEntries.length) {

--- a/src/apps/review/src/lib/components/TableReview/TableReview.tsx
+++ b/src/apps/review/src/lib/components/TableReview/TableReview.tsx
@@ -844,12 +844,14 @@ export const TableReview: FC<TableReviewProps> = (props: TableReviewProps) => {
             )
         }
 
-        appendAction(buildPrimaryAction(), 'primary')
-        appendAction(buildEscalateAction(), 'escalate')
-        appendAction(buildVerifyAction(), 'verify')
-        appendAction(buildUnlockAction(), 'unlock')
-        appendAction(buildHistoryAction(), 'history')
-        appendAction(buildReopenAction(), 'reopen')
+        if (submission.isFirstReviewerRow) {
+            appendAction(buildPrimaryAction(), 'primary')
+            appendAction(buildEscalateAction(), 'escalate')
+            appendAction(buildVerifyAction(), 'verify')
+            appendAction(buildUnlockAction(), 'unlock')
+            appendAction(buildHistoryAction(), 'history')
+            appendAction(buildReopenAction(), 'reopen')
+        }
 
         if (!actionEntries.length) {
             return (

--- a/src/apps/review/src/lib/utils/reviewPhaseGuards.spec.ts
+++ b/src/apps/review/src/lib/utils/reviewPhaseGuards.spec.ts
@@ -1,6 +1,10 @@
 import type { BackendPhase, SubmissionInfo } from '../models'
 
-import { isContestReviewPhaseSubmission } from './reviewPhaseGuards'
+import {
+    isAiFailedReviewSubmission,
+    isContestReviewPhaseSubmission,
+    shouldIncludeInReviewPhase,
+} from './reviewPhaseGuards'
 
 const reviewPhase: BackendPhase = {
     constraints: [],
@@ -91,5 +95,36 @@ describe('isContestReviewPhaseSubmission', () => {
             'Review',
         ))
             .toBe(false)
+    })
+})
+
+describe('isAiFailedReviewSubmission', () => {
+    it('detects AI-locked submissions regardless of status casing', () => {
+        expect(isAiFailedReviewSubmission({ status: 'AI_FAILED_REVIEW' } as SubmissionInfo))
+            .toBe(true)
+        expect(isAiFailedReviewSubmission({ status: 'ai_failed_review' } as SubmissionInfo))
+            .toBe(true)
+    })
+
+    it('ignores other submission statuses', () => {
+        expect(isAiFailedReviewSubmission({ status: 'ACTIVE' } as SubmissionInfo))
+            .toBe(false)
+        expect(isAiFailedReviewSubmission(undefined))
+            .toBe(false)
+    })
+
+    it('keeps AI-failed submissions visible even when the phase guard excludes them', () => {
+        const aiFailedSubmission = {
+            id: 'submission-ai-failed',
+            memberId: '1001',
+            status: 'AI_FAILED_REVIEW',
+            type: 'Contest Submission',
+        } as SubmissionInfo
+
+        // No review-phase hints, so the phase guard alone would drop the row.
+        expect(shouldIncludeInReviewPhase(aiFailedSubmission, [reviewPhase]))
+            .toBe(false)
+        expect(isAiFailedReviewSubmission(aiFailedSubmission))
+            .toBe(true)
     })
 })

--- a/src/apps/review/src/lib/utils/reviewPhaseGuards.ts
+++ b/src/apps/review/src/lib/utils/reviewPhaseGuards.ts
@@ -159,6 +159,19 @@ export const isContestReviewPhaseSubmission = (
     return normalizedCandidates.has(normalizeReviewPhaseKey(targetPhaseName))
 }
 
+/**
+ * Detects submissions the AI reviewer failed and locked.
+ *
+ * @param submission - Submission candidate.
+ * @returns True when the submission status marks an AI review failure.
+ * @throws This helper does not throw.
+ * Such submissions must stay visible on the Review tab so reviewers and copilots
+ * can escalate, verify, or unlock them even without a Review-phase review record.
+ */
+export const isAiFailedReviewSubmission = (submission?: SubmissionInfo): boolean => (
+    (submission?.status ?? '').toUpperCase() === 'AI_FAILED_REVIEW'
+)
+
 export const shouldIncludeInReviewPhase = (
     submission?: SubmissionInfo,
     phases?: BackendPhase[],


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-5954


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request refactors how the application detects and handles AI-failed review submissions to improve code reuse and maintainability. The main change is centralizing the `isAiFailedReviewSubmission` logic in the shared `reviewPhaseGuards` utility, replacing local implementations and ensuring consistent behavior across the codebase. Additional updates include improved test coverage and minor logic adjustments for clarity.

### Refactoring and Code Reuse

* Moved the `isAiFailedReviewSubmission` function to `reviewPhaseGuards.ts` and updated all usages across components to import and use this shared utility, removing local duplicates. [[1]](diffhunk://#diff-1a0ff7342faf5fd6a69ae7e93ecd8e636676eb6175666cec64bdfef6b348f956R45) [[2]](diffhunk://#diff-1a0ff7342faf5fd6a69ae7e93ecd8e636676eb6175666cec64bdfef6b348f956L175-L178) [[3]](diffhunk://#diff-2d65ac02c0731d17705ac17449f570e79cc746e2c46723e6ab0c131d1f128643L7-R10) [[4]](diffhunk://#diff-2d65ac02c0731d17705ac17449f570e79cc746e2c46723e6ab0c131d1f128643L31-L34) [[5]](diffhunk://#diff-663244d0e8e80ae8781f063cb40175eb0346671acefc4e2eb6634d8136868cb0L86-R89) [[6]](diffhunk://#diff-2491aeb97406ce3d0f4ff5e2bb3ac924e6f7f150097ac78d68cb77e9b1f30757R162-R174)

### Logic and Behavior Updates

* Updated the Review Table logic to always display AI-failed submissions, even if they don't pass the regular review phase guard, ensuring they remain actionable for reviewers and copilots.
* Replaced direct status checks for `'AI_FAILED_REVIEW'` with the new utility function for consistency and clarity in multiple locations. [[1]](diffhunk://#diff-663244d0e8e80ae8781f063cb40175eb0346671acefc4e2eb6634d8136868cb0L281-R286) [[2]](diffhunk://#diff-663244d0e8e80ae8781f063cb40175eb0346671acefc4e2eb6634d8136868cb0L373-R378)

### Testing Improvements

* Added comprehensive unit tests for `isAiFailedReviewSubmission`, including case-insensitivity and scenarios where the submission is undefined or has other statuses. [[1]](diffhunk://#diff-a9a034ef2cdb61dd548310e384ff4c21becd9935e625c97bfe470e57f5388855L3-R7) [[2]](diffhunk://#diff-a9a034ef2cdb61dd548310e384ff4c21becd9935e625c97bfe470e57f5388855R100-R130)

### Minor UI Logic Fix

* Removed an unnecessary conditional around action button rendering in the review table, ensuring all relevant actions are available.