### PR TITLE
PM-5925 - move gitea endpoint to /reviews

### DIFF
--- a/src/apps/work/src/lib/services/gitea-teams.service.spec.ts
+++ b/src/apps/work/src/lib/services/gitea-teams.service.spec.ts
@@ -50,6 +50,8 @@ describe('searchGiteaTeams', () => {
         const teams = await searchGiteaTeams('  reviewers  ')
 
         expect(mockedGet.mock.calls[0][0])
+            .toContain('/reviews/gitea/teams?')
+        expect(mockedGet.mock.calls[0][0])
             .toContain('q=reviewers')
         expect(mockedGet.mock.calls[0][0])
             .toContain('limit=20')

--- a/src/apps/work/src/lib/services/gitea-teams.service.ts
+++ b/src/apps/work/src/lib/services/gitea-teams.service.ts
@@ -3,7 +3,7 @@ import { xhrGetAsync } from '~/libs/core'
 
 import { GiteaTeam } from '../models'
 
-const GITEA_TEAMS_API_URL = `${EnvironmentConfig.API.V6}/gitea/teams`
+const GITEA_TEAMS_API_URL = `${EnvironmentConfig.API.V6}/reviews/gitea/teams`
 
 const DEFAULT_SEARCH_LIMIT = 20
 


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-5925


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request updates the Gitea teams service to use the correct API endpoint for team searches and improves the related test to ensure the endpoint is used as expected. The most important changes are:

**API Endpoint Update:**
* Changed the `GITEA_TEAMS_API_URL` in `gitea-teams.service.ts` to use `/reviews/gitea/teams` instead of `/gitea/teams` to align with the correct backend route.

**Test Improvements:**
* Added a test assertion in `gitea-teams.service.spec.ts` to verify that the API call uses the `/reviews/gitea/teams` endpoint.