### PR TITLE
Fix local development circular import crash

### DIFF
--- a/src/apps/platform/src/PlatformApp.tsx
+++ b/src/apps/platform/src/PlatformApp.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { toast, ToastContainer } from 'react-toastify'
 
-import { AnalyticsTracker } from '~/libs/core'
+import { AnalyticsTracker } from '~/libs/core/lib/analytics/AnalyticsTracker'
 import { NotificationsContainer, useViewportUnitsFix } from '~/libs/shared'
 
 import { AppFooter } from './components/app-footer'

--- a/src/libs/core/lib/analytics/AnalyticsTracker.tsx
+++ b/src/libs/core/lib/analytics/AnalyticsTracker.tsx
@@ -1,6 +1,7 @@
 import { FC, useEffect } from 'react'
 
-import { ProfileContextData, useProfileContext } from '../profile'
+import type { ProfileContextData } from '../profile/profile-context/profile-context-data.model'
+import { useProfileContext } from '../profile/profile-context/profile.context'
 
 import {
     initializeAnalytics,


### PR DESCRIPTION
## Summary

- import AnalyticsTracker directly instead of initializing the full core barrel from PlatformApp
- import profile context dependencies directly from AnalyticsTracker
- prevent the circular module initialization that left UserRole and form validators undefined in local development

## Validation

- targeted ESLint passed
- analytics unit test passed
- yarn build:dev completed successfully
- patched development bundle loaded in Chromium without the circular-import runtime exception