### PR TITLE
Fix analytics warehouse timeout handling

### DIFF
--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -25,10 +25,14 @@ or result limits.
 
 Reports are limited to 366 inclusive days and 2,000 decoded rows. Query waits
 leave time for a sanitized response. A failed or aborted statement is retried
-once within the same deadline. If Redshift Serverless needs longer than one
-HTTP request to resume, the statement remains active and a browser retry
-reattaches to it through a server-generated, thirty-minute idempotency window
-instead of starting another warehouse query. Concurrency and API throttles cap
+once within the same deadline. Clients can opt into resumable requests with
+`async=true`. If Redshift Serverless needs longer than one HTTP request, the API
+returns `202`, `Retry-After`, and a server-generated query token. The browser
+polls with that token until the original statement completes instead of
+starting another warehouse query. Tokens are accepted only for the exact SQL,
+validated parameters, retry attempt, and current or previous thirty-minute
+window, which permits one boundary crossing without making tokens reusable for
+other reports. Browser polling is bounded. Concurrency and API throttles cap
 warehouse pressure, and successful responses use `Cache-Control: private,
 no-store`. Logs contain request IDs and service-owned error categories only.
 
@@ -96,7 +100,7 @@ After deployment, expected public authorization behavior is:
 ```text
 no or malformed bearer token -> 401 from API Gateway
 valid token without analytics -> 403 from Lambda
-valid token with analytics    -> 200 aggregate JSON
+valid token with analytics    -> 200 aggregate JSON, or 202 until the query completes
 ```
 
 The canonical development endpoint is
@@ -105,6 +109,7 @@ route settings when adding 5 requests/second, burst 10, detailed metrics for
 the three `GET` routes and the public `OPTIONS /v1/analytics/{proxy+}` route.
 
 Also verify an invalid date returns `400`, an unsupported route returns `404`,
+an opted-in cold query returns resumable `202` responses instead of `504`,
 responses are `private, no-store`, and CloudWatch logs do not contain tokens,
 filters, SQL, or record values.
 

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -25,7 +25,9 @@ MAX_QUERY_ATTEMPTS = 2
 REPORT_CACHE_SECONDS = 60
 FILTER_CACHE_SECONDS = 300
 QUERY_TOKEN_WINDOW_SECONDS = 1_800
+QUERY_POLL_DELAY_MILLISECONDS = 1_000
 SAFE_FILTER_PATTERN = re.compile(r"^[A-Za-z0-9._~-]{1,100}$")
+QUERY_TOKEN_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 NO_FILTER_PARAMETER = "*"
 
 _redshift_data = boto3.client("redshift-data")
@@ -371,7 +373,7 @@ class QueryFailure(RuntimeError):
 
 
 class QueryTimeout(RuntimeError):
-    """Raised when a reusable reporting query cannot finish inside the HTTP deadline."""
+    """Raised with a reusable query token when work outlives one HTTP deadline."""
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -389,6 +391,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """
 
     request_id = _request_id(event, context)
+    asynchronous = False
     try:
         route_key = str(event.get("routeKey", ""))
         if route_key.startswith("OPTIONS "):
@@ -398,16 +401,26 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             return _response(403, {"message": "Analytics access is not permitted", "requestId": request_id})
 
         query = event.get("queryStringParameters") or {}
+        asynchronous = _asynchronous_query_requested(query)
+        query_token = _resume_query_token(query, asynchronous)
 
         if route_key == "GET /v1/analytics/filters":
-            return _response(200, _cached_report("filters", FILTER_CACHE_SECONDS, _filters_report, context))
+            return _response(
+                200,
+                _cached_report(
+                    "filters",
+                    FILTER_CACHE_SECONDS,
+                    lambda: _filters_report(context, query_token),
+                    context,
+                ),
+            )
         if route_key == "GET /v1/analytics/campaign":
             filters = _campaign_filters(query)
             cache_key = f"campaign:{json.dumps(filters, sort_keys=True)}"
             report = _cached_report(
                 cache_key,
                 REPORT_CACHE_SECONDS,
-                lambda: _campaign_report(filters, context),
+                lambda: _campaign_report(filters, context, query_token),
                 context,
             )
             return _response(200, report)
@@ -417,7 +430,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             report = _cached_report(
                 cache_key,
                 REPORT_CACHE_SECONDS,
-                lambda: _general_report(filters, context),
+                lambda: _general_report(filters, context, query_token),
                 context,
             )
             return _response(200, report)
@@ -425,7 +438,18 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         return _response(404, {"message": "Analytics route not found", "requestId": request_id})
     except ValueError as error:
         return _response(400, {"message": str(error), "requestId": request_id})
-    except QueryTimeout:
+    except QueryTimeout as error:
+        if asynchronous:
+            return _response(
+                202,
+                {
+                    "status": "pending",
+                    "queryToken": str(error),
+                    "retryAfterMs": QUERY_POLL_DELAY_MILLISECONDS,
+                    "requestId": request_id,
+                },
+                {"Retry-After": str(QUERY_POLL_DELAY_MILLISECONDS // 1_000)},
+            )
         return _response(504, {"message": "Analytics data is still being prepared. Please retry.", "requestId": request_id})
     except QueryFailure:
         _log_error(request_id, "redshift-query-failed")
@@ -468,8 +492,12 @@ def _cached_report(
     return result
 
 
-def _filters_report() -> dict[str, Any]:
+def _filters_report(context: Any, query_token: str | None = None) -> dict[str, Any]:
     """Load bounded campaign and surface filter options.
+
+    Args:
+        context: Lambda context used to respect the remaining deadline.
+        query_token: Optional server-issued token that resumes a pending statement.
 
     Returns:
         Filter option arrays and available event-date bounds.
@@ -478,7 +506,7 @@ def _filters_report() -> dict[str, Any]:
         QueryFailure or QueryTimeout when Redshift cannot return data.
     """
 
-    rows = _execute_query(FILTERS_SQL, [], None)
+    rows = _execute_query(FILTERS_SQL, [], context, query_token)
     options: dict[str, list[str]] = {
         "campaigns": [],
         "campaignIds": [],
@@ -515,12 +543,17 @@ def _filters_report() -> dict[str, Any]:
     }
 
 
-def _campaign_report(filters: dict[str, str], context: Any) -> dict[str, Any]:
+def _campaign_report(
+    filters: dict[str, str],
+    context: Any,
+    query_token: str | None = None,
+) -> dict[str, Any]:
     """Load and shape the ordered campaign funnel report.
 
     Args:
         filters: Validated date and UTM filter values.
         context: Lambda context used to respect the remaining deadline.
+        query_token: Optional server-issued token that resumes a pending statement.
 
     Returns:
         Funnel totals, daily series, campaign/landing breakdowns, and click locations.
@@ -529,7 +562,7 @@ def _campaign_report(filters: dict[str, str], context: Any) -> dict[str, Any]:
         QueryFailure or QueryTimeout when Redshift cannot return data.
     """
 
-    rows = _execute_query(CAMPAIGN_SQL, _sql_parameters(filters), context)
+    rows = _execute_query(CAMPAIGN_SQL, _sql_parameters(filters), context, query_token)
     summary = next((row for row in rows if row.get("row_type") == "summary"), {})
     totals = {
         "landingUsers": _integer(summary.get("metric_1")),
@@ -589,12 +622,17 @@ def _campaign_report(filters: dict[str, str], context: Any) -> dict[str, Any]:
     }
 
 
-def _general_report(filters: dict[str, str], context: Any) -> dict[str, Any]:
+def _general_report(
+    filters: dict[str, str],
+    context: Any,
+    query_token: str | None = None,
+) -> dict[str, Any]:
     """Load and shape general Topcoder site engagement analytics.
 
     Args:
         filters: Validated date and optional surface filter values.
         context: Lambda context used to respect the remaining deadline.
+        query_token: Optional server-issued token that resumes a pending statement.
 
     Returns:
         General totals, daily series, pages, traffic sources, and surfaces.
@@ -603,7 +641,7 @@ def _general_report(filters: dict[str, str], context: Any) -> dict[str, Any]:
         QueryFailure or QueryTimeout when Redshift cannot return data.
     """
 
-    rows = _execute_query(GENERAL_SQL, _sql_parameters(filters), context)
+    rows = _execute_query(GENERAL_SQL, _sql_parameters(filters), context, query_token)
     summary = next((row for row in rows if row.get("row_type") == "summary"), {})
     return {
         "generatedAt": _now_iso(),
@@ -724,6 +762,51 @@ def _general_filters(query: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def _asynchronous_query_requested(query: dict[str, Any]) -> bool:
+    """Validate and resolve the opt-in asynchronous warehouse protocol.
+
+    Args:
+        query: Untrusted API Gateway query string values.
+
+    Returns:
+        True only when the caller explicitly requests ``async=true``.
+
+    Raises:
+        ValueError when an unsupported async value is supplied.
+    """
+
+    value = query.get("async")
+    if value in (None, ""):
+        return False
+    if value != "true":
+        raise ValueError("The async query option must be true")
+    return True
+
+
+def _resume_query_token(query: dict[str, Any], asynchronous: bool) -> str | None:
+    """Validate an opaque server-issued token used to resume one statement.
+
+    Args:
+        query: Untrusted API Gateway query string values.
+        asynchronous: Whether the caller opted into asynchronous polling.
+
+    Returns:
+        A normalized SHA-256 token, or null when starting a new query.
+
+    Raises:
+        ValueError when a token is malformed or supplied without async polling.
+    """
+
+    value = query.get("queryToken")
+    if value in (None, ""):
+        return None
+    if not asynchronous:
+        raise ValueError("A query token requires async=true")
+    if not isinstance(value, str) or not QUERY_TOKEN_PATTERN.fullmatch(value):
+        raise ValueError("The query token is invalid")
+    return value
+
+
 def _date_filters(query: dict[str, Any]) -> dict[str, str]:
     """Parse an inclusive UTC date range with a safe 30-day default.
 
@@ -826,6 +909,7 @@ def _execute_query(
     sql: str,
     parameters: list[dict[str, str]],
     context: Any,
+    query_token: str | None = None,
 ) -> list[dict[str, Any]]:
     """Execute a fixed parameterized query with resumable timeout handling.
 
@@ -833,14 +917,16 @@ def _execute_query(
         sql: Server-owned SQL template.
         parameters: Validated Data API named parameters.
         context: Lambda context or null for the cached filter loader.
+        query_token: Optional server-issued token that resumes a pending statement.
 
     Returns:
         Query rows keyed by Redshift column name.
 
     Raises:
         QueryFailure after repeated provider failure or excess output and
-        QueryTimeout when the shared deadline expires. A timed-out statement
-        remains active so a client retry can resume polling it by idempotency token.
+        QueryTimeout containing the reusable token when the shared deadline
+        expires. ValueError when a token does not match this query and its
+        validated parameters.
     """
 
     request: dict[str, Any] = {
@@ -853,8 +939,14 @@ def _execute_query(
     if parameters:
         request["Parameters"] = parameters
     deadline = time.monotonic() + _query_wait_seconds(context)
-    for attempt in range(MAX_QUERY_ATTEMPTS):
-        request["ClientToken"] = _query_client_token(sql, parameters, attempt)
+    initial_attempt = _query_token_attempt(sql, parameters, query_token) if query_token else 0
+    for attempt in range(initial_attempt, MAX_QUERY_ATTEMPTS):
+        client_token = query_token if query_token and attempt == initial_attempt else _query_client_token(
+            sql,
+            parameters,
+            attempt,
+        )
+        request["ClientToken"] = client_token
         statement_id = _redshift_data.execute_statement(**request)["Id"]
         delay = 0.2
         while time.monotonic() < deadline:
@@ -868,7 +960,7 @@ def _execute_query(
             time.sleep(delay)
             delay = min(delay * 1.5, 1.0)
         else:
-            raise QueryTimeout("Redshift reporting query timed out")
+            raise QueryTimeout(client_token)
 
     raise QueryFailure("Redshift reporting query failed")
 
@@ -877,6 +969,7 @@ def _query_client_token(
     sql: str,
     parameters: list[dict[str, str]],
     attempt: int,
+    token_window: int | None = None,
 ) -> str:
     """Build a bounded idempotency key for one fixed reporting query.
 
@@ -884,6 +977,7 @@ def _query_client_token(
         sql: Server-owned SQL template.
         parameters: Validated named parameters.
         attempt: Provider retry index; failed statements receive a new token.
+        token_window: Optional explicit thirty-minute bucket used to validate a resume token.
 
     Returns:
         Sixty-four-character SHA-256 token stable within a thirty-minute window.
@@ -892,16 +986,44 @@ def _query_client_token(
         Does not raise for validated handler inputs and configured environment values.
     """
 
-    token_window = int(time.time() // QUERY_TOKEN_WINDOW_SECONDS)
+    effective_window = token_window if token_window is not None else int(time.time() // QUERY_TOKEN_WINDOW_SECONDS)
     fingerprint = json.dumps({
         "attempt": attempt,
         "database": os.environ["REDSHIFT_DATABASE"],
         "parameters": parameters,
         "sql": sql,
-        "tokenWindow": token_window,
+        "tokenWindow": effective_window,
         "workgroup": os.environ["REDSHIFT_WORKGROUP"],
     }, separators=(",", ":"), sort_keys=True)
     return hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()
+
+
+def _query_token_attempt(
+    sql: str,
+    parameters: list[dict[str, str]],
+    query_token: str,
+) -> int:
+    """Verify a resume token belongs to this exact server-owned query.
+
+    Args:
+        sql: Server-owned SQL template.
+        parameters: Validated Data API named parameters.
+        query_token: SHA-256 token returned by a pending response.
+
+    Returns:
+        Provider attempt encoded into the valid current or prior-window token.
+
+    Raises:
+        ValueError when the token belongs to another query, filter set, or expired window.
+    """
+
+    current_window = int(time.time() // QUERY_TOKEN_WINDOW_SECONDS)
+    for token_window in (current_window, current_window - 1):
+        for attempt in range(MAX_QUERY_ATTEMPTS):
+            expected = _query_client_token(sql, parameters, attempt, token_window)
+            if query_token == expected:
+                return attempt
+    raise ValueError("The query token is invalid or expired")
 
 
 def _query_wait_seconds(context: Any) -> float:
@@ -1057,12 +1179,17 @@ def _preflight_response() -> dict[str, Any]:
     }
 
 
-def _response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
+def _response(
+    status_code: int,
+    body: dict[str, Any],
+    additional_headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
     """Build a private JSON API Gateway proxy response.
 
     Args:
         status_code: HTTP response status.
         body: JSON-serializable response document.
+        additional_headers: Optional service-owned headers merged into the secure defaults.
 
     Returns:
         HTTP API v2 Lambda proxy response.
@@ -1071,16 +1198,19 @@ def _response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
         Does not raise for the service-owned response shapes.
     """
 
+    headers = {
+        "Cache-Control": "private, no-store",
+        "Content-Type": "application/json; charset=utf-8",
+        "Referrer-Policy": "no-referrer",
+        "Vary": "Authorization, Origin",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+    }
+    if additional_headers:
+        headers.update(additional_headers)
     return {
         "statusCode": status_code,
-        "headers": {
-            "Cache-Control": "private, no-store",
-            "Content-Type": "application/json; charset=utf-8",
-            "Referrer-Policy": "no-referrer",
-            "Vary": "Authorization, Origin",
-            "X-Content-Type-Options": "nosniff",
-            "X-Frame-Options": "DENY",
-        },
+        "headers": headers,
         "body": json.dumps(body, separators=(",", ":")),
     }
 

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -175,6 +175,56 @@ class AnalyticsHandlerTests(unittest.TestCase):
                     )
                     self.assertEqual(200, response["statusCode"])
 
+    def test_async_timeout_returns_a_private_pending_poll_response(self) -> None:
+        """Opted-in clients receive a reusable token instead of an HTTP failure."""
+
+        query_token = "a" * 64
+        with patch.object(
+            self.module,
+            "_execute_query",
+            side_effect=self.module.QueryTimeout(query_token),
+        ):
+            pending = self.module.handler(
+                self._event(
+                    "GET /v1/analytics/filters",
+                    ["analytics"],
+                    {"async": "true"},
+                ),
+                None,
+            )
+            legacy = self.module.handler(
+                self._event("GET /v1/analytics/filters", ["analytics"]),
+                None,
+            )
+
+        body = json.loads(pending["body"])
+        self.assertEqual(202, pending["statusCode"])
+        self.assertEqual("1", pending["headers"]["Retry-After"])
+        self.assertEqual("pending", body["status"])
+        self.assertEqual(query_token, body["queryToken"])
+        self.assertEqual(1_000, body["retryAfterMs"])
+        self.assertEqual(504, legacy["statusCode"])
+
+    def test_rejects_invalid_async_options_and_resume_tokens(self) -> None:
+        """Only opted-in clients can send a bounded server-issued query token."""
+
+        cases = [
+            {"async": "false"},
+            {"async": "true", "queryToken": "not-a-token"},
+            {"queryToken": "a" * 64},
+        ]
+        with patch.object(self.module, "_execute_query") as execute:
+            responses = [
+                self.module.handler(
+                    self._event("GET /v1/analytics/filters", ["analytics"], query),
+                    None,
+                )
+                for query in cases
+            ]
+
+        self.assertTrue(all(response["statusCode"] == 400 for response in responses))
+        execute.assert_not_called()
+
     def test_shared_api_preflight_does_not_require_a_role(self) -> None:
         """The public OPTIONS route returns no data and never queries Redshift."""
 
@@ -309,13 +359,12 @@ class AnalyticsHandlerTests(unittest.TestCase):
 
         self.assertEqual(2, execute.call_count)
 
-    def test_timeout_keeps_an_idempotent_statement_for_the_next_request(self) -> None:
-        """A client retry reuses rather than cancels a query that outlives one HTTP request."""
+    def test_timeout_token_resumes_across_an_idempotency_window_boundary(self) -> None:
+        """A pending response pins its statement even when the clock enters a new token window."""
 
         context = Mock()
         context.get_remaining_time_in_millis.return_value = 28_000
         with (
-            patch.object(self.module.time, "time", return_value=1_000),
             patch.object(self.module, "_query_wait_seconds", return_value=0),
             patch.object(
                 self.module._redshift_data,
@@ -324,16 +373,42 @@ class AnalyticsHandlerTests(unittest.TestCase):
             ) as execute,
             patch.object(self.module._redshift_data, "cancel_statement") as cancel,
         ):
-            for _ in range(2):
-                with self.assertRaises(self.module.QueryTimeout):
-                    self.module._execute_query("SELECT 1", [], context)
+            with (
+                patch.object(
+                    self.module.time,
+                    "time",
+                    return_value=self.module.QUERY_TOKEN_WINDOW_SECONDS - 1,
+                ),
+                self.assertRaises(self.module.QueryTimeout) as initial_timeout,
+            ):
+                self.module._execute_query("SELECT 1", [], context)
+            query_token = str(initial_timeout.exception)
+            with (
+                patch.object(
+                    self.module.time,
+                    "time",
+                    return_value=self.module.QUERY_TOKEN_WINDOW_SECONDS + 1,
+                ),
+                self.assertRaises(self.module.QueryTimeout) as resumed_timeout,
+            ):
+                self.module._execute_query("SELECT 1", [], context, query_token)
 
+        self.assertEqual(query_token, str(resumed_timeout.exception))
+        self.assertRegex(query_token, r"^[0-9a-f]{64}$")
         self.assertEqual(2, execute.call_count)
         self.assertEqual(
             execute.call_args_list[0].kwargs["ClientToken"],
             execute.call_args_list[1].kwargs["ClientToken"],
         )
         cancel.assert_not_called()
+
+    def test_resume_token_cannot_be_reused_for_another_query(self) -> None:
+        """A server token is bound to the fixed SQL and validated parameter set."""
+
+        with patch.object(self.module.time, "time", return_value=1_000):
+            query_token = self.module._query_client_token("SELECT 1", [], 0)
+            with self.assertRaisesRegex(ValueError, "invalid or expired"):
+                self.module._query_token_attempt("SELECT 2", [], query_token)
 
     def test_query_client_token_is_scoped_by_query_attempt_and_time_window(self) -> None:
         """Idempotency tokens reuse only the same query attempt inside one bounded window."""

--- a/src/apps/analytics/README.md
+++ b/src/apps/analytics/README.md
@@ -25,11 +25,11 @@ On `analytics.<domain>`, the same children are `/campaigns` and `/general`.
 
 ## Reports
 
-Campaign Analytics uses first-touch UTM attribution and an ordered cohort
-funnel. Its totals answer how many distinct landing visitors clicked, then
-registered for a challenge after clicking, then submitted after registering.
-It also shows campaign and landing-page breakdowns plus aggregate click
-locations by semantic element fields and ten-percentage-point viewport buckets.
+Campaign Analytics uses UTM attribution and an ordered cohort funnel. Its
+totals answer how many distinct landing visitors clicked, then registered for
+a challenge after clicking, then submitted after registering. It also shows
+campaign and landing-page breakdowns plus aggregate click locations by semantic
+element fields and ten-percentage-point viewport buckets.
 
 General Analytics shows page views, distinct visitors, clicks, and distinct
 clickers over time, with page, traffic-source, and instrumented-application
@@ -40,10 +40,12 @@ ranges are inclusive and limited to 366 days. The UI displays the warehouse's
 `dataThrough` value because the development transform currently runs daily.
 Empty dates in a series are not inferred as provider outages.
 
-Redshift Serverless can take one request to resume after an idle period. The UI
-automatically retries one warehouse timeout after a one-second delay while
-keeping the loading state visible. A second timeout is surfaced with the
-explicit retry action so requests remain bounded.
+Redshift Serverless can take longer than one HTTP request after an idle period.
+The UI opts into resumable queries and transparently polls `202` responses with
+the server-issued query token while keeping the loading state visible. Polling
+is bounded to twelve requests (roughly five minutes at the API's maximum query
+wait); after that, or after a genuine failure, the explicit retry action is
+shown.
 
 ## Privacy
 

--- a/src/apps/analytics/src/lib/services/analytics.service.spec.ts
+++ b/src/apps/analytics/src/lib/services/analytics.service.spec.ts
@@ -6,6 +6,7 @@ import {
     getAnalyticsFilters,
     getCampaignReport,
     getGeneralReport,
+    requestAnalyticsReport,
 } from './analytics.service'
 
 jest.mock('~/config', () => ({
@@ -35,7 +36,7 @@ describe('Analytics API service', () => {
         }))
             .toBe(
                 'https://api.example.com/v1/analytics/campaign'
-                + '?from=2026-08-01&to=2026-08-30&campaign=launch+2026',
+                + '?from=2026-08-01&to=2026-08-30&campaign=launch+2026&async=true',
             )
     })
 
@@ -55,19 +56,63 @@ describe('Analytics API service', () => {
         expect(mockedXhrGetAsync)
             .toHaveBeenNthCalledWith(
                 1,
-                'https://api.example.com/v1/analytics/filters',
+                'https://api.example.com/v1/analytics/filters?async=true',
             )
         expect(mockedXhrGetAsync)
             .toHaveBeenNthCalledWith(
                 2,
                 'https://api.example.com/v1/analytics/campaign'
-                + '?from=2026-08-01&to=2026-08-30&campaign=launch',
+                + '?from=2026-08-01&to=2026-08-30&campaign=launch&async=true',
             )
         expect(mockedXhrGetAsync)
             .toHaveBeenNthCalledWith(
                 3,
                 'https://api.example.com/v1/analytics/general'
-                + '?from=2026-08-01&to=2026-08-30&surface=platform_ui',
+                + '?from=2026-08-01&to=2026-08-30&surface=platform_ui&async=true',
             )
+    })
+
+    it('polls a pending warehouse query with its server-issued token', async () => {
+        const queryToken = 'a'.repeat(64)
+        const report = { campaigns: [], generatedAt: '2026-09-01T00:00:00Z' }
+        const wait = jest.fn()
+            .mockResolvedValue(undefined)
+        mockedXhrGetAsync
+            .mockResolvedValueOnce({
+                queryToken,
+                retryAfterMs: 1_000,
+                status: 'pending',
+            })
+            .mockResolvedValueOnce(report)
+
+        await expect(requestAnalyticsReport('filters', {}, wait))
+            .resolves.toEqual(report)
+        expect(wait)
+            .toHaveBeenCalledWith(1_000)
+        expect(mockedXhrGetAsync)
+            .toHaveBeenNthCalledWith(
+                2,
+                'https://api.example.com/v1/analytics/filters'
+                + `?async=true&queryToken=${queryToken}`,
+            )
+    })
+
+    it('bounds polling and exposes a timeout-shaped error', async () => {
+        const wait = jest.fn()
+            .mockResolvedValue(undefined)
+        mockedXhrGetAsync.mockResolvedValue({
+            queryToken: 'b'.repeat(64),
+            retryAfterMs: 10_000,
+            status: 'pending',
+        })
+
+        await expect(requestAnalyticsReport('filters', {}, wait))
+            .rejects.toMatchObject({ response: { status: 504 } })
+        expect(mockedXhrGetAsync)
+            .toHaveBeenCalledTimes(12)
+        expect(wait)
+            .toHaveBeenCalledTimes(11)
+        expect(wait)
+            .toHaveBeenLastCalledWith(5_000)
     })
 })

--- a/src/apps/analytics/src/lib/services/analytics.service.ts
+++ b/src/apps/analytics/src/lib/services/analytics.service.ts
@@ -13,6 +13,18 @@ import {
 export const ANALYTICS_API_BASE = EnvironmentConfig.ANALYTICS.API_URL.replace(/\/$/, '')
 
 type AnalyticsQueryValues = Partial<CampaignFilters & GeneralFilters>
+type AnalyticsPollWait = (milliseconds: number) => Promise<void>
+
+interface AnalyticsPendingResponse {
+    queryToken: string
+    retryAfterMs: number
+    status: 'pending'
+}
+
+const ANALYTICS_MAX_POLL_ATTEMPTS = 12
+const ANALYTICS_MAX_POLL_DELAY = 5_000
+const ANALYTICS_MIN_POLL_DELAY = 250
+const ANALYTICS_QUERY_TOKEN_PATTERN = /^[0-9a-f]{64}$/
 
 const ANALYTICS_QUERY_KEYS: Array<keyof AnalyticsQueryValues> = [
     'from',
@@ -29,12 +41,14 @@ const ANALYTICS_QUERY_KEYS: Array<keyof AnalyticsQueryValues> = [
  *
  * @param path API path relative to the configured analytics base.
  * @param values allowlisted scalar filters.
+ * @param queryToken optional server-issued token used to resume a pending warehouse query.
  * @returns absolute URL with encoded query values.
  * @throws Error when the analytics API has not been configured for the environment.
  */
 export function buildAnalyticsUrl(
     path: string,
     values: AnalyticsQueryValues = {},
+    queryToken: string | undefined = undefined,
 ): string {
     if (!ANALYTICS_API_BASE) {
         throw new Error('Analytics API is not configured for this environment')
@@ -46,8 +60,88 @@ export function buildAnalyticsUrl(
             const value = values[key]
             if (value) query.set(key, value)
         })
+    query.set('async', 'true')
+    if (queryToken) query.set('queryToken', queryToken)
     const encodedQuery = query.toString()
     return `${ANALYTICS_API_BASE}/${path}${encodedQuery ? `?${encodedQuery}` : ''}`
+}
+
+/**
+ * Waits for the bounded delay requested by a pending analytics response.
+ *
+ * @param milliseconds server-provided delay clamped by the caller.
+ * @returns promise resolved after the delay.
+ * @throws Does not throw under normal browser timer operation.
+ */
+function waitForAnalyticsPoll(milliseconds: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(resolve, milliseconds)
+    })
+}
+
+/**
+ * Checks whether an analytics response is a valid server-issued polling instruction.
+ *
+ * @param value unknown response body returned by the authenticated API client.
+ * @returns true for a bounded pending response containing a reusable SHA-256 token.
+ * @throws Does not throw for malformed response values.
+ */
+function isAnalyticsPendingResponse(value: unknown): value is AnalyticsPendingResponse {
+    const candidate = value as Partial<AnalyticsPendingResponse> | undefined
+    return candidate?.status === 'pending'
+        && typeof candidate.queryToken === 'string'
+        && ANALYTICS_QUERY_TOKEN_PATTERN.test(candidate.queryToken)
+        && typeof candidate.retryAfterMs === 'number'
+        && Number.isFinite(candidate.retryAfterMs)
+}
+
+/**
+ * Builds a timeout-shaped error compatible with the shared analytics error classifier.
+ *
+ * @returns error carrying an HTTP-style 504 response after bounded polling is exhausted.
+ * @throws Does not throw while constructing the error.
+ */
+function analyticsPollingTimeout(): Error & { response: { status: number } } {
+    return Object.assign(new Error('Analytics warehouse polling limit exceeded'), {
+        response: { status: 504 },
+    })
+}
+
+/**
+ * Loads one report and transparently resumes server-side work that outlives an HTTP request.
+ *
+ * @param path API path relative to the configured analytics base.
+ * @param values validated date, UTM, or surface filters.
+ * @param wait injectable polling delay used by deterministic tests.
+ * @returns completed analytics document after zero or more pending responses.
+ * @throws Request failures immediately and a timeout-shaped error after bounded polling.
+ */
+export async function requestAnalyticsReport<T>(
+    path: string,
+    values: AnalyticsQueryValues = {},
+    wait: AnalyticsPollWait = waitForAnalyticsPoll,
+): Promise<T> {
+    let queryToken: string | undefined
+
+    for (let attempt = 0; attempt < ANALYTICS_MAX_POLL_ATTEMPTS; attempt += 1) {
+        // Polling requests must remain sequential so each response supplies the next token.
+        // eslint-disable-next-line no-await-in-loop
+        const response = await xhrGetAsync<T | AnalyticsPendingResponse>(
+            buildAnalyticsUrl(path, values, queryToken),
+        )
+        if (!isAnalyticsPendingResponse(response)) return response as T
+
+        queryToken = response.queryToken
+        if (attempt + 1 >= ANALYTICS_MAX_POLL_ATTEMPTS) break
+        // The server-directed delay is part of the sequential polling protocol.
+        // eslint-disable-next-line no-await-in-loop
+        await wait(Math.min(
+            ANALYTICS_MAX_POLL_DELAY,
+            Math.max(ANALYTICS_MIN_POLL_DELAY, response.retryAfterMs),
+        ))
+    }
+
+    throw analyticsPollingTimeout()
 }
 
 /**
@@ -57,7 +151,7 @@ export function buildAnalyticsUrl(
  * @throws Rejects when configuration, authentication, authorization, or the API request fails.
  */
 export function getAnalyticsFilters(): Promise<AnalyticsFilterOptions> {
-    return xhrGetAsync(buildAnalyticsUrl('filters'))
+    return requestAnalyticsReport('filters')
 }
 
 /**
@@ -68,7 +162,7 @@ export function getAnalyticsFilters(): Promise<AnalyticsFilterOptions> {
  * @throws Rejects when configuration, authentication, authorization, or the API request fails.
  */
 export function getCampaignReport(filters: CampaignFilters): Promise<CampaignReport> {
-    return xhrGetAsync(buildAnalyticsUrl('campaign', filters))
+    return requestAnalyticsReport('campaign', filters)
 }
 
 /**
@@ -79,5 +173,5 @@ export function getCampaignReport(filters: CampaignFilters): Promise<CampaignRep
  * @throws Rejects when configuration, authentication, authorization, or the API request fails.
  */
 export function getGeneralReport(filters: GeneralFilters): Promise<GeneralReport> {
-    return xhrGetAsync(buildAnalyticsUrl('general', filters))
+    return requestAnalyticsReport('general', filters)
 }


### PR DESCRIPTION
## Summary
- return resumable 202 responses for analytics queries that outlive one HTTP request
- transparently poll the original Redshift statement from the Analytics UI
- keep legacy clients backward compatible and bound browser polling

## Validation
- yarn lint
- focused Analytics Jest suite (22 tests)
- yarn run build
- analytics API unittest suite (17 tests)
- CloudFormation template validation
- authenticated dev probe: 202 -> 202 -> 200 with one reused Redshift statement