### PR TITLE
PM-6046 Revalidate registration before submission upload

### DIFF
--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
@@ -54,8 +54,18 @@ function challengeFixture(overrides: Partial<ChallengeOpportunity> = {}): Challe
     }
 }
 
-/** Renders the upload workflow with stable no-op callbacks and optional prop overrides. */
-function renderUpload(challenge: ChallengeOpportunity = challengeFixture()): RenderResult {
+/**
+ * Renders the upload workflow with stable callbacks.
+ *
+ * @param challenge challenge fixture rendered by the form.
+ * @param onValidateRegistration pre-upload registration result.
+ * @returns Testing Library render result.
+ * @throws Does not throw.
+ */
+function renderUpload(
+    challenge: ChallengeOpportunity = challengeFixture(),
+    onValidateRegistration: () => Promise<boolean> = async () => true,
+): RenderResult {
     return render(
         <ChallengeSubmissionUpload
             challenge={challenge}
@@ -65,6 +75,7 @@ function renderUpload(challenge: ChallengeOpportunity = challengeFixture()): Ren
             onShowRequirements={jest.fn()}
             onShowTerms={jest.fn()}
             onSubmitted={jest.fn()}
+            onValidateRegistration={onValidateRegistration}
         />,
     )
 }
@@ -169,5 +180,47 @@ describe('ChallengeSubmissionUpload', () => {
                 member_id: '123',
                 submission_type: 'CHECKPOINT_SUBMISSION',
             }, true)
+    })
+
+    it('does not upload when the submitter registration is no longer current', async () => {
+        const validateRegistration = jest.fn()
+            .mockResolvedValue(false)
+        renderUpload(challengeFixture(), validateRegistration)
+        const file = new File(['zip'], 'MySubmission.zip', { type: 'application/zip' })
+
+        fireEvent.change(screen.getByLabelText(/Upload File\*/), {
+            target: { files: [file] },
+        })
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' }))
+            .not.toBeDisabled())
+        expect(validateRegistration)
+            .toHaveBeenCalledTimes(1)
+        expect(mockedCreateSubmission)
+            .not.toHaveBeenCalled()
+    })
+
+    it('keeps cancellation effective while registration validation is pending', async () => {
+        let resolveRegistration: ((value: boolean) => void) | undefined
+        const validateRegistration = jest.fn(() => new Promise<boolean>(resolve => {
+            resolveRegistration = resolve
+        }))
+        renderUpload(challengeFixture(), validateRegistration)
+        const file = new File(['zip'], 'MySubmission.zip', { type: 'application/zip' })
+
+        fireEvent.change(screen.getByLabelText(/Upload File\*/), {
+            target: { files: [file] },
+        })
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+        await waitFor(() => expect(validateRegistration)
+            .toHaveBeenCalledTimes(1))
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel upload' }))
+        await act(async () => resolveRegistration?.(true))
+
+        expect(mockedCreateSubmission)
+            .not.toHaveBeenCalled()
     })
 })

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
@@ -33,6 +33,7 @@ interface ChallengeSubmissionUploadProps {
     onShowRequirements: () => void
     onShowTerms: () => void
     onSubmitted: (submission: ChallengeSubmission) => Promise<unknown> | unknown
+    onValidateRegistration: () => Promise<boolean>
 }
 
 /**
@@ -183,7 +184,8 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
     }
 
     /**
-     * Uploads the accepted archive and advances to the immutable confirmation state.
+     * Revalidates challenge registration, uploads the accepted archive, and advances
+     * to the immutable confirmation state.
      *
      * @returns promise settled after the Review API response and cache refresh callback.
      * @throws Does not throw; request failures restore the ready state with an error message.
@@ -196,6 +198,8 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
         setProgress(0)
         setUploading(true)
         try {
+            const registrationIsCurrent = await props.onValidateRegistration()
+            if (!registrationIsCurrent || controller.signal.aborted) return
             const submission = await createChallengeSubmission(
                 props.challenge.id,
                 props.memberId,
@@ -212,16 +216,15 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
             }, true)
             setProgress(100)
             setSubmissionId(submission.id)
-            setUploading(false)
             await props.onSubmitted(submission)
         } catch (caughtError) {
             if (controller.signal.aborted) return
             setError(caughtError instanceof Error
                 ? caughtError.message
                 : 'Unable to upload this submission.')
-            setUploading(false)
         } finally {
             if (abortController.current === controller) abortController.current = undefined
+            setUploading(false)
         }
     }
 

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -13,14 +13,17 @@ import {
     Route,
     Routes,
 } from 'react-router-dom'
+import { toast } from 'react-toastify'
 
 import { ChallengeDetailsPage } from './ChallengeDetailsPage'
 
 const mockUseSWR = jest.fn()
 const mockDeleteSubmission = jest.fn()
+const mockRegistrationMutate = jest.fn()
 const mockUnregister = jest.fn()
 let mockProfile: { handle: string; roles?: string[]; userId: number } | undefined
 let mockRegistration: { id: string } | undefined
+let mockRegistrationRemoved: boolean
 let mockChallenge: Record<string, unknown>
 let mockMemberProfiles: Record<string, unknown>[]
 let mockProjectResults: Record<string, unknown>[]
@@ -267,6 +270,7 @@ describe('ChallengeDetailsPage member flows', () => {
         jest.clearAllMocks()
         mockProfile = undefined
         mockRegistration = undefined
+        mockRegistrationRemoved = false
         mockMemberProfiles = []
         mockProjectResults = []
         mockPreviewSubmissions = []
@@ -286,13 +290,19 @@ describe('ChallengeDetailsPage member flows', () => {
         }
         mockUnregister.mockResolvedValue(undefined)
         mockDeleteSubmission.mockResolvedValue(undefined)
+        mockRegistrationMutate.mockImplementation(async () => (
+            mockRegistrationRemoved ? undefined : mockRegistration
+        ))
         mockUseSWR.mockImplementation((key: unknown) => {
             if (typeof key === 'string' && key.startsWith('opportunities:challenge:')) {
                 return swrResponse(mockChallenge)
             }
 
             if (Array.isArray(key) && key[0] === 'opportunities:registration') {
-                return swrResponse(mockRegistration)
+                return {
+                    ...swrResponse(mockRegistration),
+                    mutate: mockRegistrationMutate,
+                }
             }
 
             if (Array.isArray(key) && key[0] === 'opportunities:submissions') {
@@ -456,20 +466,42 @@ describe('ChallengeDetailsPage member flows', () => {
             ])
     })
 
-    it('opens the in-tab upload workflow from the registered header action', () => {
+    it('opens the in-tab upload workflow from the revalidated registered header action', async () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }
 
         renderPage()
         fireEvent.click(screen.getByRole('button', { name: 'Submit a solution' }))
 
-        expect(screen.getByRole('tab', { name: 'My Submissions' }))
-            .toHaveAttribute('aria-selected', 'true')
+        await waitFor(() => expect(screen.getByRole('tab', { name: 'My Submissions' }))
+            .toHaveAttribute('aria-selected', 'true'))
+        expect(mockRegistrationMutate)
+            .toHaveBeenCalledTimes(1)
         expect(screen.getByText('Submission upload form'))
             .toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: 'Back to submissions' }))
         expect(screen.getByText('You have no submissions yet'))
             .toBeInTheDocument()
+    })
+
+    it('does not open the upload workflow when the cached registration was removed', async () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'stale-resource-id' }
+        mockRegistrationRemoved = true
+
+        renderPage()
+        fireEvent.click(screen.getByRole('button', { name: 'Submit a solution' }))
+
+        await waitFor(() => expect(toast.error)
+            .toHaveBeenCalledWith(
+                'Your registration is no longer active. Register again before submitting.',
+            ))
+        expect(mockRegistrationMutate)
+            .toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('tab', { name: 'Requirements' }))
+            .toHaveAttribute('aria-selected', 'true')
+        expect(screen.queryByText('Submission upload form'))
+            .not.toBeInTheDocument()
     })
 
     it('resets the selected member tab when unregistering', async () => {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -94,6 +94,8 @@ type ChallengeTab = 'requirements' | 'registrants' | 'submissions' | 'mine' | 'd
 
 const HISTORY_ICON_PATH = 'M13 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7v3l4-4-4-4v3z'
     + 'M12 8v5l4.25 2.52.77-1.28-3.52-2.09V8z'
+const STALE_REGISTRATION_MESSAGE
+    = 'Your registration is no longer active. Register again before submitting.'
 
 /**
  * Builds the challenge-scoped Review App destination used by authored actions.
@@ -275,17 +277,45 @@ export const ChallengeDetailsPage: FC = () => {
     }
 
     /**
-     * Opens the Figma submission flow under the registered member's My Submissions tab.
+     * Refreshes the authenticated member's Submitter resource before an upload can start.
      *
-     * @returns void after selecting the tab, or redirecting an anonymous member to sign in.
+     * @returns true when registration still exists; false after restoring an actionable page state.
+     * @throws Does not throw; Resource API failures are reported to the member.
+     */
+    const validateSubmissionRegistration = async (): Promise<boolean> => {
+        if (!memberId) return false
+        setRegistrationBusy(true)
+        try {
+            const currentRegistration = await registrationResponse.mutate()
+            if (currentRegistration) return true
+            setActiveTab('requirements')
+            setSubmissionFlowOpen(false)
+            toast.error(STALE_REGISTRATION_MESSAGE)
+            return false
+        } catch (error) {
+            toast.error(error instanceof Error && error.message.trim()
+                ? error.message
+                : 'Unable to verify your challenge registration. Please try again.')
+            return false
+        } finally {
+            setRegistrationBusy(false)
+        }
+    }
+
+    /**
+     * Opens the Figma submission flow under the member's revalidated My Submissions tab.
+     *
+     * @returns promise settled after selecting the tab, restoring registration state,
+     * or redirecting an anonymous member to sign in.
      * @throws Does not throw.
      */
-    const startSubmission = (): void => {
+    const startSubmission = async (): Promise<void> => {
         if (!memberId) {
             window.location.assign(authUrlLogin(window.location.href))
             return
         }
 
+        if (!await validateSubmissionRegistration()) return
         setActiveTab('mine')
         setSubmissionFlowOpen(true)
     }
@@ -476,6 +506,7 @@ export const ChallengeDetailsPage: FC = () => {
                             ...challenge,
                             numOfSubmissions: (challenge.numOfSubmissions ?? 0) + 1,
                         }, { revalidate: false })}
+                        onValidateRegistration={validateSubmissionRegistration}
                         submissionFlowOpen={submissionFlowOpen}
                     />
                 </section>
@@ -531,6 +562,7 @@ interface ChallengeTabContentProps {
     onShowTerms: (term?: ChallengeTerm) => void
     onStartSubmission: () => void
     onSubmitted: () => Promise<unknown> | unknown
+    onValidateRegistration: () => Promise<boolean>
     submissionFlowOpen: boolean
 }
 
@@ -564,6 +596,7 @@ const ChallengeTabContent: FC<ChallengeTabContentProps> = props => {
                     onShowRequirements={props.onShowRequirements}
                     onShowTerms={props.onShowTerms}
                     onSubmitted={props.onSubmitted}
+                    onValidateRegistration={props.onValidateRegistration}
                 />
             )
         }


### PR DESCRIPTION
## Summary

- revalidate the member's Submitter resource before opening the submission form and again before uploading
- refresh SWR registration state and return stale registrations to the Requirements tab with an actionable re-register message
- preserve upload cancellation while registration validation is pending
- add regression coverage for valid, stale, and cancelled registration preflights

## Reproduction

Using challenge `2b6d19fb-6b67-4fc7-9df0-6bf93f486a36` and the reported ZIP, the existing deployed upload transport reached Review API but returned `INVALID_SUBMITTER_REGISTRATION` after the cached Submitter resource had disappeared. Re-registering with the UI contract and retrying the same DMZ object returned HTTP 201. Submission `6UgiM98TgcZxLi` is ACTIVE, antivirus-scanned, and latest for the member.

This change prevents the stale UI from sending the ZIP and guides the member back to registration instead.

## Validation

- `yarn test:no-watch --runTestsByPath src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx` — 27/27 passed
- `yarn lint` — passed
- `yarn run build` — passed with existing repository warnings
- broader Opportunities run — 31/32 suites passed and all 199 executed tests passed; `opportunity.utils.spec.ts` has a pre-existing Jest resolution failure for `~/apps/copilots`, in untouched code

JIRA: PM-6046
