### PR TITLE
PM-5562: Preserve aggregate Marathon Match wins

### DIFF
--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx
@@ -595,6 +595,38 @@ describe('getSubTrackSummaryStats', () => {
                 wins: 2,
             })
     })
+
+    it('keeps aggregate Marathon Match wins when legacy placement history is partial', () => {
+        const summaryStats = getSubTrackSummaryStats({
+            challenges: 225,
+            name: 'MARATHON_MATCH',
+            submissions: {
+                submissions: 7,
+            },
+            wins: 76,
+        } as MemberStats, [
+            {
+                challengeId: 'legacy-mm-1',
+                challengeName: 'Legacy Marathon Match 1',
+                newRating: 1210,
+                placement: 122,
+                ratingDate: 1301961600000,
+            },
+            {
+                challengeId: 'legacy-mm-2',
+                challengeName: 'Legacy Marathon Match 2',
+                newRating: 1218,
+                placement: 145,
+                ratingDate: 1302652800000,
+            },
+        ])
+
+        expect(summaryStats)
+            .toEqual({
+                submissions: 7,
+                wins: 76,
+            })
+    })
 })
 
 describe('getTrackSummaryStats', () => {

--- a/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
+++ b/src/apps/profiles/src/hooks/useFetchActiveTracks.tsx
@@ -120,7 +120,8 @@ export const getSubTrackDisplaySubmissionCount = (subTrack?: MemberStats): numbe
  * Some unified stats rows currently include challenge/rating history while the
  * aggregate win or submission counters are stale, omitted, or left at zero. In
  * that case, placement-bearing history is used for wins and history/challenge
- * count is used as the minimum visible submission count.
+ * count is used as the minimum visible submission count. Legacy Marathon Match
+ * history is partial, so its explicit aggregate win counter remains authoritative.
  *
  * @param {MemberStats | undefined} subTrack - The subtrack to summarize.
  * @param {StatsHistory[]} trackHistory - Optional history rows for the same subtrack.
@@ -130,16 +131,21 @@ export const getSubTrackSummaryStats = (
     subTrack?: MemberStats,
     trackHistory: StatsHistory[] = [],
 ): SubTrackSummaryStats => {
-    const statWins = getFiniteNumber(subTrack?.wins) ?? 0
+    const aggregateWins = getFiniteNumber(subTrack?.wins)
+    const statWins = aggregateWins ?? 0
     const historyWithPlacements = trackHistory
         .filter(history => getFiniteNumber(history.placement) !== undefined)
     const historyWins = historyWithPlacements.filter(history => history.placement === 1).length
     const displaySubmissions = getSubTrackDisplaySubmissionCount(subTrack) ?? 0
     const historySubmissions = trackHistory.length
+    const hasAuthoritativeAggregateWins = subTrack?.name === 'MARATHON_MATCH'
+        && aggregateWins !== undefined
 
     return {
         submissions: Math.max(displaySubmissions, historySubmissions),
-        wins: historyWithPlacements.length > 0 ? historyWins : statWins,
+        wins: historyWithPlacements.length > 0 && !hasAuthoritativeAggregateWins
+            ? historyWins
+            : statWins,
     }
 }
 


### PR DESCRIPTION
What was broken

The previous PM-5562 follow-up fixed Development totals for subtracks whose
history had no placement data. QA still found that profile totals for `pops`
and `wleite` showed 76 instead of 152 and 2 instead of 36.

Root cause

Both remaining gaps are legacy Marathon Match wins. Those history payloads
contain placement fields but are incomplete: `pops` has 5 history rows for 225
challenges and `wleite` has 87 rows for 575 challenges. None of those partial
rows records a first place, so the shared subtrack summary replaced valid
aggregate win counters (76 and 34) with zero placement wins. The prior fix only
covered histories with no placement fields at all.

What was changed

- Keep an explicit aggregate wins value authoritative for `MARATHON_MATCH`.
- Continue using placement-derived wins for modern tracks, preserving the
  PM-5458 stale-counter correction.
- Preserve PR #2172's Development deduplication and rating-only history fixes.
- Challenge and submission aggregation is unchanged.

Any added/updated tests

- Added a `getSubTrackSummaryStats` regression case modeled on the `pops`
  payload, proving that 76 aggregate Marathon Match wins survive partial
  placement history with no first-place rows.
- `yarn test:no-watch src/apps/profiles/src/hooks/useFetchActiveTracks.spec.tsx`
  passes: 15 tests.
- `yarn lint` passes cleanly.
- `yarn run build` succeeds; it reports only existing repository warnings.
- Live dev API validation now computes 152 wins for `pops` and 36 for `wleite`,
  matching their API totals.

The broader profiles test command was also run: 14 suites pass, including all
PM-5562 coverage. Two unrelated baseline suites still fail for the same reasons
recorded on the prior attempt: `MemberRatingCard` is missing a
`useProfileCompleteness` mock, and `MemberRatingInfoModal` has a stale `2200+`
expectation.
