### PR TITLE
PM-5935: Render a not-found page instead of a blank page for unowned paths

### DIFF
--- a/src/apps/platform/src/platform.routes.tsx
+++ b/src/apps/platform/src/platform.routes.tsx
@@ -25,11 +25,27 @@ const Home: LazyLoadedComponent = lazyLoad(
     'HomePage',
 )
 
+const NotFound: LazyLoadedComponent = lazyLoad(
+    () => import('./routes/not-found'),
+    'NotFoundPage',
+)
+
 const homeRoutes: ReadonlyArray<PlatformRoute> = [
     {
         element: <Home />,
         id: 'Home page',
         route: '',
+    },
+]
+
+// Catch-all for paths Platform UI is served for but does not own a route for,
+// eg. `/opportunities` on the Topcoder apex host. React-router ranks the `*`
+// path last, so this never shadows a route declared above.
+const notFoundRoutes: ReadonlyArray<PlatformRoute> = [
+    {
+        element: <NotFound />,
+        id: 'Not found page',
+        route: '*',
     },
 ]
 
@@ -57,4 +73,5 @@ export const platformRoutes: Array<PlatformRoute> = [
     ...adminRoutes,
     ...reportsRoutes,
     ...customerPortalRoutes,
+    ...notFoundRoutes,
 ]

--- a/src/apps/platform/src/routes/not-found/NotFound.module.scss
+++ b/src/apps/platform/src/routes/not-found/NotFound.module.scss
@@ -1,0 +1,31 @@
+@import "@libs/ui/styles/includes";
+
+.container {
+    min-height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: $sp-6;
+    padding: $sp-15 $sp-8;
+    color: $black-100;
+
+    svg {
+        color: $black-60;
+    }
+}
+
+.title {
+    @include font-barlow;
+    font-weight: 600;
+    font-size: 28px;
+    line-height: 34px;
+    margin: 0;
+}

--- a/src/apps/platform/src/routes/not-found/NotFound.spec.tsx
+++ b/src/apps/platform/src/routes/not-found/NotFound.spec.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import type { PropsWithChildren } from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import NotFoundPage from './NotFound'
+
+jest.mock('~/libs/ui', () => ({
+    ContentLayout: (props: PropsWithChildren): JSX.Element => <div>{props.children}</div>,
+    IconOutline: {
+        ExclamationCircleIcon: (): JSX.Element => <svg />,
+    },
+    LinkButton: (props: PropsWithChildren<{ to: string }>): JSX.Element => (
+        <a href={props.to}>{props.children}</a>
+    ),
+    PageTitle: (): JSX.Element => <></>,
+}), { virtual: true })
+
+// `getRouteElement` renders a childless `PlatformRoute` as `<Route path={route.route} />`,
+// so these paths mirror the platform `homeRoutes` and `notFoundRoutes` entries.
+function renderPlatformRoutes(pathname: string): void {
+    render(
+        <MemoryRouter initialEntries={[pathname]}>
+            <Routes>
+                <Route element={<div>home page</div>} path='' />
+                <Route element={<NotFoundPage />} path='*' />
+            </Routes>
+        </MemoryRouter>,
+    )
+}
+
+describe('NotFoundPage', () => {
+    it('renders a message instead of a blank page for an unmatched path', () => {
+        renderPlatformRoutes('/opportunities')
+
+        expect(screen.getByRole('alert'))
+            .toBeInTheDocument()
+        expect(screen.getByText('We were unable to find that page'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Go to the home page'))
+            .toHaveAttribute('href', '/')
+    })
+
+    it('does not shadow a route the platform does own', () => {
+        renderPlatformRoutes('/')
+
+        expect(screen.getByText('home page'))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('alert'))
+            .not.toBeInTheDocument()
+    })
+})

--- a/src/apps/platform/src/routes/not-found/NotFound.tsx
+++ b/src/apps/platform/src/routes/not-found/NotFound.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+
+import {
+    ContentLayout,
+    IconOutline,
+    LinkButton,
+    PageTitle,
+} from '~/libs/ui'
+
+import styles from './NotFound.module.scss'
+
+/**
+ * Fallback page for a path Platform UI is served for but has no route for.
+ *
+ * Without it react-router matches nothing, the router renders an empty
+ * container inside the app shell, and the user is shown a blank page.
+ */
+const NotFoundPage: FC<{}> = () => (
+    <ContentLayout outerClass={styles.container}>
+        <PageTitle>Page Not Found | Topcoder</PageTitle>
+
+        <div className={styles.content} role='alert'>
+            <IconOutline.ExclamationCircleIcon className='icon-xxxl' />
+            <h2 className={styles.title}>We were unable to find that page</h2>
+            <p className='body-main'>
+                The page you requested does not exist or is not available yet.
+            </p>
+            <LinkButton primary size='lg' to='/'>
+                Go to the home page
+            </LinkButton>
+        </div>
+    </ContentLayout>
+)
+
+export default NotFoundPage

--- a/src/apps/platform/src/routes/not-found/index.ts
+++ b/src/apps/platform/src/routes/not-found/index.ts
@@ -1,0 +1,1 @@
+export { default as NotFoundPage } from './NotFound'


### PR DESCRIPTION
## What was broken

The Topcoder opportunities page showed nothing at all. On
`https://topcoder-dev.com/opportunities` the Platform UI shell loaded (header, footer,
application container) but the content area stayed empty, and the browser console
reported `No routes matched location "/opportunities"`.

## Root cause

The website CloudFront viewer-request function now hands `/opportunities` and
`/opportunities/*` on the apex host to the Platform UI origin (topcoder-website commit
"Route opportunities to platform UI"), and the new Opportunities application is still on
the unmerged `opportunities-v6` branch (PR #2147). Platform UI therefore serves the
request but has no route registered for that path.

`PlatformRouter` renders one `<Route>` per entry in `platformRoutes`, none of which
matched, so react-router rendered nothing and the user saw a blank page. Platform UI had
no fallback route at all, so the same blank page appeared for any path routed to it that
it does not own.

## What was changed

- Added `NotFoundPage` under `src/apps/platform/src/routes/not-found`, reusing the
  existing `ContentLayout`, `PageTitle`, `IconOutline` and `LinkButton` components and
  mirroring the styling of the existing `MemberNotFound` page.
- Registered it in `platformRoutes` as a `route: '*'` catch-all, placed last in the list.

React-router ranks the `*` path lowest, so the fallback cannot shadow any route declared
above it, and `routeGetActive` never selects it because `isActiveTool` matches with
`startsWith(route.route)`. On an app subdomain `routeMatchAppRouter` still replaces
`allRoutes` with that app's router, so subdomain behaviour is unchanged.

`/opportunities` now renders a clear "We were unable to find that page" message with a
link home instead of a blank page. Once the Opportunities application merges,
`/opportunities` matches its own route and the fallback is no longer reached.

### Verified against a local `yarn build:dev` bundle

| path | before | after |
| --- | --- | --- |
| `/opportunities` | blank | not-found page |
| `/opportunities/detail` | blank | not-found page |
| `/` | home route | home route (unchanged) |
| `/support`, `/onboarding` | owned routes | owned routes (unchanged) |

## Any added/updated tests

Added `src/apps/platform/src/routes/not-found/NotFound.spec.tsx`, which renders the
platform home and fallback route shapes together and asserts that:

- `/opportunities` renders the not-found content with a link to `/`
- `/` still renders the home route, i.e. the catch-all does not shadow an owned route

`yarn lint`, `npx tsc --noEmit` and `yarn build:dev` all pass. `yarn test:no-watch`
reports 1171 passing tests with 24 failures in 19 suites; the identical 19 suites and 24
tests fail on an unmodified `origin/dev` checkout, so no new failures are introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
