### PR TITLE
PM-6095 PM-6096 QA follow-ups

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -185,7 +185,9 @@ filters, global sorting, counts, and pagination. The terms modal similarly
 filters Challenge API references to the
 Submitter role and loads complete v5 Terms API records before an electronic
 agreement. Passive “Review challenge terms” mode never registers or agrees on
-a member's behalf.
+a member's behalf. Terms API HTML retains its semantic structure and safe links,
+but document-authored inline styles are removed so modal-scoped Figtree headings,
+Nunito Sans body copy, and spacing remain authoritative.
 DocuSign-template terms expose the Terms API recipient flow and return to the
 challenge route after signing; registration remains blocked until the service
 reports that every external agreement is complete.

--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -249,10 +249,10 @@ official announcements and can reply throughout every challenge forum.
 
 The Report an Issue dialog preserves the Figma subject, category, and
 1000-character description while keeping attachments optional. Files upload
-through the shared Filestack support-ticket pipeline with a 2MB-per-file UI
-limit, grouped under the active challenge ID when one exists or a draft upload
-context before ticket creation otherwise. Because support-api-v6 accepts only
-`challengeId` and Markdown `description`, the client serializes the subject,
+through the authenticated `POST /v6/support/attachments` multipart endpoint
+with a 2 MiB-per-file UI limit, so the browser does not connect directly to an
+S3 bucket. Because support-api-v6 accepts only `challengeId` and Markdown
+`description` when creating the ticket, the client serializes the subject,
 category, body, and any uploaded links into that description without inventing
 unsupported request fields.
 

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
@@ -173,7 +173,8 @@
 
         p,
         li,
-        a {
+        a,
+        span {
             font-family: inherit;
             font-size: inherit;
             line-height: inherit;

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -99,12 +99,27 @@ describe('ChallengeTermsModal', () => {
             .toHaveTextContent("We couldn't load the full challenge terms.")
     })
 
-    it('renders hydrated term headings and body copy in view mode', () => {
+    it('normalizes Word-exported term styles while preserving semantic content and safe links', () => {
         mockSWRResponse = {
             ...mockSWRResponse,
             data: [{
                 id: 'standard-terms',
-                text: '<h1>Acceptance of Terms and Conditions</h1><p>Welcome to topcoder.com.</p>',
+                text: `
+                    <div class="WordSection1">
+                        <h4 style="margin-top:30pt;margin-bottom:8pt;line-height:111%">
+                            <span style="font-size:25.5pt;line-height:111%;color:#2a2a2a">
+                                Acceptance of Terms and Conditions
+                            </span>
+                        </h4>
+                        <p class="MsoNormal" style="margin-bottom:15pt;line-height:150%">
+                            <span style="font-family:Roboto;font-size:12pt;line-height:150%">Welcome to </span>
+                            <a href="https://www.topcoder.com">
+                                <span style="font-family:Roboto;font-size:12pt;line-height:150%">topcoder.com</span>
+                            </a>
+                            <a href="javascript:alert('unsafe')">Unsafe link</a>
+                        </p>
+                    </div>
+                `,
                 title: 'Standard Terms 2026',
             }],
             isValidating: false,
@@ -120,11 +135,27 @@ describe('ChallengeTermsModal', () => {
             />,
         )
 
-        expect(screen.getByRole('dialog', { name: 'Standard Terms 2026' }))
+        const dialog = screen.getByRole('dialog', { name: 'Standard Terms 2026' })
+        const heading = screen.getByRole('heading', {
+            level: 4,
+            name: 'Acceptance of Terms and Conditions',
+        })
+        const safeLink = screen.getByRole('link', { name: 'topcoder.com' })
+        const unsafeLink = screen.getByText('Unsafe link')
+
+        expect(dialog)
             .toBeInTheDocument()
-        expect(screen.getByText('Acceptance of Terms and Conditions'))
+        expect(heading.tagName)
+            .toBe('H4')
+        expect(screen.getByText('Welcome to'))
             .toBeInTheDocument()
-        expect(screen.getByText('Welcome to topcoder.com.'))
-            .toBeInTheDocument()
+        expect(safeLink)
+            .toHaveAttribute('href', 'https://www.topcoder.com')
+        expect(unsafeLink)
+            .toHaveProperty('tagName', 'A')
+        expect(unsafeLink)
+            .not.toHaveAttribute('href')
+        expect(dialog.querySelector('[style]'))
+            .toBeNull()
     })
 })

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -101,8 +101,20 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         }
     }, [props.open, props.mode])
 
-    /** Sanitizes trusted-format Terms API HTML before inserting it. */
-    const sanitizedText = (text: string): string => String(DOMPurify.sanitize(text))
+    /**
+     * Sanitizes Terms API HTML while removing document-authored inline CSS.
+     *
+     * The API can return Word-exported markup whose inline typography and
+     * spacing override the Opportunities design system. Semantic elements and
+     * safe links remain available for the modal's scoped styles to format.
+     *
+     * @param text Terms API HTML to sanitize.
+     * @returns safe semantic HTML without inline style attributes.
+     * @throws Does not throw.
+     */
+    const sanitizedText = (text: string): string => String(DOMPurify.sanitize(text, {
+        FORBID_ATTR: ['style'],
+    }))
 
     /** Submits the exact resolved term records displayed to the member. */
     const accept = (): void => props.onAccept(terms)

--- a/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
@@ -8,7 +8,10 @@ import {
 } from '@testing-library/react'
 import { PropsWithChildren, ReactNode } from 'react'
 
-import { uploadSupportAttachment } from '~/apps/support/src/lib/services/support-attachment.service'
+import {
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES,
+    uploadSupportAttachment,
+} from '~/apps/support/src/lib/services/support-attachment.service'
 import { createSupportTicket } from '~/apps/support/src/lib/services/support.service'
 
 import {
@@ -22,6 +25,7 @@ jest.mock('react-toastify', () => ({
 
 jest.mock('~/apps/support/src/lib/services/support-attachment.service', () => ({
     MAX_SUPPORT_ATTACHMENT_BYTES: 2 * 1024 * 1024,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES: ['.png', 'image/png'],
     uploadSupportAttachment: jest.fn(),
 }), { virtual: true })
 
@@ -90,6 +94,8 @@ describe('ReportIssueModal', () => {
             .not.toBeInTheDocument()
         expect(screen.getByText('Max. 2 MB per file'))
             .toBeInTheDocument()
+        expect(screen.getByLabelText('Attach files'))
+            .toHaveAttribute('accept', SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES.join(','))
         expect(screen.getByRole('button', { name: 'Send report' }))
             .toBeDisabled()
     })

--- a/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react'
 import { PropsWithChildren, ReactNode } from 'react'
 
-import { uploadReviewAttachment } from '~/apps/review/src/lib/services/file-upload.service'
+import { uploadSupportAttachment } from '~/apps/support/src/lib/services/support-attachment.service'
 import { createSupportTicket } from '~/apps/support/src/lib/services/support.service'
 
 import {
@@ -20,8 +20,9 @@ jest.mock('react-toastify', () => ({
     toast: { success: jest.fn() },
 }))
 
-jest.mock('~/apps/review/src/lib/services/file-upload.service', () => ({
-    uploadReviewAttachment: jest.fn(),
+jest.mock('~/apps/support/src/lib/services/support-attachment.service', () => ({
+    MAX_SUPPORT_ATTACHMENT_BYTES: 2 * 1024 * 1024,
+    uploadSupportAttachment: jest.fn(),
 }), { virtual: true })
 
 jest.mock('~/apps/support/src/lib/services/support.service', () => ({
@@ -58,7 +59,7 @@ jest.mock('~/libs/ui', () => {
 }, { virtual: true })
 
 const mockedCreateSupportTicket = createSupportTicket as jest.Mock
-const mockedUploadAttachment = uploadReviewAttachment as jest.MockedFunction<typeof uploadReviewAttachment>
+const mockedUploadAttachment = uploadSupportAttachment as jest.MockedFunction<typeof uploadSupportAttachment>
 
 describe('ReportIssueModal', () => {
     beforeEach(() => {
@@ -170,13 +171,10 @@ describe('ReportIssueModal', () => {
         expect(await screen.findByText('Thank you for reporting this issue.'))
             .toBeInTheDocument()
         expect(mockedUploadAttachment)
-            .toHaveBeenCalledWith(file, expect.objectContaining({
-                category: 'support-ticket',
-                challengeId: 'challenge-id',
-            }))
+            .toHaveBeenCalledWith(file)
     })
 
-    it('falls back to a draft upload context when the report is not challenge-scoped', async () => {
+    it('uses the same authenticated Support upload without a draft context outside a challenge', async () => {
         render(<ReportIssueModal onClose={jest.fn()} open />)
         const file = new File(['screenshot'], 'Screenshot.png', { type: 'image/png' })
         Object.defineProperty(file, 'size', { value: 1153434 })
@@ -186,10 +184,7 @@ describe('ReportIssueModal', () => {
         })
 
         await waitFor(() => expect(mockedUploadAttachment)
-            .toHaveBeenCalledWith(file, expect.objectContaining({
-                category: 'support-ticket',
-                challengeId: expect.stringMatching(/^draft-/),
-            })))
+            .toHaveBeenCalledWith(file))
     })
 
     it('rejects files larger than the authored two-megabyte limit', async () => {

--- a/src/apps/opportunities/src/components/ReportIssueModal.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.tsx
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify'
 
 import {
     MAX_SUPPORT_ATTACHMENT_BYTES,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES,
     SupportAttachmentUploadResult,
     uploadSupportAttachment,
 } from '~/apps/support/src/lib/services/support-attachment.service'
@@ -384,6 +385,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
                             {attachments.length ? 'Attach Screenshots, Files' : 'Attach Files'}
                         </span>
                         <input
+                            accept={SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES.join(',')}
                             aria-label='Attach files'
                             disabled={busy || uploading}
                             multiple

--- a/src/apps/opportunities/src/components/ReportIssueModal.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.tsx
@@ -3,23 +3,22 @@ import {
     ChangeEvent,
     DragEvent,
     FC,
-    useEffect,
     useRef,
     useState,
 } from 'react'
 import { toast } from 'react-toastify'
 
 import {
-    ReviewAttachmentUploadResult,
-    uploadReviewAttachment,
-} from '~/apps/review/src/lib/services/file-upload.service'
+    MAX_SUPPORT_ATTACHMENT_BYTES,
+    SupportAttachmentUploadResult,
+    uploadSupportAttachment,
+} from '~/apps/support/src/lib/services/support-attachment.service'
 import { createSupportTicket } from '~/apps/support/src/lib/services/support.service'
 import { BaseModal, Button, IconOutline } from '~/libs/ui'
 
 import styles from './ReportIssueModal.module.scss'
 
 const DESCRIPTION_LIMIT = 1000
-const MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024
 const ISSUE_CATEGORIES = [
     'Registration',
     'Submission',
@@ -39,21 +38,8 @@ interface IssueAttachment {
     error?: string
     file: File
     id: number
-    result?: ReviewAttachmentUploadResult
+    result?: SupportAttachmentUploadResult
     status: 'error' | 'uploaded' | 'uploading'
-}
-
-/**
- * Creates a non-authoritative upload grouping ID for attachments added before
- * the support ticket exists.
- *
- * @returns unique draft upload context.
- * @throws Does not throw.
- */
-function createUploadContext(): string {
-    return `draft-${Date.now()}-${Math.random()
-        .toString(36)
-        .slice(2)}`
 }
 
 /**
@@ -84,7 +70,7 @@ export function buildReportIssueDescription(
     subject: string,
     category: string,
     description: string,
-    attachments: ReviewAttachmentUploadResult[],
+    attachments: SupportAttachmentUploadResult[],
 ): string {
     const attachmentLines = attachments.map(attachment => {
         const label = attachment.filename.replace(/\[|\]/g, '') || 'Attachment'
@@ -107,7 +93,7 @@ export function buildReportIssueDescription(
 /**
  * Renders both authored Report an Issue states while adapting their richer
  * fields to support-api-v6's challenge-id plus Markdown-description contract.
- * Attachments are optional and upload through the shared Filestack pipeline
+ * Attachments are optional and upload through the authenticated Support API
  * before submission.
  *
  * @param props optional challenge context and modal state.
@@ -123,12 +109,11 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
     const [dragActive, setDragActive] = useState(false)
     const [error, setError] = useState<string>()
     const [subject, setSubject] = useState('')
-    const [uploadContext, setUploadContext] = useState(createUploadContext)
     const attachmentId = useRef(0)
     const fileInput = useRef<HTMLInputElement>(null)
     const uploading = attachments.some(attachment => attachment.status === 'uploading')
     const uploaded = attachments
-        .filter((attachment): attachment is IssueAttachment & { result: ReviewAttachmentUploadResult } => (
+        .filter((attachment): attachment is IssueAttachment & { result: SupportAttachmentUploadResult } => (
             attachment.status === 'uploaded' && !!attachment.result
         ))
     const canSubmit = !!subject.trim()
@@ -136,13 +121,6 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
         && !!description.trim()
         && !uploading
         && !busy
-    const uploadOwnerId = props.challengeId?.trim() || uploadContext
-
-    useEffect(() => {
-        if (props.open) {
-            setUploadContext(createUploadContext())
-        }
-    }, [props.open])
 
     /**
      * Clears local form and confirmation state for the next modal session.
@@ -158,7 +136,6 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
         setDragActive(false)
         setError(undefined)
         setSubject('')
-        setUploadContext(createUploadContext())
         if (fileInput.current) fileInput.current.value = ''
     }
 
@@ -184,7 +161,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
     const addAttachments = async (files: FileList | File[]): Promise<void> => {
         const candidates = Array.from(files)
         if (!candidates.length) return
-        const oversized = candidates.find(file => file.size > MAX_ATTACHMENT_BYTES)
+        const oversized = candidates.find(file => file.size > MAX_SUPPORT_ATTACHMENT_BYTES)
         if (oversized) {
             setError(`${oversized.name} is larger than the 2 MB attachment limit.`)
             return
@@ -202,10 +179,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
         setAttachments(current => [...current, ...pending])
         await Promise.all(pending.map(async attachment => {
             try {
-                const result = await uploadReviewAttachment(attachment.file, {
-                    category: 'support-ticket',
-                    challengeId: uploadOwnerId,
-                })
+                const result = await uploadSupportAttachment(attachment.file)
                 setAttachments(current => current.map(item => (item.id === attachment.id
                     ? { ...item, result, status: 'uploaded' }
                     : item)))

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.spec.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.spec.tsx
@@ -155,5 +155,21 @@ describe('FieldMarkdownEditor', () => {
 
         expect(mockEasyMDEInstances[0].options.uploadImage)
             .toBe(true)
+        expect(mockEasyMDEInstances[0].options.imageAccept)
+            .toContain('svg')
+    })
+
+    it('uses an accepted-upload-types override', async () => {
+        render(
+            <FieldMarkdownEditor acceptedUploadTypes={['.png', 'image/png']} />,
+        )
+
+        await waitFor(() => {
+            expect(mockEasyMDEInstances)
+                .toHaveLength(1)
+        })
+
+        expect(mockEasyMDEInstances[0].options.imageAccept)
+            .toBe('.png, image/png')
     })
 })

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
@@ -48,6 +48,11 @@ interface Props {
     disabled?: boolean
     uploadCategory?: string
     uploadAttachment?: UploadAttachment
+    /**
+     * Overrides the file-extension and MIME accept tokens advertised and
+     * validated by EasyMDE. Review's existing file set remains the default.
+     */
+    acceptedUploadTypes?: readonly string[]
     maxUploadSize?: number
     maxCharactersAllowed?: number
     textareaId?: string
@@ -617,7 +622,24 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
             position.end = end
         }
 
-        if (!editor.options.imageAccept.includes(getFileType())) {
+        const acceptedUploadTypes = String(editor.options.imageAccept)
+            .split(',')
+            .map(type => type.trim()
+                .toLowerCase())
+            .filter(Boolean)
+        const extensionIndex = file.name.lastIndexOf('.')
+        const extension = extensionIndex >= 0
+            ? file.name.slice(extensionIndex)
+                .toLowerCase()
+            : ''
+        const candidateTypes = [
+            file.type.trim()
+                .toLowerCase(),
+            extension,
+            extension.slice(1),
+        ].filter(Boolean)
+
+        if (!candidateTypes.some(type => acceptedUploadTypes.includes(type))) {
             onErrorSup(
                 fillErrorMessage(editor.options.errorMessages.typeNotAllowed),
             )
@@ -681,10 +703,10 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
             errorMessages,
             forceSync: true, // true, force text changes made in EasyMDE to be immediately stored in original text area.
             hideIcons: ['guide', 'heading', 'preview', 'side-by-side'],
-            imageAccept: [
+            imageAccept: (props.acceptedUploadTypes ?? [
                 ...allowedImageExtensions,
                 ...allowedOtherExtensions,
-            ].join(', '), // A comma-separated list of mime-types and extensions
+            ]).join(', '), // A comma-separated list of mime-types and extensions
             imageMaxSize: props.maxUploadSize ?? defaultMaxUploadSize, // Maximum image size in bytes
             imageTexts: {
                 sbInit: 'Attach files by dragging & dropping, selecting or pasting them.',

--- a/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
+++ b/src/apps/review/src/lib/components/FieldMarkdownEditor/FieldMarkdownEditor.tsx
@@ -48,6 +48,7 @@ interface Props {
     disabled?: boolean
     uploadCategory?: string
     uploadAttachment?: UploadAttachment
+    maxUploadSize?: number
     maxCharactersAllowed?: number
     textareaId?: string
     ariaLabel?: string
@@ -63,7 +64,7 @@ const errorMessages = {
     typeNotAllowed:
         'Uploading #image_name# was failed. The file type (#image_type#) is not supported.',
 }
-const maxUploadSize = 40 * 1024 * 1024
+const defaultMaxUploadSize = 40 * 1024 * 1024
 const imageExtensions = ['gif', 'png', 'jpeg', 'jpg', 'bmp', 'svg']
 const allowedImageExtensions = [
     ...imageExtensions,
@@ -684,7 +685,7 @@ export const FieldMarkdownEditor: FC<Props> = (props: Props) => {
                 ...allowedImageExtensions,
                 ...allowedOtherExtensions,
             ].join(', '), // A comma-separated list of mime-types and extensions
-            imageMaxSize: maxUploadSize, // Maximum image size in bytes
+            imageMaxSize: props.maxUploadSize ?? defaultMaxUploadSize, // Maximum image size in bytes
             imageTexts: {
                 sbInit: 'Attach files by dragging & dropping, selecting or pasting them.',
                 sbOnDragEnter: 'Drop file to upload it.',

--- a/src/apps/support/README.md
+++ b/src/apps/support/README.md
@@ -33,8 +33,14 @@ one `file` field as authenticated multipart form data to
 `POST /v6/support/attachments`; support-api-v6 then uses the standard hosted
 upload flow and returns the canonical HTTPS URL inserted into Markdown. The
 browser never connects directly to the configured storage bucket. Both the UI
-and API enforce a 2 MiB limit. Display uses `react-markdown` with GFM and line
-breaks; raw HTML is deliberately disabled.
+and API enforce a 2 MiB limit. The Support editor and API share the exact
+extension/MIME allowlist: `.7z`, `.bmp`, `.csv`, `.doc`, `.docx`, `.gif`, `.gz`,
+`.jpeg`, `.jpg`, `.json`, `.log`, `.pdf`, `.png`, `.ppt`, `.pptx`, `.rar`,
+`.tar`, `.tgz`, `.tif`, `.tiff`, `.txt`, `.webp`, `.xls`, `.xlsx`, `.xml`, and
+`.zip`; the declared MIME type must match its extension. Active formats such as
+SVG and HTML are not offered by the file picker and remain rejected by the API.
+Display uses `react-markdown` with GFM and line breaks; raw HTML is deliberately
+disabled.
 
 ## Domain infrastructure follow-ups
 

--- a/src/apps/support/README.md
+++ b/src/apps/support/README.md
@@ -27,10 +27,14 @@ The app calls `${EnvironmentConfig.API.V6}/support`. Local Platform UI rewrites
 the `/v6/support` prefix to `http://localhost:3014`, so run support-api-v6 on
 that port before starting Platform UI.
 
-Ticket and response fields use the shared Review `FieldMarkdownEditor` and
-`uploadReviewAttachment`. Uploads are grouped under the `support-ticket` or
-`support-ticket-response` category. Display uses `react-markdown` with GFM and
-line breaks; raw HTML is deliberately disabled.
+Ticket and response fields use the shared Review `FieldMarkdownEditor`, but
+attachments use the Support-owned `uploadSupportAttachment` client. It posts
+one `file` field as authenticated multipart form data to
+`POST /v6/support/attachments`; support-api-v6 then uses the standard hosted
+upload flow and returns the canonical HTTPS URL inserted into Markdown. The
+browser never connects directly to the configured storage bucket. Both the UI
+and API enforce a 2 MiB limit. Display uses `react-markdown` with GFM and line
+breaks; raw HTML is deliberately disabled.
 
 ## Domain infrastructure follow-ups
 

--- a/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.tsx
+++ b/src/apps/support/src/lib/components/OpenSupportRequestModal/OpenSupportRequestModal.tsx
@@ -39,18 +39,6 @@ interface ChallengeOption {
 }
 
 /**
- * Creates a non-authoritative upload grouping ID for attachments added before ticket creation.
- *
- * @returns unique draft upload context.
- * @throws Does not throw.
- */
-function createUploadContext(): string {
-    return `draft-${Date.now()}-${Math.random()
-        .toString(36)
-        .slice(2)}`
-}
-
-/**
  * Renders and validates the member-only Open support request modal.
  *
  * @param props open state and close/success callbacks.
@@ -65,7 +53,7 @@ export const OpenSupportRequestModal: FC<OpenSupportRequestModalProps> = props =
     const [descriptionError, setDescriptionError] = useState<string | undefined>()
     const [requestError, setRequestError] = useState<string | undefined>()
     const [submitting, setSubmitting] = useState(false)
-    const [uploadContext, setUploadContext] = useState(createUploadContext)
+    const [editorRevision, setEditorRevision] = useState(0)
     const challengeRequestKey: string | undefined = props.open && memberId
         ? `support-active-challenges:${memberId}`
         : undefined
@@ -98,7 +86,7 @@ export const OpenSupportRequestModal: FC<OpenSupportRequestModalProps> = props =
         setDescription('')
         setDescriptionError(undefined)
         setRequestError(undefined)
-        setUploadContext(createUploadContext())
+        setEditorRevision(current => current + 1)
     }
 
     /**
@@ -220,13 +208,12 @@ export const OpenSupportRequestModal: FC<OpenSupportRequestModalProps> = props =
                     )}
                 </div>
                 <SupportMarkdownEditor
-                    contextId={uploadContext}
                     disabled={submitting}
+                    editorId={`support-request-${editorRevision}`}
                     error={descriptionError}
-                    key={uploadContext}
+                    key={editorRevision}
                     label='Description'
                     onChange={handleDescriptionChange}
-                    uploadCategory='support-ticket'
                     value={description}
                 />
                 {requestError && <p className={styles.requestError} role='alert'>{requestError}</p>}

--- a/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.spec.tsx
+++ b/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.spec.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { render } from '@testing-library/react'
+
+import {
+    MAX_SUPPORT_ATTACHMENT_BYTES,
+    uploadSupportAttachment,
+} from '../../services'
+import { SupportMarkdownEditor } from './SupportMarkdownEditor'
+
+let mockEditorProps: {
+    maxUploadSize?: number
+    uploadAttachment?: typeof uploadSupportAttachment
+} = {}
+
+jest.mock('~/apps/review/src/lib/components/FieldMarkdownEditor', () => ({
+    FieldMarkdownEditor: (props: typeof mockEditorProps): JSX.Element => {
+        mockEditorProps = props
+        return <div data-testid='field-markdown-editor' />
+    },
+}), { virtual: true })
+
+jest.mock('../../services', () => ({
+    MAX_SUPPORT_ATTACHMENT_BYTES: 2 * 1024 * 1024,
+    uploadSupportAttachment: jest.fn(),
+}))
+
+const mockedUpload = uploadSupportAttachment as jest.MockedFunction<typeof uploadSupportAttachment>
+
+describe('SupportMarkdownEditor', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockEditorProps = {}
+        mockedUpload.mockResolvedValue({
+            filename: 'screenshot.png',
+            handle: 'hosted-handle',
+            url: 'https://cdn.filestackcontent.com/hosted-handle',
+        })
+    })
+
+    it('delegates to the Support uploader and exposes its two-megabyte limit', async () => {
+        render(
+            <SupportMarkdownEditor
+                editorId='support-reply'
+                label='Reply'
+                onChange={jest.fn()}
+                value=''
+            />,
+        )
+        const file = new File(['image'], 'screenshot.png', { type: 'image/png' })
+        const onProgress = jest.fn()
+
+        await mockEditorProps.uploadAttachment?.(file, { onProgress })
+
+        expect(mockEditorProps.maxUploadSize)
+            .toBe(MAX_SUPPORT_ATTACHMENT_BYTES)
+        expect(mockedUpload)
+            .toHaveBeenCalledWith(file, { onProgress })
+    })
+})

--- a/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.spec.tsx
+++ b/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.spec.tsx
@@ -3,11 +3,13 @@ import { render } from '@testing-library/react'
 
 import {
     MAX_SUPPORT_ATTACHMENT_BYTES,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES,
     uploadSupportAttachment,
 } from '../../services'
 import { SupportMarkdownEditor } from './SupportMarkdownEditor'
 
 let mockEditorProps: {
+    acceptedUploadTypes?: readonly string[]
     maxUploadSize?: number
     uploadAttachment?: typeof uploadSupportAttachment
 } = {}
@@ -21,6 +23,7 @@ jest.mock('~/apps/review/src/lib/components/FieldMarkdownEditor', () => ({
 
 jest.mock('../../services', () => ({
     MAX_SUPPORT_ATTACHMENT_BYTES: 2 * 1024 * 1024,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES: ['.png', 'image/png'],
     uploadSupportAttachment: jest.fn(),
 }))
 
@@ -53,6 +56,8 @@ describe('SupportMarkdownEditor', () => {
 
         expect(mockEditorProps.maxUploadSize)
             .toBe(MAX_SUPPORT_ATTACHMENT_BYTES)
+        expect(mockEditorProps.acceptedUploadTypes)
+            .toBe(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
         expect(mockedUpload)
             .toHaveBeenCalledWith(file, { onProgress })
     })

--- a/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.tsx
+++ b/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.tsx
@@ -10,6 +10,7 @@ import {
     MAX_SUPPORT_ATTACHMENT_BYTES,
     SupportAttachmentUploadOptions,
     SupportAttachmentUploadResult,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES,
     uploadSupportAttachment,
 } from '../../services'
 
@@ -55,6 +56,7 @@ export const SupportMarkdownEditor: FC<SupportMarkdownEditorProps> = props => {
                 <span aria-hidden='true'>*</span>
             </span>
             <FieldMarkdownEditor
+                acceptedUploadTypes={SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES}
                 ariaLabel={props.label}
                 disabled={props.disabled}
                 error={props.error}

--- a/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.tsx
+++ b/src/apps/support/src/lib/components/SupportMarkdownEditor/SupportMarkdownEditor.tsx
@@ -1,56 +1,55 @@
-/** Support wrapper around the Work/Review Markdown editor and uploader. */
+/** Support wrapper around the Work/Review Markdown editor. */
 import {
     FC,
     useCallback,
 } from 'react'
 
 import { FieldMarkdownEditor } from '~/apps/review/src/lib/components/FieldMarkdownEditor'
+
 import {
-    ReviewAttachmentUploadOptions,
-    ReviewAttachmentUploadResult,
-    uploadReviewAttachment,
-} from '~/apps/review/src/lib/services/file-upload.service'
+    MAX_SUPPORT_ATTACHMENT_BYTES,
+    SupportAttachmentUploadOptions,
+    SupportAttachmentUploadResult,
+    uploadSupportAttachment,
+} from '../../services'
 
 import styles from './SupportMarkdownEditor.module.scss'
 
 export interface SupportMarkdownEditorProps {
-    contextId: string
     disabled?: boolean
+    editorId: string
     error?: string
     label: string
     onChange: (value: string) => void
     value: string
-    uploadCategory: 'support-ticket' | 'support-ticket-response'
 }
 
 /**
  * Reuses the challenge-spec editor toolbar plus drag/drop, picker, and paste uploads.
  *
- * @param props controlled value, upload context, validation state, and change handler.
+ * @param props controlled value, editor identity, validation state, and change handler.
  * @returns the shared Markdown editor configured for Support attachments.
  * @throws Upload failures are displayed by the underlying editor.
  */
 export const SupportMarkdownEditor: FC<SupportMarkdownEditorProps> = props => {
     /**
-     * Uploads through the existing Review attachment pipeline with Support grouping.
+     * Uploads through the authenticated Support API, forwarding editor progress.
      *
      * @param file browser-selected, dropped, or pasted attachment.
-     * @param options editor progress and upload metadata.
+     * @param options editor upload progress callback.
      * @returns uploaded attachment metadata for Markdown insertion.
-     * @throws The returned promise rejects when the shared uploader fails.
+     * @throws The returned promise rejects when the Support uploader fails.
      */
     const uploadAttachment = useCallback((
         file: File,
-        options?: ReviewAttachmentUploadOptions,
-    ): Promise<ReviewAttachmentUploadResult> => uploadReviewAttachment(file, {
-        ...options,
-        category: props.uploadCategory,
-        challengeId: props.contextId,
-    }), [props.contextId, props.uploadCategory])
+        options?: SupportAttachmentUploadOptions,
+    ): Promise<SupportAttachmentUploadResult> => uploadSupportAttachment(file, {
+        onProgress: options?.onProgress,
+    }), [])
 
     return (
         <div className={styles.field}>
-            <span className={styles.label} id={`${props.contextId}-editor-label`}>
+            <span className={styles.label} id={`${props.editorId}-editor-label`}>
                 {props.label}
                 {' '}
                 <span aria-hidden='true'>*</span>
@@ -62,11 +61,11 @@ export const SupportMarkdownEditor: FC<SupportMarkdownEditorProps> = props => {
                 hideErrorMessage
                 initialValue={props.value}
                 maxCharactersAllowed={50000}
+                maxUploadSize={MAX_SUPPORT_ATTACHMENT_BYTES}
                 onChange={props.onChange}
                 placeholder='Describe the issue and include any steps needed to reproduce it.'
                 showBorder
                 uploadAttachment={uploadAttachment}
-                uploadCategory={props.uploadCategory}
             />
             {props.error && <p className={styles.error} role='alert'>{props.error}</p>}
         </div>

--- a/src/apps/support/src/lib/services/index.ts
+++ b/src/apps/support/src/lib/services/index.ts
@@ -1,2 +1,3 @@
 export * from './support-challenges.service'
+export * from './support-attachment.service'
 export * from './support.service'

--- a/src/apps/support/src/lib/services/support-attachment.service.spec.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.spec.ts
@@ -1,0 +1,89 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { xhrPostAsync } from '~/libs/core'
+
+import {
+    MAX_SUPPORT_ATTACHMENT_BYTES,
+    uploadSupportAttachment,
+} from './support-attachment.service'
+import { SUPPORT_API_BASE } from './support.service'
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: { API: { V6: 'https://api.example.test/v6' } },
+}), { virtual: true })
+
+jest.mock('~/libs/core', () => ({
+    xhrPostAsync: jest.fn(),
+}), { virtual: true })
+
+const mockedPost = xhrPostAsync as jest.Mock
+
+describe('Support attachment service', () => {
+    beforeEach(() => {
+        mockedPost.mockReset()
+    })
+
+    it('posts one file to the authenticated multipart endpoint and returns its metadata', async () => {
+        const file = new File(['image'], 'screenshot.png', { type: 'image/png' })
+        const result = {
+            filename: 'screenshot.png',
+            handle: 'hosted-handle',
+            mimetype: 'image/png',
+            size: file.size,
+            url: 'https://cdn.filestackcontent.com/hosted-handle',
+        }
+        mockedPost.mockResolvedValue(result)
+
+        await expect(uploadSupportAttachment(file)).resolves.toEqual(result)
+
+        expect(mockedPost)
+            .toHaveBeenCalledWith(
+                `${SUPPORT_API_BASE}/attachments`,
+                expect.any(FormData),
+                expect.objectContaining({
+                    headers: {
+                        'Content-Type': 'multipart/form-data',
+                    },
+                    onUploadProgress: expect.any(Function),
+                }),
+            )
+        const formData = mockedPost.mock.calls[0][1] as FormData
+        expect(formData.getAll('file'))
+            .toEqual([file])
+    })
+
+    it('reports bounded, rounded upload progress', async () => {
+        const onProgress = jest.fn()
+        mockedPost.mockImplementationOnce((_url, _data, config) => {
+            config.onUploadProgress({ loaded: 1, progress: 0.126, total: 8 })
+            config.onUploadProgress({ loaded: 10, total: 8 })
+            return Promise.resolve({
+                filename: 'notes.txt',
+                handle: 'notes-handle',
+                url: 'https://cdn.filestackcontent.com/notes-handle',
+            })
+        })
+
+        await uploadSupportAttachment(
+            new File(['notes'], 'notes.txt', { type: 'text/plain' }),
+            { onProgress },
+        )
+
+        expect(onProgress.mock.calls)
+            .toEqual([[13], [100]])
+    })
+
+    it('rejects empty and oversized files before making a request', async () => {
+        const empty = new File([], 'empty.txt', { type: 'text/plain' })
+        const oversized = new File(['x'], 'large.zip', { type: 'application/zip' })
+        Object.defineProperty(oversized, 'size', {
+            value: MAX_SUPPORT_ATTACHMENT_BYTES + 1,
+        })
+
+        await expect(uploadSupportAttachment(empty))
+            .rejects.toThrow('The selected attachment is empty.')
+        await expect(uploadSupportAttachment(oversized))
+            .rejects.toThrow('larger than the 2 MB attachment limit')
+        expect(mockedPost)
+            .not.toHaveBeenCalled()
+    })
+})

--- a/src/apps/support/src/lib/services/support-attachment.service.spec.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.spec.ts
@@ -3,6 +3,8 @@ import { xhrPostAsync } from '~/libs/core'
 
 import {
     MAX_SUPPORT_ATTACHMENT_BYTES,
+    SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES,
+    SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION,
     uploadSupportAttachment,
 } from './support-attachment.service'
 import { SUPPORT_API_BASE } from './support.service'
@@ -70,6 +72,46 @@ describe('Support attachment service', () => {
 
         expect(onProgress.mock.calls)
             .toEqual([[13], [100]])
+    })
+
+    it('exports the API extension and MIME allowlist for upload controls', () => {
+        expect(Object.keys(SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION))
+            .toEqual([
+                '.7z', '.bmp', '.csv', '.doc', '.docx', '.gif', '.gz', '.jpeg', '.jpg',
+                '.json', '.log', '.pdf', '.png', '.ppt', '.pptx', '.rar', '.tar', '.tgz',
+                '.tif', '.tiff', '.txt', '.webp', '.xls', '.xlsx', '.xml', '.zip',
+            ])
+        expect(SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION['.gz'])
+            .toEqual(['application/gzip', 'application/x-gzip'])
+        expect(SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION['.xml'])
+            .toEqual(['application/xml', 'text/xml'])
+        expect(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
+            .toEqual(expect.arrayContaining([
+                '.png',
+                '.tgz',
+                'application/gzip',
+                'image/png',
+            ]))
+        expect(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
+            .not.toContain('.html')
+        expect(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
+            .not.toContain('.svg')
+        expect(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
+            .not.toContain('image/svg+xml')
+        expect(SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES)
+            .not.toContain('text/html')
+    })
+
+    it('rejects unsupported extensions and extension/MIME mismatches before upload', async () => {
+        const svg = new File(['svg'], 'diagram.svg', { type: 'image/svg+xml' })
+        const mismatch = new File(['text'], 'notes.txt', { type: 'application/json' })
+
+        await expect(uploadSupportAttachment(svg))
+            .rejects.toThrow('This file type is not allowed for support attachments.')
+        await expect(uploadSupportAttachment(mismatch))
+            .rejects.toThrow('This file type is not allowed for support attachments.')
+        expect(mockedPost)
+            .not.toHaveBeenCalled()
     })
 
     it('rejects empty and oversized files before making a request', async () => {

--- a/src/apps/support/src/lib/services/support-attachment.service.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.ts
@@ -1,0 +1,69 @@
+/** Authenticated attachment uploader for support-api-v6. */
+import { xhrPostAsync } from '~/libs/core'
+
+import { SUPPORT_API_BASE } from './support.service'
+
+export const MAX_SUPPORT_ATTACHMENT_BYTES = 2 * 1024 * 1024
+
+export interface SupportAttachmentUploadOptions {
+    onProgress?: (percent: number) => void
+}
+
+export interface SupportAttachmentUploadResult {
+    filename: string
+    handle: string
+    key?: string
+    mimetype?: string
+    size?: number
+    url: string
+}
+
+/**
+ * Uploads one attachment through the authenticated Support API rather than
+ * connecting the browser directly to a storage bucket.
+ *
+ * @param file browser-selected, dropped, or pasted attachment.
+ * @param options optional upload-progress callback used by Markdown editors.
+ * @returns canonical hosted-file metadata for Markdown insertion.
+ * @throws Error when no file is supplied, the file is empty or larger than 2 MiB,
+ * or support-api-v6 rejects or cannot complete the upload.
+ */
+export async function uploadSupportAttachment(
+    file: File,
+    options: SupportAttachmentUploadOptions = {},
+): Promise<SupportAttachmentUploadResult> {
+    if (!file) {
+        throw new Error('No file provided for upload.')
+    }
+
+    if (!file.size) {
+        throw new Error('The selected attachment is empty.')
+    }
+
+    if (file.size > MAX_SUPPORT_ATTACHMENT_BYTES) {
+        throw new Error('The selected attachment is larger than the 2 MB attachment limit.')
+    }
+
+    const formData = new FormData()
+    formData.append('file', file, file.name)
+
+    return xhrPostAsync<FormData, SupportAttachmentUploadResult>(
+        `${SUPPORT_API_BASE}/attachments`,
+        formData,
+        {
+            headers: {
+                'Content-Type': 'multipart/form-data',
+            },
+            onUploadProgress: progressEvent => {
+                if (!options.onProgress) return
+
+                const ratio = typeof progressEvent.progress === 'number'
+                    ? progressEvent.progress
+                    : progressEvent.total
+                        ? progressEvent.loaded / progressEvent.total
+                        : 0
+                options.onProgress(Math.max(0, Math.min(100, Math.round(ratio * 100))))
+            },
+        },
+    )
+}

--- a/src/apps/support/src/lib/services/support-attachment.service.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.ts
@@ -5,6 +5,51 @@ import { SUPPORT_API_BASE } from './support.service'
 
 export const MAX_SUPPORT_ATTACHMENT_BYTES = 2 * 1024 * 1024
 
+/** Exact filename-extension to declared-MIME contract enforced by support-api-v6. */
+export const SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION: Readonly<
+    Record<string, readonly string[]>
+> = {
+    '.7z': ['application/x-7z-compressed'],
+    '.bmp': ['image/bmp'],
+    '.csv': ['text/csv'],
+    '.doc': ['application/msword'],
+    '.docx': [
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    '.gif': ['image/gif'],
+    '.gz': ['application/gzip', 'application/x-gzip'],
+    '.jpeg': ['image/jpeg'],
+    '.jpg': ['image/jpeg'],
+    '.json': ['application/json'],
+    '.log': ['text/plain'],
+    '.pdf': ['application/pdf'],
+    '.png': ['image/png'],
+    '.ppt': ['application/vnd.ms-powerpoint'],
+    '.pptx': [
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ],
+    '.rar': ['application/vnd.rar', 'application/x-rar-compressed'],
+    '.tar': ['application/x-tar'],
+    '.tgz': ['application/gzip', 'application/x-gzip'],
+    '.tif': ['image/tiff'],
+    '.tiff': ['image/tiff'],
+    '.txt': ['text/plain'],
+    '.webp': ['image/webp'],
+    '.xls': ['application/vnd.ms-excel'],
+    '.xlsx': [
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ],
+    '.xml': ['application/xml', 'text/xml'],
+    '.zip': ['application/zip', 'application/x-zip-compressed'],
+}
+
+/** Standards-compliant accept tokens derived from the Support API allowlist. */
+export const SUPPORT_ATTACHMENT_ACCEPTED_UPLOAD_TYPES: readonly string[] = [
+    ...Object.keys(SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION),
+    ...Array.from(new Set(Object.values(SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION)
+        .flat())),
+]
+
 export interface SupportAttachmentUploadOptions {
     onProgress?: (percent: number) => void
 }
@@ -25,8 +70,9 @@ export interface SupportAttachmentUploadResult {
  * @param file browser-selected, dropped, or pasted attachment.
  * @param options optional upload-progress callback used by Markdown editors.
  * @returns canonical hosted-file metadata for Markdown insertion.
- * @throws Error when no file is supplied, the file is empty or larger than 2 MiB,
- * or support-api-v6 rejects or cannot complete the upload.
+ * @throws Error when no file is supplied, the file is empty, larger than 2 MiB,
+ * does not match the Support API extension/MIME allowlist, or support-api-v6
+ * rejects or cannot complete the upload.
  */
 export async function uploadSupportAttachment(
     file: File,
@@ -42,6 +88,19 @@ export async function uploadSupportAttachment(
 
     if (file.size > MAX_SUPPORT_ATTACHMENT_BYTES) {
         throw new Error('The selected attachment is larger than the 2 MB attachment limit.')
+    }
+
+    const normalizedFilename = file.name.trim()
+    const extensionIndex = normalizedFilename.lastIndexOf('.')
+    const extension = extensionIndex >= 0
+        ? normalizedFilename.slice(extensionIndex)
+            .toLowerCase()
+        : ''
+    const mimetype = file.type.trim()
+        .toLowerCase()
+    const allowedMimetypes = SUPPORT_ATTACHMENT_MIME_TYPES_BY_EXTENSION[extension]
+    if (!allowedMimetypes?.includes(mimetype)) {
+        throw new Error('This file type is not allowed for support attachments.')
     }
 
     const formData = new FormData()

--- a/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
+++ b/src/apps/support/src/pages/ticket-details/TicketDetailPage.tsx
@@ -109,7 +109,7 @@ export const TicketDetailPage: FC = () => {
         : undefined
     const ticketOwner = Boolean(currentUserId && String(data.memberUserId) === currentUserId)
     const canReply = ticketOwner || (!closed && (!supportTeam || assignedToCurrentUser))
-    const replyContext = `${data.id}-reply-${replyRevision}`
+    const replyEditorId = `${data.id}-reply-${replyRevision}`
 
     /**
      * Adds or removes the authenticated staff assignment and refreshes detail.
@@ -328,16 +328,15 @@ export const TicketDetailPage: FC = () => {
                 <section className={styles.replyPanel}>
                     <h2>Add a reply</h2>
                     <SupportMarkdownEditor
-                        contextId={replyContext}
                         disabled={submittingReply}
+                        editorId={replyEditorId}
                         error={replyError}
-                        key={replyContext}
+                        key={replyEditorId}
                         label='Reply'
                         onChange={value => {
                             setReply(value)
                             if (value.trim()) setReplyError(undefined)
                         }}
-                        uploadCategory='support-ticket-response'
                         value={reply}
                     />
                     <div className={styles.replyActions}>


### PR DESCRIPTION
## Summary

- PM-6095: replace browser-direct Review/S3 uploads with authenticated multipart uploads through Support API
- PM-6095: keep Report an Issue attachments optional, enforce the authored 2 MiB limit, and use the same Support uploader for request/reply Markdown editors
- PM-6095: align both Support and Report Issue pickers plus client-side extension/MIME checks with the API allowlist while preserving Review editor defaults
- PM-6096: strip Word-exported inline styles so the modal consistently renders the Figtree 20px heading and Nunito Sans 16px body from the design system

## API dependency

PM-6095 depends on https://github.com/topcoder-platform/support-api-v6/pull/12 and its documented server-side `FILESTACK_API_KEY` deployment configuration. The key must belong to a Filestack app with application security disabled; policy/signature mode is intentionally rejected.

## Validation

- 6 focused QA suites, 25 tests passed after rebasing onto current `dev`
- attachment-type regression tests: 9/9 passed
- Report Issue picker regression tests: 6/6 passed
- full `yarn lint`
- full `yarn build`
- `git diff --check`

The build completed with existing repository-wide source-map and CSS-order warnings.
