### PR TITLE
fix(opportunities): use canonical submission DMZ bucket

### DIFF
--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -33,6 +33,7 @@ import {
 
 jest.mock('~/config', () => ({
     EnvironmentConfig: {
+        ADMIN: { AWS_DMZ_BUCKET: 'submission-dmz' },
         API: { V5: 'https://api.example/v5', V6: 'https://api.example/v6' },
         FILESTACK: {
             API_KEY: 'filestack-key',
@@ -40,7 +41,7 @@ jest.mock('~/config', () => ({
             PROGRESS_INTERVAL: 100,
             REGION: 'us-east-1',
             RETRY: 2,
-            SUBMISSION_CONTAINER: 'submission-dmz',
+            SUBMISSION_CONTAINER: 'general-assets-bucket',
             TIMEOUT: 1000,
         },
     },
@@ -716,7 +717,7 @@ describe('opportunities service normalization', () => {
             )
     })
 
-    it('uploads a challenge ZIP to DMZ before creating its URL-backed submission', async () => {
+    it('uploads a challenge ZIP to the canonical DMZ before creating its URL-backed submission', async () => {
         const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
         const upload = jest.fn()
             .mockImplementation(async (_file, options) => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -106,6 +106,7 @@ export async function createChallengeSubmission(
     signal?: AbortSignal,
 ): Promise<ChallengeSubmission> {
     if (signal?.aborted) throw new DOMException('Upload cancelled.', 'AbortError')
+    const submissionContainer = EnvironmentConfig.ADMIN.AWS_DMZ_BUCKET
     const storagePath = `${challengeId}-${memberId}-${type}-${Date.now()}.zip`
     const uploadOptions: UploadOptions = {
         onProgress: event => {
@@ -118,7 +119,7 @@ export async function createChallengeSubmission(
         timeout: EnvironmentConfig.FILESTACK.TIMEOUT,
     }
     const storeOptions: StoreUploadOptions = {
-        container: EnvironmentConfig.FILESTACK.SUBMISSION_CONTAINER,
+        container: submissionContainer,
         path: storagePath,
         region: EnvironmentConfig.FILESTACK.REGION,
     }
@@ -126,7 +127,7 @@ export async function createChallengeSubmission(
         .upload(file, uploadOptions, storeOptions)
     if (signal?.aborted) throw new DOMException('Upload cancelled.', 'AbortError')
     const storageKey = String(upload?.key ?? storagePath)
-    const storageUrl = `https://s3.amazonaws.com/${EnvironmentConfig.FILESTACK.SUBMISSION_CONTAINER}/${storageKey}`
+    const storageUrl = `https://s3.amazonaws.com/${submissionContainer}/${storageKey}`
     const submission = await xhrPostAsync<{
         challengeId: string
         memberId: string


### PR DESCRIPTION
## Summary

- Route Opportunities challenge uploads through the environment's canonical submission DMZ bucket.
- Use the same bucket when constructing the URL sent to Review API.
- Add regression coverage proving a general Filestack container override cannot redirect submissions to the asset bucket.

## Root cause

The deployed dev bundle supplied `tc-challenge-v5-dev` as `FILESTACK_SUBMISSION_CONTAINER`. The page CSP permits the submission DMZ bucket, but not that general asset bucket, so Filestack initialization succeeded and the S3 PUT was blocked by CSP.

## Validation

- Focused Opportunities service tests: 36 passed.
- Challenge submission component tests: 7 passed.
- ESLint and `git diff --check` passed.
- Dev production build succeeded with existing unrelated warnings.
- Live challenge verification with a sub-1 MB ZIP: DMZ preflight and PUT returned 200; `POST /v6/submissions` returned 201; submission `BwUZe09FBnoy1m` is visible under My Submissions.
