### PR TITLE
Add Review Style details to Opportunities

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -142,6 +142,12 @@ field is present for the caller.
 - Review opportunities: Review API metadata search. The application action
   uses `defaultApplicationRole` or a role selected from `applicationRoles`.
 
+Challenge details load the authenticated Review API
+`GET /v6/ai-review/configs/:challengeId` contract to render the Review Style
+rail. `AI_ONLY` and `AI_GATING` map to their Figma labels and expose the
+configuration's Instant Review state; a missing configuration or an anonymous
+viewer uses the manual Community Review Board presentation.
+
 Challenge registration and registrant displays resolve the canonical
 Submitter resource role and exclude copilot, reviewer, observer, and manager
 resources. The Registrants tab requests bounded Resource API pages and uses its

--- a/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
@@ -137,6 +137,62 @@
     button {
         margin-top: 0;
     }
+
+    a,
+    button {
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 20px;
+    }
+}
+
+.reviewStyleList {
+    margin: 0;
+    padding-left: 21px;
+
+    li + li {
+        margin-top: 8px;
+    }
+}
+
+.reviewStyleRow {
+    align-items: center;
+    display: inline-flex;
+    gap: 8px;
+    vertical-align: top;
+}
+
+.card button.reviewStyleInfoButton {
+    color: #161616;
+    flex: 0 0 20px;
+    height: 20px;
+    margin: 0;
+    padding: 0;
+    width: 20px;
+
+    svg {
+        height: 20px;
+        width: 20px;
+    }
+}
+
+.reviewStyleStatus {
+    color: #617178;
+    margin: 0;
+}
+
+.reviewStyleTooltip {
+    background: #001e2e;
+    border-radius: 8px;
+    box-shadow: none;
+    color: #fff;
+    font-family: 'Nunito Sans', sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 16px;
+    max-width: 248px;
+    padding: 16px;
+    text-align: center;
 }
 
 .resourceLinks {

--- a/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
@@ -1,0 +1,104 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { ChallengeAiReviewConfig, ChallengeOpportunity } from '../models'
+
+import { ChallengeSidebar } from './ChallengeSidebar'
+
+jest.mock('~/libs/ui', () => {
+    const Icon = (): JSX.Element => <svg />
+    return {
+        IconOutline: new Proxy({}, { get: () => Icon }),
+        Tooltip: (props: { children: JSX.Element; content: string }): JSX.Element => (
+            <>
+                {props.children}
+                <span role='tooltip'>{props.content}</span>
+            </>
+        ),
+    }
+}, { virtual: true })
+
+jest.mock('../utils', () => ({
+    challengeFileTypes: (): string[] => [],
+    challengeForumUrl: (): undefined => undefined,
+    challengeSidebarLinks: (): { attachments: []; challengeLinks: [] } => ({
+        attachments: [],
+        challengeLinks: [],
+    }),
+    challengeSubmissionLimit: (): undefined => undefined,
+}))
+
+const challenge: ChallengeOpportunity = {
+    id: 'challenge-id',
+    name: 'Review style challenge',
+    terms: [{ id: 'term-id', title: 'Standard Terms 2026' }],
+    track: 'Quality Assurance',
+}
+
+function renderSidebar(aiReviewConfig?: ChallengeAiReviewConfig): void {
+    render(
+        <MemoryRouter>
+            <ChallengeSidebar
+                aiReviewConfig={aiReviewConfig}
+                challenge={challenge}
+                onContactTeam={jest.fn()}
+                onShowTerms={jest.fn()}
+            />
+        </MemoryRouter>,
+    )
+}
+
+describe('ChallengeSidebar Review Style', () => {
+    it('shows manual review with the Figma explanation when no AI config exists', () => {
+        renderSidebar()
+
+        expect(screen.getByText('Manual'))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'About Manual' }))
+            .toBeInTheDocument()
+        expect(screen.getByText('Community Review Board performs a thorough review based on scorecards.'))
+            .toBeInTheDocument()
+        expect(screen.queryByText(/Instant Review is/))
+            .not.toBeInTheDocument()
+    })
+
+    it('shows AI-only review and the disabled Instant Review state', () => {
+        renderSidebar({
+            challengeId: challenge.id,
+            id: 'ai-only-config',
+            instantReview: false,
+            mode: 'AI_ONLY',
+        })
+
+        expect(screen.getByText('AI only'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Instant Review is Off'))
+            .toBeInTheDocument()
+        expect(screen.getByText('AI will perform a thorough review based on scorecards.'))
+            .toBeInTheDocument()
+        expect(screen.getByText('You will not receive AI feedback during the submission phase.'))
+            .toBeInTheDocument()
+    })
+
+    it('shows AI-gating review and the enabled Instant Review state', () => {
+        renderSidebar({
+            challengeId: challenge.id,
+            id: 'ai-gating-config',
+            instantReview: true,
+            mode: 'AI_GATING',
+        })
+
+        expect(screen.getByText('AI Gating'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Instant Review is On'))
+            .toBeInTheDocument()
+        expect(screen.getByText(
+            'AI performs a preliminary review, then the Community Review Board evaluates submissions that pass.',
+        ))
+            .toBeInTheDocument()
+        expect(screen.getByText('You will receive AI feedback during the submission phase'))
+            .toBeInTheDocument()
+    })
+})

--- a/src/apps/opportunities/src/components/ChallengeSidebar.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.tsx
@@ -2,9 +2,13 @@
 import { FC, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 
-import { IconOutline } from '~/libs/ui'
+import { IconOutline, Tooltip } from '~/libs/ui'
 
-import { ChallengeOpportunity, ChallengeTerm } from '../models'
+import {
+    ChallengeAiReviewConfig,
+    ChallengeOpportunity,
+    ChallengeTerm,
+} from '../models'
 import {
     challengeFileTypes,
     challengeForumUrl,
@@ -17,15 +21,118 @@ import programBanner from '../assets/ai-exponential-program.png'
 import styles from './ChallengeSidebar.module.scss'
 
 interface ChallengeSidebarProps {
+    aiReviewConfig?: ChallengeAiReviewConfig
     challenge: ChallengeOpportunity
     onContactTeam: () => void
     onShowTerms: (term?: ChallengeTerm) => void
+    reviewStyleLoading?: boolean
+    reviewStyleUnavailable?: boolean
 }
 
 interface SidebarCardProps {
     children: ReactNode
     icon: ReactNode
     title: string
+}
+
+interface ReviewStyleItemProps {
+    label: string
+    tooltip: string
+}
+
+interface ReviewStyleSectionProps {
+    config?: ChallengeAiReviewConfig
+    loading?: boolean
+    unavailable?: boolean
+}
+
+interface ReviewStylePresentation {
+    label: string
+    tooltip: string
+}
+
+const MANUAL_REVIEW_STYLE: ReviewStylePresentation = {
+    label: 'Manual',
+    tooltip: 'Community Review Board performs a thorough review based on scorecards.',
+}
+
+const AI_REVIEW_STYLES: Record<ChallengeAiReviewConfig['mode'], ReviewStylePresentation> = {
+    AI_GATING: {
+        label: 'AI Gating',
+        tooltip: 'AI performs a preliminary review, then the Community Review Board evaluates submissions that pass.',
+    },
+    AI_ONLY: {
+        label: 'AI only',
+        tooltip: 'AI will perform a thorough review based on scorecards.',
+    },
+}
+
+/**
+ * Renders one Figma review-style bullet and its accessible explanation.
+ *
+ * @param props member-facing label and tooltip copy.
+ * @returns one review-style list item.
+ * @throws Does not throw.
+ */
+const ReviewStyleItem: FC<ReviewStyleItemProps> = props => (
+    <li>
+        <span className={styles.reviewStyleRow}>
+            <span>{props.label}</span>
+            <Tooltip
+                className={styles.reviewStyleTooltip}
+                content={props.tooltip}
+                place='top'
+                triggerOn='click-hover'
+            >
+                <button
+                    aria-label={`About ${props.label}`}
+                    className={styles.reviewStyleInfoButton}
+                    type='button'
+                >
+                    <IconOutline.InformationCircleIcon aria-hidden='true' />
+                </button>
+            </Tooltip>
+        </span>
+    </li>
+)
+
+/**
+ * Renders the API-backed Review Style rows shared by every challenge type.
+ *
+ * @param props AI review configuration and request state.
+ * @returns Review Style heading with manual or AI-specific detail rows.
+ * @throws Does not throw.
+ */
+const ReviewStyleSection: FC<ReviewStyleSectionProps> = props => {
+    const presentation = props.config
+        ? AI_REVIEW_STYLES[props.config.mode] ?? MANUAL_REVIEW_STYLE
+        : MANUAL_REVIEW_STYLE
+
+    return (
+        <div className={styles.infoSection}>
+            <h3>
+                <IconOutline.DocumentSearchIcon />
+                Review Style
+            </h3>
+            {props.loading
+                ? <p className={styles.reviewStyleStatus}>Loading review style…</p>
+                : props.unavailable
+                    ? <p className={styles.reviewStyleStatus}>Review style is unavailable.</p>
+                    : (
+                        <ul className={styles.reviewStyleList}>
+                            <ReviewStyleItem {...presentation} />
+                            {props.config && (
+                                <ReviewStyleItem
+                                    label={`Instant Review is ${props.config.instantReview ? 'On' : 'Off'}`}
+                                    tooltip={props.config.instantReview
+                                        ? 'You will receive AI feedback during the submission phase'
+                                        : 'You will not receive AI feedback during the submission phase.'}
+                                />
+                            )}
+                        </ul>
+                    )}
+        </div>
+    )
 }
 
 /**
@@ -208,16 +315,14 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                         </div>
                     </>
                 )}
+                <ReviewStyleSection
+                    config={props.aiReviewConfig}
+                    loading={props.reviewStyleLoading}
+                    unavailable={props.reviewStyleUnavailable}
+                />
                 <div className={styles.infoSection}>
                     <h3>
-                        <IconOutline.UserGroupIcon />
-                        Review Style
-                    </h3>
-                    <p>{designChallenge ? 'Community Review Board' : 'Challenge Review'}</p>
-                </div>
-                <div className={styles.infoSection}>
-                    <h3>
-                        <IconOutline.ScaleIcon />
+                        <IconOutline.ShieldCheckIcon />
                         Challenge Terms
                     </h3>
                     {(props.challenge.terms ?? []).length > 0

--- a/src/apps/opportunities/src/models/opportunity.models.ts
+++ b/src/apps/opportunities/src/models/opportunity.models.ts
@@ -98,6 +98,17 @@ export interface ChallengeMetadata {
     value: unknown
 }
 
+/** AI review modes exposed by Review API for a challenge. */
+export type ChallengeAiReviewMode = 'AI_GATING' | 'AI_ONLY'
+
+/** Public-facing subset of a challenge's AI review configuration. */
+export interface ChallengeAiReviewConfig {
+    challengeId: string
+    id: string
+    instantReview: boolean
+    mode: ChallengeAiReviewMode
+}
+
 export interface ChallengeOpportunity {
     attachments?: ChallengeAttachment[]
     currentPhase?: ChallengePhase

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -117,6 +117,7 @@ jest.mock('../components/challenge-card.utils', () => ({
 jest.mock('../services', () => ({
     agreeToChallengeTerms: jest.fn(),
     deleteChallengeSubmission: (...args: unknown[]) => mockDeleteSubmission(...args),
+    getChallengeAiReviewConfig: jest.fn(),
     getChallengeOpportunity: jest.fn(),
     getChallengeProjectResults: jest.fn(),
     getChallengeRegistration: jest.fn(),

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.spec.tsx
@@ -57,6 +57,7 @@ jest.mock('../components/challenge-card.utils', () => ({
 
 jest.mock('../services', () => ({
     agreeToChallengeTerms: jest.fn(),
+    getChallengeAiReviewConfig: jest.fn(),
     getChallengeOpportunity: jest.fn(),
     getChallengeProjectResults: jest.fn(),
     getChallengeRegistration: jest.fn(),

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -42,6 +42,7 @@ import {
     challengePlacementPrizes,
 } from '../components/challenge-card.utils'
 import {
+    ChallengeAiReviewConfig,
     ChallengeOpportunity,
     ChallengeProjectResult,
     ChallengeResource,
@@ -54,6 +55,7 @@ import {
 import {
     agreeToChallengeTerms,
     deleteChallengeSubmission,
+    getChallengeAiReviewConfig,
     getChallengeOpportunity,
     getChallengeProjectResults,
     getChallengeRegistration,
@@ -216,6 +218,11 @@ export const ChallengeDetailsPage: FC = () => {
         challengeId ? `opportunities:challenge:${challengeId}` : undefined,
         () => getChallengeOpportunity(challengeId),
         { revalidateOnFocus: false },
+    )
+    const aiReviewConfigResponse: SWRResponse<ChallengeAiReviewConfig | undefined, Error> = useSWR(
+        challengeId && profile ? ['opportunities:challenge-review-style', challengeId] : undefined,
+        () => getChallengeAiReviewConfig(challengeId),
+        { revalidateOnFocus: false, shouldRetryOnError: false },
     )
     const memberId = profile?.userId === undefined ? undefined : String(profile.userId)
     const registrationResponse: SWRResponse<ChallengeResource | undefined, Error> = useSWR(
@@ -461,9 +468,14 @@ export const ChallengeDetailsPage: FC = () => {
                 </section>
                 {activeTab === 'requirements' && (
                     <ChallengeSidebar
+                        aiReviewConfig={aiReviewConfigResponse.data}
                         challenge={challenge}
                         onContactTeam={() => setIssueOpen(true)}
                         onShowTerms={showTerms}
+                        reviewStyleLoading={aiReviewConfigResponse.isValidating
+                            && aiReviewConfigResponse.data === undefined
+                            && !aiReviewConfigResponse.error}
+                        reviewStyleUnavailable={!!aiReviewConfigResponse.error}
                     />
                 )}
             </div>

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -10,6 +10,7 @@ import {
     buildOpportunityPageUrl,
     createChallengeSubmission,
     deleteChallengeSubmission,
+    getChallengeAiReviewConfig,
     getChallengeProjectResults,
     getChallengeReviewSummations,
     getChallengeSubmissionHistory,
@@ -398,6 +399,37 @@ describe('opportunities service normalization', () => {
             .toBe('startDate')
         expect(startingSoon.searchParams.get('sortOrder'))
             .toBe('asc')
+    })
+
+    it('loads the challenge AI review configuration used by Review Style', async () => {
+        const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
+        get.mockResolvedValueOnce({
+            challengeId: 'challenge/id',
+            id: 'config-id',
+            instantReview: true,
+            mode: 'AI_GATING',
+        })
+
+        await expect(getChallengeAiReviewConfig('challenge/id'))
+            .resolves.toEqual(expect.objectContaining({
+                instantReview: true,
+                mode: 'AI_GATING',
+            }))
+        expect(get)
+            .toHaveBeenLastCalledWith('https://api.example/v6/ai-review/configs/challenge%2Fid')
+    })
+
+    it('treats a missing AI review config as manual review and propagates other failures', async () => {
+        const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
+        const networkError = new Error('Network unavailable')
+        get
+            .mockRejectedValueOnce({ response: { status: 404 } })
+            .mockRejectedValueOnce(networkError)
+
+        await expect(getChallengeAiReviewConfig('manual-challenge'))
+            .resolves.toBeUndefined()
+        await expect(getChallengeAiReviewConfig('failed-challenge'))
+            .rejects.toBe(networkError)
     })
 
     it('normalizes the public preview gallery totalCount contract', async () => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -12,6 +12,7 @@ import {
 import {
     ApiEnvelope,
     ApiListResponse,
+    ChallengeAiReviewConfig,
     ChallengeOpportunity,
     ChallengeProjectResult,
     ChallengeResource,
@@ -166,6 +167,21 @@ function appendValues(url: URL, name: string, values?: string[]): void {
 function unwrap<T>(payload: T | ApiEnvelope<T>): T {
     const envelope = payload as ApiEnvelope<T>
     return envelope.result?.content ?? envelope.content ?? payload as T
+}
+
+/**
+ * Reads the HTTP status exposed by either shared-XHR or Axios failures.
+ *
+ * @param error rejected request value.
+ * @returns numeric response status when one is available.
+ * @throws Does not throw.
+ */
+function requestStatus(error: unknown): number | undefined {
+    const failure = error as {
+        response?: { status?: number }
+        status?: number
+    }
+    return failure.status ?? failure.response?.status
 }
 
 /**
@@ -592,6 +608,26 @@ export async function getOpportunityPage(
  */
 export function getChallengeOpportunity(challengeId: string): Promise<ChallengeOpportunity> {
     return xhrGetAsync<ChallengeOpportunity>(`${V6_URL}/challenges/${encodeURIComponent(challengeId)}`)
+}
+
+/**
+ * Loads the latest AI review configuration used to explain a challenge's review style.
+ *
+ * @param challengeId challenge UUID.
+ * @returns AI configuration, or undefined when the challenge uses manual review.
+ * @throws Propagates authorization and network errors; a missing config is expected.
+ */
+export async function getChallengeAiReviewConfig(
+    challengeId: string,
+): Promise<ChallengeAiReviewConfig | undefined> {
+    try {
+        return await xhrGetAsync<ChallengeAiReviewConfig>(
+            `${V6_URL}/ai-review/configs/${encodeURIComponent(challengeId)}`,
+        )
+    } catch (error) {
+        if (requestStatus(error) === 404) return undefined
+        throw error
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- load the authenticated AI review configuration for challenge details, with the manual Figma presentation for missing configurations and anonymous viewers
- render AI only, AI Gating, and Instant Review states with the exact Figma tooltip copy and accessible triggers
- align the shared sidebar card typography, spacing, and icons, and add service/component coverage plus API documentation

## Testing
- yarn lint
- npx tsc --noEmit --pretty false
- yarn test:no-watch --runInBand src/apps/opportunities/src (30 suites, 169 tests)
- yarn build:dev (passes with existing repository warnings)