### PR TITLE
Improve analytics loading and General dashboard layout

### DIFF
--- a/docs/adr/0002-aws-product-analytics.md
+++ b/docs/adr/0002-aws-product-analytics.md
@@ -202,11 +202,11 @@ non-cacheable.
 
 The Campaigns tab exposes the ordered landing, click, registration, and
 submission funnel with UTM, landing-page, and privacy-safe click-location
-breakdowns. The General tab exposes page views, visitors, clicks, pages,
-traffic sources, and application surfaces over time. Both report warehouse
-freshness and limit callers to 366 inclusive days. QuickSight remains the AWS
-native exploratory dashboard; the Platform UI app is the narrowly scoped daily
-operational interface.
+breakdowns. The General tab exposes page views, visitors, and clicks in
+separate daily charts plus paginated page and traffic-source tables. Both
+report warehouse freshness and limit callers to 366 inclusive days. QuickSight
+remains the AWS native exploratory dashboard; the Platform UI app is the
+narrowly scoped daily operational interface.
 
 ## Configuration
 
@@ -252,6 +252,14 @@ events are present in event_v2; the tagged event retained codex, integration,
 and aws_analytics while the control event remained Direct. The default AWS
 Clickstream dashboard, Topcoder reporting dashboard, Redshift data source, and
 all three custom datasets reported successful creation status.
+
+On 2026-09-02, the development collector received a larger pseudonymous fixture
+for campaign `aws_analytics` and UTM ID `dev_fixture_20260902`. The standard
+transform and Redshift load completed successfully, and both the reporting view
+and role-gated API returned an ordered 30 landing visitors, 22 clickers, 14
+registrations, and 8 submissions. Three landing paths and three semantic click
+placements provide non-empty table data. These aggregates are synthetic UI
+test data and must not be interpreted as member traffic.
 
 If the daily pipeline misses its freshness objective, first inspect failures and
 job duration. Increasing processing frequency is a cost-bearing design change,

--- a/src/apps/analytics/README.md
+++ b/src/apps/analytics/README.md
@@ -32,18 +32,27 @@ campaign and landing-page breakdowns plus aggregate click locations by semantic
 element fields and ten-percentage-point viewport buckets.
 
 General Analytics shows page views, distinct visitors, clicks, and distinct
-clickers over time, with page, traffic-source, and instrumented-application
-breakdowns.
+clickers. Page views, visitors, and clicks use separate daily area charts, and
+the ranked page table is paginated twenty rows at a time. Traffic-source and
+page breakdowns remain available; the application-surface breakdown is not
+shown.
 
 Counts are daily aggregates from the AWS Clickstream reporting views. Date
 ranges are inclusive and limited to 366 days. The UI displays the warehouse's
 `dataThrough` value because the development transform currently runs daily.
 Empty dates in a series are not inferred as provider outages.
 
+Development includes a clearly labeled synthetic campaign named
+`aws_analytics` with UTM ID `dev_fixture_20260902`. Its verified ordered funnel
+contains 30 landing visitors, 22 clickers, 14 registrations, and 8 submissions,
+plus multiple landing paths and click placements. Treat it as UI test data, not
+member traffic.
+
 Redshift Serverless can take longer than one HTTP request after an idle period.
 The UI opts into resumable queries and transparently polls `202` responses with
-the server-issued query token while keeping the loading state visible. Polling
-is bounded to twelve requests (roughly five minutes at the API's maximum query
+the server-issued query token. The report spinner stays in a contained region
+below the filters, leaving filters and Analytics navigation usable. Polling is
+bounded to twelve requests (roughly five minutes at the API's maximum query
 wait); after that, or after a genuine failure, the explicit retry action is
 shown.
 
@@ -81,6 +90,7 @@ yarn lint
 CI=true yarn test --watchAll=false --runTestsByPath \
   src/apps/analytics/src/config/routes.config.spec.ts \
   src/apps/analytics/src/analytics-app.routes.spec.tsx \
+  src/apps/analytics/src/pages/AnalyticsPages.spec.tsx \
   src/apps/analytics/src/lib/services/analytics.service.spec.ts \
   src/apps/analytics/src/lib/utils/analytics.utils.spec.ts \
   src/apps/analytics/src/lib/hooks/useAnalyticsResource.spec.ts

--- a/src/apps/analytics/src/lib/components/AnalyticsLoadingState/AnalyticsLoadingState.module.scss
+++ b/src/apps/analytics/src/lib/components/AnalyticsLoadingState/AnalyticsLoadingState.module.scss
@@ -1,0 +1,16 @@
+@import '@libs/ui/styles/includes';
+
+.region {
+    background: #ffffff;
+    border: 1px solid #dce3e9;
+    border-radius: 10px;
+    min-height: 320px;
+    overflow: hidden;
+    position: relative;
+}
+
+@include ltesm {
+    .region {
+        min-height: 240px;
+    }
+}

--- a/src/apps/analytics/src/lib/components/AnalyticsLoadingState/AnalyticsLoadingState.tsx
+++ b/src/apps/analytics/src/lib/components/AnalyticsLoadingState/AnalyticsLoadingState.tsx
@@ -1,0 +1,25 @@
+/** Contained loading state for an Analytics report body. */
+import { FC } from 'react'
+
+import { LoadingSpinner } from '~/libs/ui'
+
+import styles from './AnalyticsLoadingState.module.scss'
+
+interface AnalyticsLoadingStateProps {
+    message: string
+}
+
+/**
+ * Renders a report spinner inside normal page flow without covering filters or navigation.
+ *
+ * @param props accessible loading message shown beside the spinner.
+ * @returns fixed-height status region that contains the shared absolute spinner.
+ * @throws Does not throw.
+ */
+export const AnalyticsLoadingState: FC<AnalyticsLoadingStateProps> = props => (
+    <section aria-label={props.message} className={styles.region} role='status'>
+        <LoadingSpinner message={props.message} />
+    </section>
+)
+
+export default AnalyticsLoadingState

--- a/src/apps/analytics/src/lib/components/AnalyticsLoadingState/index.ts
+++ b/src/apps/analytics/src/lib/components/AnalyticsLoadingState/index.ts
@@ -1,0 +1,1 @@
+export * from './AnalyticsLoadingState'

--- a/src/apps/analytics/src/lib/components/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/src/apps/analytics/src/lib/components/TimeSeriesChart/TimeSeriesChart.tsx
@@ -16,6 +16,7 @@ interface TimeSeriesChartProps {
     ariaLabel: string
     points: object[]
     series: TimeSeriesDefinition[]
+    variant?: 'area' | 'line'
 }
 
 /**
@@ -46,12 +47,13 @@ function dateLabel(value: string): string {
 /**
  * Renders a multi-series daily line chart and an equivalent screen-reader table.
  *
- * @param props accessible label, normalized points, and series definitions.
+ * @param props accessible label, normalized points, series definitions, and optional line/area variant.
  * @returns chart, accessible table, or explicit empty state.
  * @throws Does not throw.
  */
 export const TimeSeriesChart: FC<TimeSeriesChartProps> = props => {
     const hasData = props.points.some(point => props.series.some(series => pointValue(point, series.key) > 0))
+    const chartType = props.variant ?? 'line'
     const options = useMemo<Highcharts.Options>(() => ({
         accessibility: { enabled: false },
         chart: {
@@ -59,17 +61,22 @@ export const TimeSeriesChart: FC<TimeSeriesChartProps> = props => {
             backgroundColor: 'transparent',
             height: 360,
             spacing: [16, 12, 8, 4],
-            type: 'line',
+            type: chartType,
         },
         colors: props.series.map(series => series.color),
         credits: { enabled: false },
         exporting: { enabled: false },
         legend: {
             align: 'center',
+            enabled: props.series.length > 1,
             itemStyle: { color: '#0d3445', fontSize: '12px', fontWeight: '600' },
             verticalAlign: 'top',
         },
         plotOptions: {
+            area: {
+                fillOpacity: 0.14,
+                lineWidth: 2,
+            },
             line: { lineWidth: 3 },
             series: {
                 animation: false,
@@ -81,7 +88,7 @@ export const TimeSeriesChart: FC<TimeSeriesChartProps> = props => {
             color: series.color,
             data: props.points.map(point => pointValue(point, series.key)),
             name: series.label,
-            type: 'line',
+            type: chartType,
         })) as Highcharts.SeriesOptionsType[],
         title: { text: undefined },
         tooltip: {
@@ -104,7 +111,7 @@ export const TimeSeriesChart: FC<TimeSeriesChartProps> = props => {
             min: 0,
             title: { text: undefined },
         },
-    }), [props.points, props.series])
+    }), [chartType, props.points, props.series])
 
     if (!hasData) {
         return <div className={styles.empty} role='status'>No activity is available for this period.</div>

--- a/src/apps/analytics/src/lib/components/index.ts
+++ b/src/apps/analytics/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AnalyticsLayout'
+export * from './AnalyticsLoadingState'
 export * from './AnalyticsNav'
 export * from './MetricCard'
 export * from './ReportError'

--- a/src/apps/analytics/src/pages/AnalyticsPages.module.scss
+++ b/src/apps/analytics/src/pages/AnalyticsPages.module.scss
@@ -199,6 +199,50 @@
     tbody tr:last-child td {
         border-bottom: 0;
     }
+
+    tbody tr:nth-child(even) {
+        background: #f7f9fa;
+    }
+}
+
+.pagination {
+    align-items: center;
+    border-top: 1px solid #e4eaee;
+    color: #617681;
+    display: flex;
+    font-size: 13px;
+    justify-content: space-between;
+    margin-top: $sp-4;
+    padding-top: $sp-4;
+
+    nav {
+        align-items: center;
+        display: flex;
+        gap: $sp-3;
+    }
+
+    button {
+        background: #ffffff;
+        border: 1px solid #aebbc2;
+        border-radius: 6px;
+        color: #0d3445;
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+        min-height: 36px;
+        padding: 0 $sp-4;
+
+        &:disabled {
+            background: #f2f6f8;
+            color: #93a2a9;
+            cursor: default;
+        }
+
+        &:focus-visible {
+            outline: 2px solid #137d60;
+            outline-offset: 2px;
+        }
+    }
 }
 
 .primaryCell,
@@ -256,5 +300,11 @@
 
     .freshness {
         text-align: left;
+    }
+
+    .pagination {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: $sp-3;
     }
 }

--- a/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
+++ b/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
@@ -1,0 +1,191 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { useAnalyticsResource } from '../lib/hooks'
+import { AnalyticsFilterOptions, GeneralReport } from '../lib/models'
+
+import { CampaignAnalyticsPage } from './CampaignAnalyticsPage'
+import { GeneralAnalyticsPage } from './GeneralAnalyticsPage'
+
+jest.mock('~/libs/ui', () => ({
+    Button: (props: {
+        children?: ReactNode
+        disabled?: boolean
+        onClick?: () => void
+        type?: 'button' | 'submit'
+    }) => (
+        <button
+            disabled={props.disabled}
+            onClick={props.onClick}
+            type={props.type === 'submit' ? 'submit' : 'button'}
+        >
+            {props.children}
+        </button>
+    ),
+    IconOutline: { RefreshIcon: 'refresh' },
+    LoadingSpinner: (props: { message?: string; overlay?: boolean }) => (
+        <div data-overlay={String(Boolean(props.overlay))} data-testid='loading-spinner'>
+            {props.message}
+        </div>
+    ),
+    PageTitle: (props: { children?: ReactNode }) => <>{props.children}</>,
+}), { virtual: true })
+
+jest.mock('~/config', () => ({
+    AppSubdomain: { analytics: 'analytics' },
+    EnvironmentConfig: { SUBDOMAIN: 'platform-ui' },
+}), { virtual: true })
+
+jest.mock('highcharts-react-official', () => ({
+    __esModule: true,
+    default: (props: { options: { chart?: { type?: string } } }) => (
+        <div data-chart-type={props.options.chart?.type} data-testid='highcharts' />
+    ),
+}))
+
+jest.mock('../lib/hooks', () => ({ useAnalyticsResource: jest.fn() }))
+jest.mock('../lib/services', () => ({
+    getAnalyticsFilters: jest.fn(),
+    getCampaignReport: jest.fn(),
+    getGeneralReport: jest.fn(),
+}))
+
+const mockedUseAnalyticsResource = useAnalyticsResource as unknown as jest.Mock
+const refresh = jest.fn()
+const filterOptions: AnalyticsFilterOptions = {
+    campaignIds: ['dev_fixture'],
+    campaigns: ['aws_analytics'],
+    generatedAt: '2026-09-02T00:00:00Z',
+    mediums: ['integration'],
+    sources: ['codex'],
+    surfaces: ['platform_ui', 'topcoder_website'],
+}
+
+let reportResource: object
+
+/**
+ * Configures the generic analytics resource mock for one page render.
+ *
+ * @param resource report lifecycle state returned for the non-filter request.
+ * @returns void after installing stable filter and report responses.
+ * @throws Does not throw.
+ */
+function mockAnalyticsResources(resource: object): void {
+    reportResource = resource
+    mockedUseAnalyticsResource.mockImplementation((key: string) => (
+        key === 'analytics-filters'
+            ? { data: filterOptions, loading: false, refresh, refreshing: false }
+            : reportResource
+    ))
+}
+
+describe('Analytics report pages', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('keeps campaign controls usable and places loading after the filters without an overlay', () => {
+        mockAnalyticsResources({ loading: true, refresh, refreshing: false })
+
+        render(<CampaignAnalyticsPage />)
+
+        const filters = screen.getByRole('heading', { name: 'Filters' })
+            .closest('form') as HTMLFormElement
+        const loading = screen.getByRole('status', { name: 'Loading campaign analytics…' })
+        const siblings = Array.from(filters.parentElement?.children ?? [])
+
+        expect(siblings.indexOf(filters))
+            .toBeLessThan(siblings.indexOf(loading))
+        expect(within(loading)
+            .getByTestId('loading-spinner'))
+            .toHaveAttribute('data-overlay', 'false')
+        expect(screen.getByLabelText('Campaign'))
+            .toBeEnabled()
+        expect(screen.getByRole('button', { name: 'Apply' }))
+            .toBeEnabled()
+    })
+
+    it('uses separate area charts, omits surfaces, and paginates visited pages twenty at a time', () => {
+        const data: GeneralReport = {
+            dataThrough: '2026-09-01',
+            filters: { from: '2026-08-04', surface: '', to: '2026-09-02' },
+            generatedAt: '2026-09-02T00:00:00Z',
+            pages: Array.from({ length: 45 }, (_, index) => ({
+                pageViews: 1_000 - index,
+                path: `/page-${String(index + 1)
+                    .padStart(2, '0')}`,
+                surface: index % 2 === 0 ? 'topcoder_website' : 'platform_ui',
+                visitors: 500 - index,
+            })),
+            series: [
+                { clickers: 12, clicks: 24, date: '2026-09-01', pageViews: 100, visitors: 60 },
+            ],
+            sources: [{ pageViews: 100, source: 'Direct', visitors: 60 }],
+            surfaces: [{ clicks: 24, pageViews: 100, surface: 'platform_ui', visitors: 60 }],
+            totals: { clickers: 12, clicks: 24, pageViews: 100, visitors: 60 },
+        }
+        mockAnalyticsResources({ data, loading: false, refresh, refreshing: false })
+
+        render(<GeneralAnalyticsPage />)
+
+        const chartLabels = ['Daily page views', 'Daily unique visitors', 'Daily clicks']
+        chartLabels.forEach(label => {
+            expect(within(screen.getByLabelText(label))
+                .getByTestId('highcharts'))
+                .toHaveAttribute('data-chart-type', 'area')
+        })
+        expect(screen.queryByText('Site engagement over time'))
+            .not.toBeInTheDocument()
+        expect(screen.queryByText('Application surfaces'))
+            .not.toBeInTheDocument()
+
+        const pagesPanel = screen.getByRole('heading', { name: 'Most visited pages' })
+            .closest('section') as HTMLElement
+        expect(within(pagesPanel)
+            .getByText('/page-01'))
+            .toBeInTheDocument()
+        expect(within(pagesPanel)
+            .getByText('/page-20'))
+            .toBeInTheDocument()
+        expect(within(pagesPanel)
+            .queryByText('/page-21'))
+            .not.toBeInTheDocument()
+        expect(within(pagesPanel)
+            .getByText('Showing 1–20 of 45 pages'))
+            .toBeInTheDocument()
+
+        fireEvent.click(within(pagesPanel)
+            .getByRole('button', { name: 'Next' }))
+
+        expect(within(pagesPanel)
+            .queryByText('/page-01'))
+            .not.toBeInTheDocument()
+        expect(within(pagesPanel)
+            .getByText('/page-21'))
+            .toBeInTheDocument()
+        expect(within(pagesPanel)
+            .getByText('Showing 21–40 of 45 pages'))
+            .toBeInTheDocument()
+    })
+
+    it('contains the General loading state below its still-enabled filters', () => {
+        mockAnalyticsResources({ loading: false, refresh, refreshing: true })
+
+        render(<GeneralAnalyticsPage />)
+
+        const filters = screen.getByRole('heading', { name: 'Filters' })
+            .closest('form') as HTMLFormElement
+        const loading = screen.getByRole('status', { name: 'Loading general analytics…' })
+        const siblings = Array.from(filters.parentElement?.children ?? [])
+
+        expect(siblings.indexOf(filters))
+            .toBeLessThan(siblings.indexOf(loading))
+        expect(within(loading)
+            .getByTestId('loading-spinner'))
+            .toHaveAttribute('data-overlay', 'false')
+        expect(screen.getByRole('button', { name: 'Apply' }))
+            .toBeEnabled()
+    })
+})

--- a/src/apps/analytics/src/pages/CampaignAnalyticsPage.tsx
+++ b/src/apps/analytics/src/pages/CampaignAnalyticsPage.tsx
@@ -11,11 +11,11 @@ import {
 import {
     Button,
     IconOutline,
-    LoadingSpinner,
     PageTitle,
 } from '~/libs/ui'
 
 import {
+    AnalyticsLoadingState,
     MetricCard,
     ReportError,
     TimeSeriesChart,
@@ -145,12 +145,10 @@ export const CampaignAnalyticsPage: FC = () => {
     }, [])
 
     const data = report.data
+    const reportPending = report.loading || report.refreshing
     return (
         <>
             <PageTitle>Campaign Analytics</PageTitle>
-            {(report.loading || report.refreshing) && (
-                <LoadingSpinner message='Loading campaign analytics…' overlay />
-            )}
             <div className={styles.page}>
                 <header className={styles.pageHeader}>
                     <div>
@@ -233,8 +231,11 @@ export const CampaignAnalyticsPage: FC = () => {
                     )}
                 </form>
 
+                {reportPending && (
+                    <AnalyticsLoadingState message='Loading campaign analytics…' />
+                )}
                 {report.error && !data && <ReportError error={report.error} onRetry={report.refresh} />}
-                {data && (
+                {data && !reportPending && (
                     <>
                         <div className={styles.freshness} role='status'>
                             Data through
@@ -299,7 +300,7 @@ export const CampaignAnalyticsPage: FC = () => {
                             <div className={styles.panelHeader}>
                                 <div>
                                     <h2>Campaign performance</h2>
-                                    <p>First-touch attribution grouped by campaign, source, medium, and UTM ID.</p>
+                                    <p>Attribution grouped by campaign, source, medium, and UTM ID.</p>
                                 </div>
                             </div>
                             <div className={styles.tableScroll}>

--- a/src/apps/analytics/src/pages/GeneralAnalyticsPage.tsx
+++ b/src/apps/analytics/src/pages/GeneralAnalyticsPage.tsx
@@ -11,11 +11,11 @@ import {
 import {
     Button,
     IconOutline,
-    LoadingSpinner,
     PageTitle,
 } from '~/libs/ui'
 
 import {
+    AnalyticsLoadingState,
     MetricCard,
     ReportError,
     TimeSeriesChart,
@@ -41,11 +41,10 @@ import {
 
 import styles from './AnalyticsPages.module.scss'
 
-const generalSeries = [
-    { color: '#2c95d7', key: 'pageViews', label: 'Page views' },
-    { color: '#6f42c1', key: 'visitors', label: 'Visitors' },
-    { color: '#137d60', key: 'clicks', label: 'Clicks' },
-]
+const MOST_VISITED_PAGE_SIZE = 20
+const pageViewSeries = [{ color: '#2c5de5', key: 'pageViews', label: 'Page views' }]
+const visitorSeries = [{ color: '#6f42c1', key: 'visitors', label: 'Unique visitors' }]
+const clickSeries = [{ color: '#137d60', key: 'clicks', label: 'Clicks' }]
 
 /**
  * Creates the complete default general analytics filter state.
@@ -72,8 +71,52 @@ const EmptyTableRow: FC<{ columns: number }> = props => (
     </tr>
 )
 
+interface AnalyticsTablePaginationProps {
+    onNext: () => void
+    onPrevious: () => void
+    page: number
+    pageSize: number
+    total: number
+    totalPages: number
+}
+
 /**
- * Renders general site totals, engagement graph, and page/source/surface tables.
+ * Renders compact previous/next controls and the visible range for a local analytics table.
+ *
+ * @param props current page metadata and stable navigation callbacks.
+ * @returns accessible pagination summary and controls.
+ * @throws Does not throw.
+ */
+const AnalyticsTablePagination: FC<AnalyticsTablePaginationProps> = props => {
+    const start = props.total === 0 ? 0 : ((props.page - 1) * props.pageSize) + 1
+    const end = Math.min(props.total, props.page * props.pageSize)
+
+    return (
+        <div className={styles.pagination}>
+            <span>{`Showing ${start}–${end} of ${props.total} pages`}</span>
+            <nav aria-label='Most visited pages pagination'>
+                <button
+                    disabled={props.page <= 1}
+                    onClick={props.onPrevious}
+                    type='button'
+                >
+                    Previous
+                </button>
+                <span>{`Page ${props.page} of ${props.totalPages}`}</span>
+                <button
+                    disabled={props.page >= props.totalPages}
+                    onClick={props.onNext}
+                    type='button'
+                >
+                    Next
+                </button>
+            </nav>
+        </div>
+    )
+}
+
+/**
+ * Renders general totals, separate daily charts, and paginated page/source tables.
  *
  * @returns role-gated General Analytics page.
  * @throws Does not throw; request failures are rendered inline.
@@ -83,6 +126,7 @@ export const GeneralAnalyticsPage: FC = () => {
     const [draftFilters, setDraftFilters] = useState<GeneralFilters>(initialFilters)
     const [appliedFilters, setAppliedFilters] = useState<GeneralFilters>(initialFilters)
     const [filterError, setFilterError] = useState<string>()
+    const [visitedPagesPage, setVisitedPagesPage] = useState(1)
     const filterOptions = useAnalyticsResource<AnalyticsFilterOptions>('analytics-filters', getAnalyticsFilters)
     const reportKey = analyticsRequestKey('general', appliedFilters)
     const report = useAnalyticsResource<GeneralReport>(
@@ -98,22 +142,42 @@ export const GeneralAnalyticsPage: FC = () => {
         event.preventDefault()
         const error = validateAnalyticsDateRange(draftFilters)
         setFilterError(error)
-        if (!error) setAppliedFilters({ ...draftFilters })
+        if (!error) {
+            setAppliedFilters({ ...draftFilters })
+            setVisitedPagesPage(1)
+        }
     }, [draftFilters])
     const resetFilters = useCallback(() => {
         const next = initialGeneralFilters()
         setDraftFilters(next)
         setAppliedFilters(next)
+        setVisitedPagesPage(1)
         setFilterError(undefined)
     }, [])
 
     const data = report.data
+    const reportPending = report.loading || report.refreshing
+    const visitedPagesTotal = data?.pages.length ?? 0
+    const visitedPagesTotalPages = Math.max(
+        1,
+        Math.ceil(visitedPagesTotal / MOST_VISITED_PAGE_SIZE),
+    )
+    const activeVisitedPagesPage = Math.min(visitedPagesPage, visitedPagesTotalPages)
+    const visibleVisitedPages = data?.pages.slice(
+        (activeVisitedPagesPage - 1) * MOST_VISITED_PAGE_SIZE,
+        activeVisitedPagesPage * MOST_VISITED_PAGE_SIZE,
+    ) ?? []
+    const showPreviousVisitedPages = useCallback(() => {
+        setVisitedPagesPage(current => Math.max(1, current - 1))
+    }, [])
+    const showNextVisitedPages = useCallback(() => {
+        setVisitedPagesPage(current => Math.min(visitedPagesTotalPages, current + 1))
+    }, [visitedPagesTotalPages])
+    const reportingPeriod = `${formatAnalyticsFreshness(appliedFilters.from)} – ${
+        formatAnalyticsFreshness(appliedFilters.to)}`
     return (
         <>
             <PageTitle>General Analytics</PageTitle>
-            {(report.loading || report.refreshing) && (
-                <LoadingSpinner message='Loading general analytics…' overlay />
-            )}
             <div className={styles.page}>
                 <header className={styles.pageHeader}>
                     <div>
@@ -177,8 +241,11 @@ export const GeneralAnalyticsPage: FC = () => {
                     )}
                 </form>
 
+                {reportPending && (
+                    <AnalyticsLoadingState message='Loading general analytics…' />
+                )}
                 {report.error && !data && <ReportError error={report.error} onRetry={report.refresh} />}
-                {data && (
+                {data && !reportPending && (
                     <>
                         <div className={styles.freshness} role='status'>
                             Data through
@@ -214,14 +281,45 @@ export const GeneralAnalyticsPage: FC = () => {
                         <section className={styles.panel}>
                             <div className={styles.panelHeader}>
                                 <div>
-                                    <h2>Site engagement over time</h2>
-                                    <p>Daily views, visitors, and interactions across the selected surface.</p>
+                                    <h2>Page views</h2>
+                                    <p>{reportingPeriod}</p>
                                 </div>
                             </div>
                             <TimeSeriesChart
-                                ariaLabel='Daily Topcoder site engagement'
+                                ariaLabel='Daily page views'
                                 points={data.series}
-                                series={generalSeries}
+                                series={pageViewSeries}
+                                variant='area'
+                            />
+                        </section>
+
+                        <section className={styles.panel}>
+                            <div className={styles.panelHeader}>
+                                <div>
+                                    <h2>Unique visitors</h2>
+                                    <p>{reportingPeriod}</p>
+                                </div>
+                            </div>
+                            <TimeSeriesChart
+                                ariaLabel='Daily unique visitors'
+                                points={data.series}
+                                series={visitorSeries}
+                                variant='area'
+                            />
+                        </section>
+
+                        <section className={styles.panel}>
+                            <div className={styles.panelHeader}>
+                                <div>
+                                    <h2>Clicks</h2>
+                                    <p>{reportingPeriod}</p>
+                                </div>
+                            </div>
+                            <TimeSeriesChart
+                                ariaLabel='Daily clicks'
+                                points={data.series}
+                                series={clickSeries}
+                                variant='area'
                             />
                         </section>
 
@@ -229,7 +327,7 @@ export const GeneralAnalyticsPage: FC = () => {
                             <div className={styles.panelHeader}>
                                 <div>
                                     <h2>Most visited pages</h2>
-                                    <p>Query-free paths grouped by application surface.</p>
+                                    <p>Top query-free paths ranked by page views.</p>
                                 </div>
                             </div>
                             <div className={styles.tableScroll}>
@@ -243,7 +341,7 @@ export const GeneralAnalyticsPage: FC = () => {
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        {data.pages.map(row => (
+                                        {visibleVisitedPages.map(row => (
                                             <tr key={`${row.surface}-${row.path}`}>
                                                 <td>{formatAnalyticsSurface(row.surface)}</td>
                                                 <th scope='row'>{row.path}</th>
@@ -251,74 +349,50 @@ export const GeneralAnalyticsPage: FC = () => {
                                                 <td>{formatAnalyticsInteger(row.visitors)}</td>
                                             </tr>
                                         ))}
-                                        {data.pages.length === 0 && <EmptyTableRow columns={4} />}
+                                        {visibleVisitedPages.length === 0 && <EmptyTableRow columns={4} />}
                                     </tbody>
                                 </table>
                             </div>
+                            {visitedPagesTotal > 0 && (
+                                <AnalyticsTablePagination
+                                    onNext={showNextVisitedPages}
+                                    onPrevious={showPreviousVisitedPages}
+                                    page={activeVisitedPagesPage}
+                                    pageSize={MOST_VISITED_PAGE_SIZE}
+                                    total={visitedPagesTotal}
+                                    totalPages={visitedPagesTotalPages}
+                                />
+                            )}
                         </section>
 
-                        <section className={styles.twoColumnGrid}>
-                            <article className={styles.panel}>
-                                <div className={styles.panelHeader}>
-                                    <div>
-                                        <h2>Traffic sources</h2>
-                                        <p>First-touch source for viewed pages.</p>
-                                    </div>
+                        <section className={styles.panel}>
+                            <div className={styles.panelHeader}>
+                                <div>
+                                    <h2>Traffic sources</h2>
+                                    <p>Attributed source for viewed pages.</p>
                                 </div>
-                                <div className={styles.tableScroll}>
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th scope='col'>Source</th>
-                                                <th scope='col'>Page views</th>
-                                                <th scope='col'>Visitors</th>
+                            </div>
+                            <div className={styles.tableScroll}>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th scope='col'>Source</th>
+                                            <th scope='col'>Page views</th>
+                                            <th scope='col'>Visitors</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {data.sources.map(row => (
+                                            <tr key={row.source}>
+                                                <th scope='row'>{row.source}</th>
+                                                <td>{formatAnalyticsInteger(row.pageViews)}</td>
+                                                <td>{formatAnalyticsInteger(row.visitors)}</td>
                                             </tr>
-                                        </thead>
-                                        <tbody>
-                                            {data.sources.map(row => (
-                                                <tr key={row.source}>
-                                                    <th scope='row'>{row.source}</th>
-                                                    <td>{formatAnalyticsInteger(row.pageViews)}</td>
-                                                    <td>{formatAnalyticsInteger(row.visitors)}</td>
-                                                </tr>
-                                            ))}
-                                            {data.sources.length === 0 && <EmptyTableRow columns={3} />}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </article>
-
-                            <article className={styles.panel}>
-                                <div className={styles.panelHeader}>
-                                    <div>
-                                        <h2>Application surfaces</h2>
-                                        <p>Engagement split between instrumented Topcoder web applications.</p>
-                                    </div>
-                                </div>
-                                <div className={styles.tableScroll}>
-                                    <table>
-                                        <thead>
-                                            <tr>
-                                                <th scope='col'>Surface</th>
-                                                <th scope='col'>Views</th>
-                                                <th scope='col'>Visitors</th>
-                                                <th scope='col'>Clicks</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {data.surfaces.map(row => (
-                                                <tr key={row.surface}>
-                                                    <th scope='row'>{formatAnalyticsSurface(row.surface)}</th>
-                                                    <td>{formatAnalyticsInteger(row.pageViews)}</td>
-                                                    <td>{formatAnalyticsInteger(row.visitors)}</td>
-                                                    <td>{formatAnalyticsInteger(row.clicks)}</td>
-                                                </tr>
-                                            ))}
-                                            {data.surfaces.length === 0 && <EmptyTableRow columns={4} />}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </article>
+                                        ))}
+                                        {data.sources.length === 0 && <EmptyTableRow columns={3} />}
+                                    </tbody>
+                                </table>
+                            </div>
                         </section>
                     </>
                 )}


### PR DESCRIPTION
## Summary

- keep Analytics navigation and filters usable while reports load by containing the spinner below the filter panel
- split General page views, unique visitors, and clicks into separate area charts; remove Application Surfaces
- paginate Most visited pages twenty rows at a time and improve table readability
- remove remaining first-touch wording and document the synthetic aws_analytics development fixture
- add page-level regression coverage for loading placement, charts, and pagination

## Verification

- `yarn lint`
- `yarn run build`
- 7 Analytics test suites / 26 tests passed
- `git diff --check`