### PR TITLE
fix(opportunities): address PM-5997 QA follow-ups

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -199,7 +199,9 @@ submission metadata needed for locked cards, while the public-safe
 that Review API has released. Anonymous visitors receive only that public page.
 Review API remains authoritative for group, whitelist, screening, and
 review-phase release checks; absent previews render as locked placeholders.
-Design challenges without the flag retain the authored submission-list state.
+Design challenges without the flag keep challenge-wide submissions private and
+render the explicit private state. A registered member's My Submissions table
+remains available independently of that public release flag.
 
 Opportunity detail tabs keep their page header and tab navigation mounted while
 the selected panel changes. Lazy challenge panels use a panel-scoped loading
@@ -209,8 +211,11 @@ are reserved for the initial detail-route request. Review and copilot detail
 tabs likewise switch in place, and engagement detail background checks render
 inside their owning section.
 
-The standard Submissions tab follows community-app's authenticated-member
-gate; registration is required only for My Submissions and authored actions.
+The standard non-Design Submissions tab follows community-app's
+authenticated-member gate; registration is required only for My Submissions
+and authored actions. Registrants and standard submission tables order newest
+dates first and expose accessible date headers that toggle the owning API's
+ascending or descending ordering.
 Review API submissions and Marathon Match review summations own provisional
 and final scores. Final Marathon Match values remain hidden while a submission
 phase is open, then appear after Review closes or Review API publishes a final
@@ -223,14 +228,18 @@ scores are requested only for authenticated members.
 
 Registered members submit without leaving challenge details. The My
 Submissions flow accepts one `.zip` archive up to 500MB, requires the authored
-declaration, reports live multipart progress, and posts the file directly to
-`POST /v6/submissions`. The active phase selects `CONTEST_SUBMISSION`,
+declaration, and reports live upload progress. The browser uploads to
+Filestack's S3 endpoint using the environment's canonical submissions DMZ
+bucket, then sends the resulting storage URL to `POST /v6/submissions`. The
+active phase selects `CONTEST_SUBMISSION`,
 `CHECKPOINT_SUBMISSION`, or `STUDIO_FINAL_FIX_SUBMISSION`; Review API remains
 authoritative for registration, phase, winner, submission-limit, and file
 validation. Design shows the four expected inner deliverables, while
 Development, Marathon Match, and Quality Assurance direct members to their
 Requirements content. Successful uploads expose the created submission ID and
-refresh challenge counts without leaving the confirmation state.
+refresh challenge counts without leaving the confirmation state. Design
+submissions can be deleted only while Submission or Checkpoint Submission is
+open.
 
 Challenge Discussion reads and writes use the authenticated
 `/v6/forums` API. Topic creation, comments and nested replies, owner edits and

--- a/src/apps/opportunities/src/components/ChallengeForum.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeForum.module.scss
@@ -134,7 +134,7 @@
         color: #007d79;
         cursor: pointer;
         font: inherit;
-        font-size: 14px;
+        font-size: 16px;
         font-weight: 700;
         line-height: 20px;
         padding: 0;
@@ -231,7 +231,7 @@
         color: #161616;
         cursor: pointer;
         display: flex;
-        font-size: 14px;
+        font-size: 16px;
         gap: 8px;
         line-height: 32px;
         min-height: 32px;
@@ -330,6 +330,11 @@
     dd {
         margin: 0;
     }
+}
+
+.discussionInfo dl > div {
+    font-size: 14px;
+    line-height: 20px;
 }
 
 .member {
@@ -524,8 +529,13 @@
         }
     }
 
+    p strong {
+        font-weight: 700;
+    }
+
     > strong {
         font-size: 14px;
+        font-weight: 700;
         line-height: 20px;
         margin-top: 16px;
     }
@@ -854,9 +864,9 @@
 .topicExcerpt {
     color: #161616;
     display: -webkit-box;
-    font-size: 14px;
+    font-size: 16px;
     -webkit-line-clamp: 3;
-    line-height: 20px;
+    line-height: 22px;
     margin: 20px 0 0;
     overflow: hidden;
     -webkit-box-orient: vertical;
@@ -891,7 +901,7 @@
         color: #007d79;
         display: inline-flex;
         font: inherit;
-        font-size: 14px;
+        font-size: 16px;
         font-weight: 700;
         gap: 5px;
         line-height: 20px;
@@ -1300,8 +1310,8 @@
 
 .postContent {
     color: #161616;
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 16px;
+    line-height: 22px;
     min-height: 80px;
 }
 

--- a/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
@@ -162,6 +162,14 @@
     text-decoration: underline;
     white-space: nowrap;
 
+    svg {
+        display: inline-block;
+        height: 14px;
+        margin-left: 3px;
+        vertical-align: -2px;
+        width: 14px;
+    }
+
     &:hover {
         text-decoration: none;
     }

--- a/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
@@ -13,6 +13,14 @@ const designChallengeLearningUrl
     = 'https://www.topcoder.example/thrive/articles/How%20To%20Compete%20in%20Design'
 const checkpointFeedbackLearningUrl
     = 'https://www.topcoder.example/thrive/articles/how-to-approach-the-checkpoint-feedback-to-decipher-hidden-codes'
+const marathonMatchLearningUrl
+    = 'https://www.topcoder.com/thrive/articles/How%20To%20Compete%20in%20a%20Marathon%20Match'
+const designSubmissionFormatUrl
+    = 'https://www.topcoder.com/thrive/articles/Formatting%20Your%20Submission%20for%20Design%20Challenges'
+const designScreeningLearningUrl
+    = 'https://www.topcoder.com/blog/ultimate-guide-pass-screening-design-challenges'
+const designPolicyUrl
+    = 'https://help.topcoder.com/hc/en-us/articles/217959447-Font-Policy-for-Design-Challenges'
 
 const mockUseSWR = jest.fn()
 
@@ -42,6 +50,7 @@ jest.mock('../utils', () => ({
         challengeLinks: [],
     }),
     challengeSubmissionLimit: (): undefined => undefined,
+    isMarathonMatchChallenge: (value: ChallengeOpportunity): boolean => value.type === 'Marathon Match',
 }))
 jest.mock('../services', () => ({
     getChallengeTermsDetails: jest.fn(),
@@ -50,7 +59,9 @@ jest.mock('../utils/opportunity-learning.utils', () => ({
     CHALLENGE_EXPLAINED_URL: challengeExplainedUrl,
     CHECKPOINT_FEEDBACK_LEARNING_URL: checkpointFeedbackLearningUrl,
     DESIGN_CHALLENGE_LEARNING_URL: designChallengeLearningUrl,
-    SCREENING_LEARNING_URL: 'https://www.topcoder.example/thrive/search?title=How%20to%20Pass%20Screening',
+    DESIGN_SCREENING_LEARNING_URL: designScreeningLearningUrl,
+    DESIGN_SUBMISSION_FORMAT_URL: designSubmissionFormatUrl,
+    MARATHON_MATCH_LEARNING_URL: marathonMatchLearningUrl,
 }))
 
 const challenge: ChallengeOpportunity = {
@@ -68,6 +79,11 @@ const designChallenge: ChallengeOpportunity = {
 const developmentChallenge: ChallengeOpportunity = {
     ...challenge,
     track: 'Development',
+}
+
+const marathonChallenge: ChallengeOpportunity = {
+    ...challenge,
+    type: 'Marathon Match',
 }
 
 function renderSidebar(
@@ -150,6 +166,18 @@ describe('ChallengeSidebar Review Style', () => {
                 'href',
                 challengeExplainedUrl,
             )
+        expect(screen.getByText('The place to see your scores and feedback, and improve before the final review.'))
+            .toBeInTheDocument()
+    })
+
+    it('adds the authored Marathon Match guide and arrow indicators', () => {
+        renderSidebar(undefined, marathonChallenge)
+
+        expect(screen.getByRole('link', { name: 'How to Compete in a Marathon Match' }))
+            .toHaveAttribute('href', marathonMatchLearningUrl)
+        expect(screen.getByRole('link', { name: 'Topcoder Challenges Explained' })
+            .querySelector('img'))
+            .not.toBeNull()
     })
 
     it('keeps design-only educational links and copy out of development challenges', () => {
@@ -250,5 +278,13 @@ describe('ChallengeSidebar Review Style', () => {
             .toHaveTextContent('how to pass screening.')
         expect(faqLink.parentElement)
             .toHaveTextContent('Trouble formatting your submission or want to learn more? Read the FAQ.')
+        expect(policyLink)
+            .toHaveAttribute('href', designPolicyUrl)
+        expect(policyLink)
+            .toHaveAttribute('target', '_blank')
+        expect(screeningLink)
+            .toHaveAttribute('href', designScreeningLearningUrl)
+        expect(faqLink)
+            .toHaveAttribute('href', designSubmissionFormatUrl)
     })
 })

--- a/src/apps/opportunities/src/components/ChallengeSidebar.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.tsx
@@ -16,12 +16,15 @@ import {
     ChallengeSidebarLink,
     challengeSidebarLinks,
     challengeSubmissionLimit,
+    isMarathonMatchChallenge,
 } from '../utils'
 import {
     CHALLENGE_EXPLAINED_URL,
     CHECKPOINT_FEEDBACK_LEARNING_URL,
     DESIGN_CHALLENGE_LEARNING_URL,
-    SCREENING_LEARNING_URL,
+    DESIGN_SCREENING_LEARNING_URL,
+    DESIGN_SUBMISSION_FORMAT_URL,
+    MARATHON_MATCH_LEARNING_URL,
 } from '../utils/opportunity-learning.utils'
 import { getChallengeTermsDetails } from '../services'
 import programBanner from '../assets/ai-exponential-program.png'
@@ -39,7 +42,7 @@ import sidebarSearchIcon from '../assets/sidebar-search.svg'
 import styles from './ChallengeSidebar.module.scss'
 
 const FILE_SUBMISSION_POLICY_URL
-    = 'https://help.topcoder.com/hc/en-us/articles/24958207774103-File-Submission-and-Review'
+    = 'https://help.topcoder.com/hc/en-us/articles/217959447-Font-Policy-for-Design-Challenges'
 
 interface ChallengeSidebarProps {
     aiReviewConfig?: ChallengeAiReviewConfig
@@ -227,6 +230,7 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
     const forumUrl = challengeForumUrl(props.challenge)
     const designChallenge = catalogName(props.challenge.track)
         .toLowerCase() === 'design'
+    const marathonMatch = isMarathonMatchChallenge(props.challenge)
     const developmentChallenge = catalogName(props.challenge.track)
         .toLowerCase() === 'development'
     const submissionGuidance = designChallenge || developmentChallenge
@@ -286,7 +290,7 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                 </div>
             </section>
             <SidebarCard icon={<img alt='' aria-hidden='true' src={sidebarReviewIcon} />} title='Review App'>
-                <p>The place to track your screening and review scores.</p>
+                <p>The place to see your scores and feedback, and improve before the final review.</p>
                 <Link to={`/review/active-challenges/${props.challenge.id}/challenge-details`}>
                     View Review App
                     <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
@@ -294,14 +298,25 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
             </SidebarCard>
             <SidebarCard icon={<img alt='' aria-hidden='true' src={sidebarBookIcon} />} title='Educational Materials'>
                 <p>Read educational material in Topcoder Thrive.</p>
-                <a href={CHALLENGE_EXPLAINED_URL} rel='noreferrer' target='_blank'>Topcoder Challenges Explained</a>
+                <a href={CHALLENGE_EXPLAINED_URL} rel='noreferrer' target='_blank'>
+                    Topcoder Challenges Explained
+                    <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
+                </a>
+                {marathonMatch && (
+                    <a href={MARATHON_MATCH_LEARNING_URL} rel='noreferrer' target='_blank'>
+                        How to Compete in a Marathon Match
+                        <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
+                    </a>
+                )}
                 {designChallenge && (
                     <>
                         <a href={DESIGN_CHALLENGE_LEARNING_URL} rel='noreferrer' target='_blank'>
                             How to compete in design challenges
+                            <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
                         </a>
                         <a href={CHECKPOINT_FEEDBACK_LEARNING_URL} rel='noreferrer' target='_blank'>
                             How to approach the checkpoint feedback
+                            <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
                         </a>
                     </>
                 )}
@@ -346,11 +361,12 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                                 {' '}
                                 <a
                                     className={styles.inlineAnchor}
-                                    href={CHALLENGE_EXPLAINED_URL}
+                                    href={DESIGN_SUBMISSION_FORMAT_URL}
                                     rel='noreferrer'
                                     target='_blank'
                                 >
                                     Read the FAQ.
+                                    <IconOutline.ExternalLinkIcon aria-hidden='true' />
                                 </a>
                             </p>
                         </div>
@@ -367,7 +383,15 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                                 {' '}
                                 the
                                 {' '}
-                                <a className={styles.inlineAnchor} href={FILE_SUBMISSION_POLICY_URL}>Policy</a>
+                                <a
+                                    className={styles.inlineAnchor}
+                                    href={FILE_SUBMISSION_POLICY_URL}
+                                    rel='noreferrer'
+                                    target='_blank'
+                                >
+                                    Policy
+                                    <IconOutline.ExternalLinkIcon aria-hidden='true' />
+                                </a>
                                 .
                             </p>
                         </div>
@@ -384,11 +408,12 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                                 {' '}
                                 <a
                                     className={styles.inlineAnchor}
-                                    href={SCREENING_LEARNING_URL}
+                                    href={DESIGN_SCREENING_LEARNING_URL}
                                     rel='noreferrer'
                                     target='_blank'
                                 >
                                     how to pass screening
+                                    <IconOutline.ExternalLinkIcon aria-hidden='true' />
                                 </a>
                                 .
                             </p>

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.module.scss
@@ -119,6 +119,22 @@
     }
 }
 
+.fileTypeIcon {
+    align-items: center;
+    border: 1.5px solid #161616;
+    border-radius: 1px;
+    box-sizing: border-box;
+    display: inline-flex;
+    flex: 0 0 16px;
+    font-size: 6px;
+    font-weight: 800;
+    height: 18px;
+    justify-content: center;
+    letter-spacing: -0.25px;
+    line-height: 8px;
+    width: 16px;
+}
+
 .tips svg {
     flex-basis: 20px;
     height: 20px;

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
@@ -149,11 +149,19 @@ describe('ChallengeSubmissionUpload', () => {
         fireEvent.change(screen.getByLabelText(/Upload File\*/), {
             target: { files: [file] },
         })
+        expect(screen.getByText('Ready to upload'))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('progressbar'))
+            .not.toBeInTheDocument()
         fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
         fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 
         expect(await screen.findByText('25%'))
             .toBeInTheDocument()
+        expect(screen.getByText('Uploading'))
+            .toBeInTheDocument()
+        expect(screen.getByRole('progressbar'))
+            .toHaveAttribute('aria-valuenow', '25')
         expect(mockedCreateSubmission)
             .toHaveBeenCalledWith(
                 'challenge-id',

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
@@ -36,6 +36,11 @@ interface ChallengeSubmissionUploadProps {
     onValidateRegistration: () => Promise<boolean>
 }
 
+/** Renders the compact extension badge used by Design required-file rows. */
+const FileTypeIcon: FC<{ extension: 'JPG' | 'TXT' | 'ZIP' }> = props => (
+    <span aria-hidden='true' className={styles.fileTypeIcon}>{props.extension}</span>
+)
+
 /**
  * Selects the Review API submission type represented by the currently open phase.
  *
@@ -280,19 +285,19 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                         {designChallenge ? (
                             <ul className={styles.requiredFiles}>
                                 <li>
-                                    <IconOutline.ArchiveIcon aria-hidden='true' />
+                                    <FileTypeIcon extension='ZIP' />
                                     Source folder zip file
                                 </li>
                                 <li>
-                                    <IconOutline.ArchiveIcon aria-hidden='true' />
+                                    <FileTypeIcon extension='ZIP' />
                                     Submission folder zip file
                                 </li>
                                 <li>
-                                    <IconOutline.DocumentTextIcon aria-hidden='true' />
+                                    <FileTypeIcon extension='TXT' />
                                     Declarations txt file
                                 </li>
                                 <li>
-                                    <IconOutline.PhotographIcon aria-hidden='true' />
+                                    <FileTypeIcon extension='JPG' />
                                     Preview jpg image
                                 </li>
                             </ul>
@@ -309,7 +314,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                     </section>
                     <section className={styles.infoCard}>
                         <h3>
-                            <IconOutline.BadgeCheckIcon aria-hidden='true' />
+                            <IconOutline.CogIcon aria-hidden='true' />
                             Submission tips
                         </h3>
                         <ul className={styles.tips}>
@@ -416,7 +421,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                             </div>
                             {file && (
                                 <div className={styles.uploadedFile}>
-                                    <strong>Uploading</strong>
+                                    <strong aria-live='polite'>{uploading ? 'Uploading' : 'Ready to upload'}</strong>
                                     <div className={styles.fileRow}>
                                         <IconOutline.PhotographIcon aria-hidden='true' />
                                         <div className={styles.fileCopy}>

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
@@ -200,6 +200,17 @@
         color: #137d60;
         font-weight: 700;
     }
+
+    > a {
+        align-items: center;
+        display: inline-flex;
+        gap: 4px;
+
+        svg {
+            height: 16px;
+            width: 16px;
+        }
+    }
 }
 
 .externalButton {

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -9,7 +9,12 @@ import DOMPurify from 'dompurify'
 import useSWR, { SWRResponse } from 'swr'
 
 import { getSafeCmsLink } from '~/libs/cms'
-import { BaseModal, Button, LoadingSpinner } from '~/libs/ui'
+import {
+    BaseModal,
+    Button,
+    IconOutline,
+    LoadingSpinner,
+} from '~/libs/ui'
 
 import { ChallengeTerm } from '../models'
 import {
@@ -240,6 +245,7 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                                 {getSafeCmsLink(term.url) && (
                                     <a href={getSafeCmsLink(term.url)} rel='noreferrer' target='_blank'>
                                         Open this term in a new window
+                                        <IconOutline.ExternalLinkIcon aria-hidden='true' />
                                     </a>
                                 )}
                                 {registrationMode && requiresExternalAgreement(term) && term.docusignTemplateId && (

--- a/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
+++ b/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
@@ -514,7 +514,7 @@ describe('OpportunityListCard owner-specific grid presentation', () => {
             .not.toBeInTheDocument()
     })
 
-    it('shows authored under-review, on-hold, and declined engagement labels', () => {
+    it('shows authored under-review, shortlisted, on-hold, and declined engagement labels', () => {
         const { rerender }: RenderResult = render(
             <MemoryRouter>
                 <OpportunityListCard
@@ -530,6 +530,21 @@ describe('OpportunityListCard owner-specific grid presentation', () => {
         )
 
         expect(screen.getByText('Under Review').className)
+            .toContain('stateApplied')
+        rerender(
+            <MemoryRouter>
+                <OpportunityListCard
+                    item={{
+                        applicationStatus: 'SHORTLISTED',
+                        id: 'shortlisted-engagement',
+                        status: 'OPEN',
+                        title: 'Shortlisted engagement',
+                    }}
+                    kind='engagements'
+                />
+            </MemoryRouter>,
+        )
+        expect(screen.getByText('Shortlisted').className)
             .toContain('stateApplied')
         rerender(
             <MemoryRouter>

--- a/src/apps/opportunities/src/components/OpportunityListCard.tsx
+++ b/src/apps/opportunities/src/components/OpportunityListCard.tsx
@@ -764,7 +764,7 @@ export const OpportunityListCard: FC<OpportunityListCardProps> = props => {
     const remaining = Math.max(0, card.skills.filter(Boolean).length - visibleSkills.length)
     const stateKey = challengeCatalogKey(card.state)
     const stateIsAccepted = ['accepted', 'approved', 'assigned', 'completed', 'selected'].includes(stateKey)
-    const stateIsApplied = ['applied', 'onhold', 'underreview'].includes(stateKey)
+    const stateIsApplied = ['applied', 'onhold', 'shortlisted', 'underreview'].includes(stateKey)
     const stateIsClosed = [
         'applicationclosed',
         'cancelled',

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -424,7 +424,7 @@ describe('ChallengeDetailsPage member flows', () => {
             .not.toBeInTheDocument()
     })
 
-    it('uses the Design submission table when private previews are disabled', () => {
+    it('keeps Design submissions private unless released previews are enabled', () => {
         mockChallenge = { ...mockChallenge, track: 'Design' }
         mockSubmissions = [{
             id: 'submission-1',
@@ -435,11 +435,54 @@ describe('ChallengeDetailsPage member flows', () => {
         renderPage()
         fireEvent.click(screen.getByRole('tab', { name: /^Submissions/ }))
 
-        const headers = ['Handle', 'Submission Date', 'Action']
-        headers.forEach(header => expect(screen.getByRole('columnheader', { name: header }))
-            .toBeInTheDocument())
-        expect(screen.queryByRole('columnheader', { name: 'Rating' }))
+        expect(screen.getByText('Submissions are private'))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('table'))
             .not.toBeInTheDocument()
+    })
+
+    it('toggles server-backed registration and submission date ordering', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockRegistrants = [{
+            created: '2026-06-03T09:30:00.000Z',
+            id: 'resource-1',
+            memberHandle: 'registrant',
+            memberId: '456',
+        }]
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-1',
+            memberId: '456',
+            submitterHandle: 'registrant',
+        }]
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: /^Registrants/ }))
+        expect(screen.getByRole('columnheader', { name: 'Registration Date' }))
+            .toHaveAttribute('aria-sort', 'descending')
+        fireEvent.click(screen.getByRole('button', { name: 'Registration Date' }))
+        expect(screen.getByRole('columnheader', { name: 'Registration Date' }))
+            .toHaveAttribute('aria-sort', 'ascending')
+        expect(mockUseSWR.mock.calls.some(([key]) => (
+            Array.isArray(key)
+            && key[0] === 'opportunities:registrants'
+            && key[4] === 'asc'
+        )))
+            .toBe(true)
+
+        fireEvent.click(screen.getByRole('tab', { name: /^Submissions/ }))
+        expect(screen.getByRole('columnheader', { name: 'Submission Date' }))
+            .toHaveAttribute('aria-sort', 'descending')
+        fireEvent.click(screen.getByRole('button', { name: 'Submission Date' }))
+        expect(screen.getByRole('columnheader', { name: 'Submission Date' }))
+            .toHaveAttribute('aria-sort', 'ascending')
+        expect(mockUseSWR.mock.calls.some(([key]) => (
+            Array.isArray(key)
+            && key[0] === 'opportunities:submissions'
+            && key[5] === 'asc'
+        )))
+            .toBe(true)
     })
 
     it('shows registered tabs and the metadata-gated Marathon Match Dashboard', () => {
@@ -566,8 +609,13 @@ describe('ChallengeDetailsPage member flows', () => {
             .toBeInTheDocument()
         expect(screen.getByText('In Review'))
             .toBeInTheDocument()
-        expect(screen.getByRole('link', { name: /Open Review App/ }))
-            .toHaveAttribute('href', '/review/active-challenges/challenge-id/challenge-details?tab=submission')
+        expect(screen.queryByRole('link', { name: /^Open Review App$/ }))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'Open submission submission-1 in Review App' }))
+            .toHaveAttribute('href', '/review/challenge-id?tab=submission')
+        expect(screen.getByText('submission-1')
+            .closest('a'))
+            .toBeNull()
         expect(screen.queryByRole('button', { name: 'Download submission submission-1' }))
             .not.toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'View history for submission submission-1' }))
@@ -577,7 +625,11 @@ describe('ChallengeDetailsPage member flows', () => {
     it('renders and deletes the compact Design My Submissions actions', async () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }
-        mockChallenge = { ...mockChallenge, track: 'Design' }
+        mockChallenge = {
+            ...mockChallenge,
+            phases: [{ isOpen: true, name: 'Submission' }],
+            track: 'Design',
+        }
         mockSubmissions = [{
             createdAt: '2026-06-03T09:30:00.000Z',
             id: 'submission-1',
@@ -606,6 +658,34 @@ describe('ChallengeDetailsPage member flows', () => {
             .toHaveBeenCalledWith('submission-1'))
         await waitFor(() => expect(deleteButton)
             .not.toBeDisabled())
+    })
+
+    it('disables Design submission deletion after the submission phase closes', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockChallenge = {
+            ...mockChallenge,
+            phases: [{ isOpen: true, name: 'Review' }],
+            track: 'Design',
+        }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-closed',
+            type: 'CONTEST_SUBMISSION',
+        }]
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        const deleteButton = screen.getByRole('button', {
+            name: 'Delete submission submission-closed',
+        })
+        expect(deleteButton)
+            .toBeDisabled()
+        expect(deleteButton)
+            .toHaveAttribute('title', 'Submission deletion is closed')
+        expect(mockDeleteSubmission)
+            .not.toHaveBeenCalled()
     })
 
     it('renders the compact QA My Submissions columns and authored actions', () => {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
@@ -269,7 +269,7 @@
     border: 1px solid #e0e0e0;
     border-radius: 8px;
     box-sizing: border-box;
-    overflow-x: auto;
+    overflow-x: visible;
     padding: 24px;
 
     table {
@@ -354,21 +354,33 @@
     gap: 4px;
     text-decoration: none;
 
-    svg {
-        height: 20px;
-        width: 20px;
+    img {
+        height: 16px;
+        width: 16px;
     }
 }
 
 .sortedHeader {
     align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
     display: inline-flex;
+    font: inherit;
     gap: 4px;
+    padding: 0;
 
     svg {
         height: 16px;
+        transition: transform 150ms ease;
         width: 16px;
     }
+}
+
+.sortAscending {
+    transform: rotate(180deg);
 }
 
 .ratedRegistrantTable,
@@ -380,7 +392,7 @@
 .myCompactSubmissionTable,
 .mySubmissionTable,
 .myMarathonTable {
-    min-width: 1152px;
+    min-width: 0;
 }
 
 .ratedRegistrantTable {
@@ -447,9 +459,8 @@
     th:nth-child(8) { width: 108px; }
 }
 
-.submissionIdLink {
-    color: #007d79;
-    text-decoration: none;
+.submissionId {
+    color: #161616;
 }
 
 .currentStatus {
@@ -519,7 +530,7 @@
     }
 
     button:disabled {
-        cursor: wait;
+        cursor: not-allowed;
         opacity: .45;
     }
 
@@ -527,6 +538,14 @@
         height: 20px;
         width: 20px;
     }
+}
+
+.reviewAppActionIcon {
+    background: currentColor;
+    display: inline-block;
+    height: 20px;
+    mask: url('../assets/sidebar-review.svg') center / contain no-repeat;
+    width: 20px;
 }
 
 .scoreNotice {
@@ -704,15 +723,16 @@
         background: #e9ecef;
         border-radius: 50%;
         color: #161616;
-        height: 20px;
-        padding: 6px;
-        width: 20px;
+        height: 24px;
+        padding: 8px;
+        width: 24px;
     }
 
     h2,
     > strong {
         font-family: 'Figtree', sans-serif;
         font-size: 16px;
+        font-weight: 700;
         line-height: 22px;
         margin: 12px 0 0;
         text-transform: none;
@@ -1070,6 +1090,22 @@
     .previewCard,
     .winnersPanel {
         padding: 16px;
+    }
+
+    .tableCard {
+        overflow-x: auto;
+    }
+
+    .ratedRegistrantTable,
+    .designRegistrantTable,
+    .developmentSubmissionTable,
+    .designSubmissionTable,
+    .qaSubmissionTable,
+    .marathonTable,
+    .myCompactSubmissionTable,
+    .mySubmissionTable,
+    .myMarathonTable {
+        min-width: 720px;
     }
 
     .previewCard {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -86,14 +86,13 @@ import {
 import medal1 from '../assets/medal-1.svg'
 import medal2 from '../assets/medal-2.svg'
 import medal3 from '../assets/medal-3.svg'
+import resetIcon from '../assets/reset.svg'
 import winnerThanksIcon from '../assets/winner-thanks.svg'
 
 import styles from './ChallengeDetailsPage.module.scss'
 
 type ChallengeTab = 'requirements' | 'registrants' | 'submissions' | 'mine' | 'dashboard' | 'forum' | 'winners'
 
-const HISTORY_ICON_PATH = 'M13 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7v3l4-4-4-4v3z'
-    + 'M12 8v5l4.25 2.52.77-1.28-3.52-2.09V8z'
 const STALE_REGISTRATION_MESSAGE
     = 'Your registration is no longer active. Register again before submitting.'
 
@@ -109,9 +108,54 @@ function challengeReviewUrl(challengeId: string, submissionType?: string): strin
     const tab = submissionType === 'CHECKPOINT_SUBMISSION'
         ? 'checkpoint-submission'
         : 'submission'
-    return `/review/active-challenges/${encodeURIComponent(challengeId)}`
-        + `/challenge-details?tab=${tab}`
+    return `/review/${encodeURIComponent(challengeId)}?tab=${tab}`
 }
+
+/**
+ * Determines whether a Design submission can still be removed while an
+ * authored submission phase is open.
+ *
+ * @param challenge challenge with expanded or compact current-phase data.
+ * @returns true during Submission or Checkpoint Submission only.
+ * @throws Does not throw.
+ */
+export function challengeAllowsDesignSubmissionDeletion(challenge: ChallengeOpportunity): boolean {
+    const openPhaseKeys = [
+        ...(challenge.phases ?? [])
+            .filter(phase => phase.isOpen === true)
+            .map(phase => challengeCatalogKey(phase.name)),
+        ...(challenge.currentPhaseNames ?? []).map(challengeCatalogKey),
+    ]
+    return openPhaseKeys.some(key => key === 'submission' || key === 'checkpointsubmission')
+}
+
+interface SortableDateHeaderProps {
+    label: string
+    onToggle: () => void
+    order: 'asc' | 'desc'
+}
+
+/** Renders an accessible date column that toggles server-backed ordering. */
+const SortableDateHeader: FC<SortableDateHeaderProps> = props => (
+    <th
+        aria-label={props.label}
+        aria-sort={props.order === 'asc' ? 'ascending' : 'descending'}
+    >
+        <button
+            aria-label={props.label}
+            className={styles.sortedHeader}
+            onClick={props.onToggle}
+            title={`Sort ${props.label.toLowerCase()} ${props.order === 'asc' ? 'descending' : 'ascending'}`}
+            type='button'
+        >
+            <span aria-hidden='true'>{props.label}</span>
+            <IconOutline.ChevronDownIcon
+                aria-hidden='true'
+                className={props.order === 'asc' ? styles.sortAscending : undefined}
+            />
+        </button>
+    </th>
+)
 
 /**
  * Formats a Review API submission enum as a member-facing label.
@@ -787,9 +831,10 @@ function registrationTimestamp(resource: ChallengeResource): string {
 const RegistrantsTab: FC<{ challenge: ChallengeOpportunity }> = props => {
     const [page, setPage] = useState(1)
     const [perPage, setPerPage] = useState(10)
+    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
     const response: SWRResponse<OpportunityPage<ChallengeResource>, Error> = useSWR(
-        ['opportunities:registrants', props.challenge.id, page, perPage],
-        () => getChallengeSubmitters(props.challenge.id, page, perPage),
+        ['opportunities:registrants', props.challenge.id, page, perPage, sortOrder],
+        () => getChallengeSubmitters(props.challenge.id, page, perPage, undefined, sortOrder),
         { revalidateOnFocus: false },
     )
     const memberIds = useMemo(
@@ -810,8 +855,6 @@ const RegistrantsTab: FC<{ challenge: ChallengeOpportunity }> = props => {
     )
     const trackKey = challengeCatalogKey(props.challenge.track)
     const showRating = trackKey !== 'design'
-    const sortRegistrationDate = trackKey === 'qualityassurance'
-        || isMarathonMatchChallenge(props.challenge)
     if (response.isValidating && !response.data) {
         return <OpportunityTabLoading label='Loading registrants' />
     }
@@ -833,14 +876,14 @@ const RegistrantsTab: FC<{ challenge: ChallengeOpportunity }> = props => {
                         <tr>
                             <th>Handle</th>
                             {showRating && <th>Rating</th>}
-                            <th>
-                                {sortRegistrationDate ? (
-                                    <span className={styles.sortedHeader}>
-                                        Registration Date
-                                        <IconOutline.ChevronDownIcon aria-hidden='true' />
-                                    </span>
-                                ) : 'Registration Date'}
-                            </th>
+                            <SortableDateHeader
+                                label='Registration Date'
+                                onToggle={() => {
+                                    setSortOrder(value => (value === 'asc' ? 'desc' : 'asc'))
+                                    setPage(1)
+                                }}
+                                order={sortOrder}
+                            />
                         </tr>
                     </thead>
                     <tbody>
@@ -904,6 +947,7 @@ interface SubmissionsTabProps {
 const SubmissionsTab: FC<SubmissionsTabProps> = props => {
     const [page, setPage] = useState(1)
     const [perPage, setPerPage] = useState(10)
+    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
     const [historySubmission, setHistorySubmission] = useState<ChallengeSubmission | undefined>()
     const [marathonView, setMarathonView] = useState<'dashboard' | 'list'>('list')
     const [deletingSubmissionId, setDeletingSubmissionId] = useState<string | undefined>()
@@ -912,17 +956,21 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
     const isDesign = trackKey === 'design'
     const isQa = trackKey === 'qualityassurance'
     const isMarathonMatch = isMarathonMatchChallenge(props.challenge)
+    const privateDesignSubmissions = isDesign
+        && !props.mine
+        && !challengeMetadataFlag(props.challenge, 'submissionsViewable')
     const privatePreviewGallery = isDesign
         && !props.mine
         && challengeMetadataFlag(props.challenge, 'submissionsViewable')
     const usePublicPreviewPage = privatePreviewGallery && !props.viewerMemberId
     const response: SWRResponse<OpportunityPage<ChallengeSubmission>, Error> = useSWR(
-        [
+        privateDesignSubmissions ? undefined : [
             usePublicPreviewPage ? 'opportunities:submission-previews' : 'opportunities:submissions',
             props.challenge.id,
             props.memberId,
             page,
             perPage,
+            sortOrder,
         ],
         () => (usePublicPreviewPage
             ? getChallengeSubmissionPreviews(props.challenge.id, page, perPage)
@@ -932,6 +980,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                 perPage,
                 props.memberId,
                 !props.mine,
+                sortOrder,
             )),
         { revalidateOnFocus: false },
     )
@@ -983,6 +1032,8 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         props.challenge,
         submissions,
     )
+    const designDeletionAllowed = isDesign
+        && challengeAllowsDesignSubmissionDeletion(props.challenge)
 
     /**
      * Opens an authorized clean-storage download without exposing private URLs in list data.
@@ -1031,6 +1082,15 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         }
     }
 
+    if (privateDesignSubmissions) {
+        return (
+            <EmptyTab
+                title='Submissions are private'
+                text='Design submissions are not visible during this challenge.'
+            />
+        )
+    }
+
     if (response.isValidating && !response.data) {
         return <OpportunityTabLoading label='Loading submissions' />
     }
@@ -1040,7 +1100,6 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         if (props.mine) {
             return (
                 <MySubmissionsEmpty
-                    challengeId={props.challenge.id}
                     onStartSubmission={props.onStartSubmission}
                 />
             )
@@ -1076,17 +1135,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                     <h2>{props.mine ? 'My Submissions' : 'All Submissions'}</h2>
                     {props.mine && <p>Manage your submissions or upload new.</p>}
                 </div>
-                {props.mine ? (
-                    <a
-                        className={styles.reviewAppButton}
-                        href={challengeReviewUrl(props.challenge.id)}
-                        rel='noreferrer'
-                        target='_blank'
-                    >
-                        Open Review App
-                        <IconOutline.ExternalLinkIcon aria-hidden='true' />
-                    </a>
-                ) : isMarathonMatch && (
+                {!props.mine && isMarathonMatch && (
                     <div aria-label='Submission view' className={styles.submissionViewToggle} role='group'>
                         <button
                             aria-label='Table view'
@@ -1133,12 +1182,14 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                             <tr>
                                 <th>Submission ID</th>
                                 {!isMarathonMatch && <th>Type</th>}
-                                <th>
-                                    <span className={styles.sortedHeader}>
-                                        Submission Date
-                                        <IconOutline.ChevronDownIcon aria-hidden='true' />
-                                    </span>
-                                </th>
+                                <SortableDateHeader
+                                    label='Submission Date'
+                                    onToggle={() => {
+                                        setSortOrder(value => (value === 'asc' ? 'desc' : 'asc'))
+                                        setPage(1)
+                                    }}
+                                    order={sortOrder}
+                                />
                                 {isMarathonMatch ? (
                                     <>
                                         <th>Current Test Process</th>
@@ -1166,11 +1217,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                     : ''
                                 return (
                                     <tr key={submission.id}>
-                                        <td>
-                                            <a className={styles.submissionIdLink} href={reviewUrl}>
-                                                {submission.id}
-                                            </a>
-                                        </td>
+                                        <td><span className={styles.submissionId}>{submission.id}</span></td>
                                         {!isMarathonMatch && <td>{submissionTypeLabel(submission.type)}</td>}
                                         <td>{formatTimestamp(submission.submittedDate ?? submission.createdAt)}</td>
                                         {isMarathonMatch ? (
@@ -1229,9 +1276,12 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                                 {isDesign && (
                                                     <button
                                                         aria-label={`Delete submission ${submission.id}`}
-                                                        disabled={deletingSubmissionId === submission.id}
+                                                        disabled={!designDeletionAllowed
+                                                            || deletingSubmissionId === submission.id}
                                                         onClick={() => removeSubmission(submission)}
-                                                        title='Delete'
+                                                        title={designDeletionAllowed
+                                                            ? 'Delete'
+                                                            : 'Submission deletion is closed'}
                                                         type='button'
                                                     >
                                                         <IconOutline.TrashIcon aria-hidden='true' />
@@ -1244,7 +1294,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                                     target='_blank'
                                                     title='Open Review App'
                                                 >
-                                                    <IconOutline.DocumentSearchIcon aria-hidden='true' />
+                                                    <span aria-hidden='true' className={styles.reviewAppActionIcon} />
                                                 </a>
                                                 {!isDesign && !isQa && (
                                                     <button
@@ -1280,12 +1330,14 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                             <tr>
                                 <th>Handle</th>
                                 {!isDesign && <th>Rating</th>}
-                                <th>
-                                    <span className={styles.sortedHeader}>
-                                        Submission Date
-                                        <IconOutline.ChevronDownIcon aria-hidden='true' />
-                                    </span>
-                                </th>
+                                <SortableDateHeader
+                                    label='Submission Date'
+                                    onToggle={() => {
+                                        setSortOrder(value => (value === 'asc' ? 'desc' : 'asc'))
+                                        setPage(1)
+                                    }}
+                                    order={sortOrder}
+                                />
                                 {isMarathonMatch && <th>Provisional Score</th>}
                                 {isMarathonMatch && <th>Final Score</th>}
                                 {isQa && <th>Initial Score</th>}
@@ -1349,12 +1401,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                                 onClick={() => setHistorySubmission(submission)}
                                                 type='button'
                                             >
-                                                <svg aria-hidden='true' viewBox='0 0 24 24'>
-                                                    <path
-                                                        d={HISTORY_ICON_PATH}
-                                                        fill='currentColor'
-                                                    />
-                                                </svg>
+                                                <img alt='' aria-hidden='true' src={resetIcon} />
                                                 History
                                             </button>
                                         </td>
@@ -1820,12 +1867,11 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
 /**
  * Renders the empty My Submissions state with its primary upload action.
  *
- * @param props challenge identifier used by Review App and upload links.
+ * @param props optional upload action shown inside the empty state.
  * @returns empty-state panel.
  * @throws Does not throw.
  */
 const MySubmissionsEmpty: FC<{
-    challengeId: string
     onStartSubmission?: () => void
 }> = props => (
     <section className={styles.mySubmissionsEmpty}>
@@ -1834,15 +1880,6 @@ const MySubmissionsEmpty: FC<{
                 <h2>My Submissions</h2>
                 <p>Manage your submissions or upload new.</p>
             </div>
-            <a
-                className={styles.reviewAppButton}
-                href={challengeReviewUrl(props.challengeId)}
-                rel='noreferrer'
-                target='_blank'
-            >
-                Open Review App
-                <IconOutline.ExternalLinkIcon aria-hidden='true' />
-            </a>
         </div>
         <EmptyTab
             action={(

--- a/src/apps/opportunities/src/pages/OpportunitiesPage.tsx
+++ b/src/apps/opportunities/src/pages/OpportunitiesPage.tsx
@@ -125,7 +125,7 @@ const LearningCard: FC<LearningCardProps> = props => (
         <p>{props.body}</p>
         <a href={props.href} rel='noreferrer' target='_blank'>
             Learn more
-            <IconOutline.ArrowRightIcon />
+            <IconOutline.ExternalLinkIcon aria-hidden='true' />
         </a>
     </aside>
 )

--- a/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.tsx
@@ -464,7 +464,7 @@ export const ReviewOpportunityDetailsPage: FC = () => {
                                     <p>Interested in evaluating submissions on Topcoder?</p>
                                     <a href={REVIEWER_LEARNING_URL} rel='noreferrer' target='_blank'>
                                         Learn more
-                                        <IconOutline.ArrowRightIcon />
+                                        <IconOutline.ExternalLinkIcon aria-hidden='true' />
                                     </a>
                                 </section>
                             )}

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -334,6 +334,62 @@ describe('opportunities service normalization', () => {
             )
     })
 
+    it('hydrates public engagement cards with the caller application and assignment states', async () => {
+        const get = xhrGlobalInstance.get as jest.MockedFunction<typeof xhrGlobalInstance.get>
+        get.mockReset()
+        get
+            .mockResolvedValueOnce({
+                data: {
+                    data: [
+                        { id: 'applied-engagement', status: 'OPEN', title: 'Applied' },
+                        { id: 'assigned-engagement', status: 'OPEN', title: 'Assigned' },
+                    ],
+                    meta: { page: 1, perPage: 10, totalCount: 2, totalPages: 1 },
+                },
+                headers: { get: () => undefined },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    data: [{
+                        engagementId: 'applied-engagement',
+                        status: 'SHORTLISTED',
+                        updatedAt: '2026-09-01T00:00:00.000Z',
+                    }],
+                    meta: { page: 1, perPage: 200, totalCount: 1, totalPages: 1 },
+                },
+                headers: { get: () => undefined },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    data: [{
+                        assignments: [{ id: 'assignment', status: 'ASSIGNED' }],
+                        id: 'assigned-engagement',
+                    }],
+                    meta: { page: 1, perPage: 200, totalCount: 1, totalPages: 1 },
+                },
+                headers: { get: () => undefined },
+            })
+
+        await expect(getOpportunityPage('engagements', {
+            memberId: '123',
+            page: 1,
+            perPage: 10,
+            statuses: ['OPEN'],
+        }))
+            .resolves.toMatchObject({
+                items: [
+                    { applicationStatus: 'SHORTLISTED', id: 'applied-engagement' },
+                    { assignments: [{ status: 'ASSIGNED' }], id: 'assigned-engagement' },
+                ],
+            })
+        expect(get.mock.calls.map(call => new URL(String(call[0])).pathname))
+            .toEqual([
+                '/v6/engagements/engagements',
+                '/v6/engagements/applications',
+                '/v6/engagements/engagements/my-assignments',
+            ])
+    })
+
     it('maps copilot track facets and skills to types and disables status grouping for honest sorting', () => {
         const url = new URL(buildOpportunityPageUrl('copilots', {
             applied: true,
@@ -665,6 +721,49 @@ describe('opportunities service normalization', () => {
             .toBe('asc')
     })
 
+    it('hydrates Review cards with standardized challenge skills', async () => {
+        const get = xhrGlobalInstance.get as jest.MockedFunction<typeof xhrGlobalInstance.get>
+        get.mockReset()
+        get
+            .mockResolvedValueOnce({
+                data: {
+                    result: {
+                        content: [{
+                            challengeData: { technologies: [] },
+                            challengeId: 'challenge-id',
+                            id: 'review-id',
+                        }],
+                        metadata: { limit: 10, page: 1, total: 1, totalPages: 1 },
+                    },
+                },
+                headers: { get: () => undefined },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    data: [{ id: 'challenge-id', skills: [{ id: 'skill-id', name: 'TypeScript' }] }],
+                    meta: { page: 1, perPage: 1, totalCount: 1, totalPages: 1 },
+                },
+                headers: { get: () => undefined },
+            })
+
+        await expect(getOpportunityPage('reviews', {
+            page: 1,
+            perPage: 10,
+            statuses: ['OPEN'],
+        }))
+            .resolves.toMatchObject({
+                items: [{
+                    challengeData: { skills: [{ id: 'skill-id', name: 'TypeScript' }] },
+                    id: 'review-id',
+                }],
+            })
+        const challengeUrl = new URL(String(get.mock.calls[1][0]))
+        expect(challengeUrl.pathname)
+            .toBe('/v6/challenges')
+        expect(challengeUrl.searchParams.getAll('ids[]'))
+            .toEqual(['challenge-id'])
+    })
+
     it('loads the challenge AI review configuration used by Review Style', async () => {
         const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
         get.mockResolvedValueOnce({
@@ -836,27 +935,27 @@ describe('opportunities service normalization', () => {
         const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
         get
             .mockResolvedValueOnce({
-                data: [{ id: 'older', submittedDate: '2026-06-01T00:00:00.000Z' }],
+                data: [{ id: 'older', memberId: '123', submittedDate: '2026-06-01T00:00:00.000Z' }],
                 meta: { page: 1, perPage: 200, totalCount: 2, totalPages: 2 },
             })
             .mockResolvedValueOnce({
-                data: [{ id: 'newer', submittedDate: '2026-06-02T00:00:00.000Z' }],
+                data: [{ id: 'newer', memberId: '123', submittedDate: '2026-06-02T00:00:00.000Z' }],
                 meta: { page: 2, perPage: 200, totalCount: 2, totalPages: 2 },
             })
 
         await expect(getChallengeSubmissionHistory('challenge', '123', 'CONTEST_SUBMISSION'))
             .resolves.toEqual([
-                { id: 'newer', submittedDate: '2026-06-02T00:00:00.000Z' },
-                { id: 'older', submittedDate: '2026-06-01T00:00:00.000Z' },
+                { id: 'newer', memberId: '123', submittedDate: '2026-06-02T00:00:00.000Z' },
+                { id: 'older', memberId: '123', submittedDate: '2026-06-01T00:00:00.000Z' },
             ])
         expect(get)
             .toHaveBeenCalledWith(
-                'https://api.example/v6/submissions?challengeId=challenge&memberId=123&page=1&perPage=200'
+                'https://api.example/v6/submissions?challengeId=challenge&page=1&perPage=200'
                 + '&sortBy=submittedDate&orderBy=desc&type=CONTEST_SUBMISSION',
             )
         expect(get)
             .toHaveBeenCalledWith(
-                'https://api.example/v6/submissions?challengeId=challenge&memberId=123&page=2&perPage=200'
+                'https://api.example/v6/submissions?challengeId=challenge&page=2&perPage=200'
                 + '&sortBy=submittedDate&orderBy=desc&type=CONTEST_SUBMISSION',
             )
     })
@@ -946,7 +1045,8 @@ describe('opportunities service normalization', () => {
             .toHaveBeenCalledWith('https://api.example/v6/resource-roles')
         expect(globalGet)
             .toHaveBeenLastCalledWith(
-                'https://api.example/v6/resources?challengeId=challenge&page=2&perPage=20&roleId=submitter-role',
+                'https://api.example/v6/resources?challengeId=challenge&page=2&perPage=20&roleId=submitter-role'
+                + '&sortBy=created&sortOrder=desc',
             )
     })
 

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -62,6 +62,7 @@ const DEFAULT_SUMMARY: OpportunitySummary = {
 const MY_WORK_KINDS: OpportunityKind[] = ['competitions', 'engagements', 'copilots', 'reviews']
 const MY_WORK_COUNT_PAGE_SIZE = 1
 const ENGAGEMENT_SKILL_SEARCH_SIZE = 25
+const MEMBER_STATE_PAGE_SIZE = 200
 
 /**
  * Resolves the shared Filestack client used for challenge submissions.
@@ -315,6 +316,137 @@ function normalizePage<T>(
     const totalPages = readNumericHeader(headers, ['x-total-pages'])
         ?? toNumber(metadata.totalPages, perPage > 0 ? Math.ceil(total / perPage) : 0)
     return { items, page, perPage, total, totalPages }
+}
+
+interface EngagementApplicationState {
+    createdAt?: string
+    engagementId: string
+    id?: string
+    status?: string
+    updatedAt?: string
+}
+
+/**
+ * Loads every page of a member-scoped Engagement API collection within the
+ * same defensive page cap used by challenge-detail expansion requests.
+ *
+ * @param pathname v6 path below the configured API root.
+ * @returns flattened records in API order.
+ * @throws Propagates Engagement API authentication and network errors.
+ */
+async function getEngagementMemberCollection<T>(pathname: string): Promise<T[]> {
+    /** Builds one authenticated member-state collection URL. */
+    const makeUrl = (page: number): string => {
+        const url = new URL(`${V6_URL}${pathname}`)
+        url.searchParams.set('page', String(page))
+        url.searchParams.set('perPage', String(MEMBER_STATE_PAGE_SIZE))
+        return url.toString()
+    }
+
+    /** Loads and normalizes one member-state page. */
+    const loadPage = async (page: number): Promise<OpportunityPage<T>> => {
+        const response = await xhrGlobalInstance.get(makeUrl(page)) as AxiosResponse<
+            T[] | ApiEnvelope<T[]> | ApiListResponse<T>
+        >
+        return normalizePage(response, page, MEMBER_STATE_PAGE_SIZE)
+    }
+
+    const firstPage = await loadPage(1)
+    const totalPages = Math.min(MAX_DETAIL_PAGES, Math.max(1, firstPage.totalPages))
+    if (totalPages === 1) return firstPage.items
+    const additionalPages = await loadPagesInBatches(
+        Array.from({ length: totalPages - 1 }, (_value, index) => index + 2),
+        async page => (await loadPage(page)).items,
+    )
+    return [...firstPage.items, ...additionalPages.flat()]
+}
+
+/**
+ * Adds the signed-in member's own application and assignment state to a public
+ * engagement page without narrowing the public result set.
+ *
+ * @param page public engagement page from the list endpoint.
+ * @returns the same page with caller-owned state merged by engagement ID.
+ * @throws Propagates Engagement API authentication and network errors.
+ */
+async function hydrateEngagementMemberState(
+    page: OpportunityPage<EngagementOpportunity>,
+): Promise<OpportunityPage<EngagementOpportunity>> {
+    const [applications, assignedEngagements] = await Promise.all([
+        getEngagementMemberCollection<EngagementApplicationState>('/engagements/applications'),
+        getEngagementMemberCollection<EngagementOpportunity>('/engagements/engagements/my-assignments'),
+    ])
+    const latestApplications = new Map<string, EngagementApplicationState>()
+    for (const application of applications) {
+        const existing = latestApplications.get(application.engagementId)
+        const existingTime = Date.parse(existing?.updatedAt ?? existing?.createdAt ?? '')
+        const applicationTime = Date.parse(application.updatedAt ?? application.createdAt ?? '')
+        if (!existing || (Number.isFinite(applicationTime) ? applicationTime : 0)
+            >= (Number.isFinite(existingTime) ? existingTime : 0)) {
+            latestApplications.set(application.engagementId, application)
+        }
+    }
+
+    const assignmentsByEngagement = new Map(
+        assignedEngagements.map(engagement => [engagement.id, engagement.assignments ?? []]),
+    )
+
+    return {
+        ...page,
+        items: page.items.map(item => {
+            const application = latestApplications.get(item.id)
+            const assignments = assignmentsByEngagement.get(item.id)
+            return {
+                ...item,
+                ...(application?.status ? {
+                    applicationStatus: application.status,
+                    myApplication: { status: application.status },
+                } : {}),
+                ...(assignments?.length ? { assignments } : {}),
+            }
+        }),
+    }
+}
+
+/**
+ * Hydrates Review API opportunity snapshots with the standardized skill names
+ * returned by Challenge API's batched ID search.
+ *
+ * @param page review opportunity page whose embedded snapshots may omit skills.
+ * @returns the same page with challenge skills merged into each snapshot.
+ * @throws Propagates Challenge API visibility and network errors.
+ */
+async function hydrateReviewOpportunitySkills(
+    page: OpportunityPage<ReviewOpportunity>,
+): Promise<OpportunityPage<ReviewOpportunity>> {
+    const missingSkillItems = page.items.filter(item => (
+        !Array.isArray(item.challengeData?.skills) || !item.challengeData.skills.length
+    ))
+    if (!missingSkillItems.length) return page
+
+    const url = new URL(`${V6_URL}/challenges`)
+    url.searchParams.set('page', '1')
+    url.searchParams.set('perPage', String(missingSkillItems.length))
+    for (const item of missingSkillItems) url.searchParams.append('ids[]', item.challengeId)
+    const response = await xhrGlobalInstance.get(url.toString()) as AxiosResponse<
+        ChallengeOpportunity[] | ApiEnvelope<ChallengeOpportunity[]> | ApiListResponse<ChallengeOpportunity>
+    >
+    const challenges = normalizePage(response, 1, missingSkillItems.length).items
+    const skillsByChallenge = new Map(challenges.map(challenge => [challenge.id, challenge.skills ?? []]))
+    return {
+        ...page,
+        items: page.items.map(item => {
+            const skills = skillsByChallenge.get(item.challengeId)
+            if (!skills?.length) return item
+            return {
+                ...item,
+                challengeData: {
+                    ...(item.challengeData ?? {}),
+                    skills,
+                },
+            }
+        }),
+    }
 }
 
 /**
@@ -913,14 +1045,16 @@ export async function getOpportunityPage(
     const page = Math.max(1, filters.page)
     const perPage = Math.max(1, filters.perPage)
     if (kind === 'reviews' && filters.tracks?.some(track => opportunityFacetKey(track) === 'ai')) {
-        return getReviewPageWithAiTrack(filters)
+        const reviewPage = await getReviewPageWithAiTrack(filters)
+        return hydrateReviewOpportunitySkills(reviewPage)
+            .catch(() => reviewPage)
     }
 
     try {
         const response = await xhrGlobalInstance.get(buildOpportunityPageUrl(kind, filters)) as AxiosResponse<
             any[] | ApiEnvelope<any[]> | ApiListResponse<any>
         >
-        const normalized = normalizePage(response, page, perPage)
+        let normalized = normalizePage(response, page, perPage)
         if (kind === 'engagements' && filters.search?.trim() && normalized.total === 0 && !filters.skills?.length) {
             const skillIds = await resolveEngagementSkillIds(filters.search)
             if (skillIds.length) {
@@ -929,8 +1063,18 @@ export async function getOpportunityPage(
                     search: undefined,
                     skills: skillIds,
                 })) as AxiosResponse<any[] | ApiEnvelope<any[]> | ApiListResponse<any>>
-                return normalizePage(skillResponse, page, perPage)
+                normalized = normalizePage(skillResponse, page, perPage)
             }
+        }
+
+        if (kind === 'engagements' && filters.memberId && !filters.applied) {
+            normalized = await hydrateEngagementMemberState(normalized)
+                .catch(() => normalized)
+        }
+
+        if (kind === 'reviews') {
+            normalized = await hydrateReviewOpportunitySkills(normalized)
+                .catch(() => normalized)
         }
 
         return kind === 'copilots'
@@ -1104,6 +1248,7 @@ function normalizeSubmissionPage(
  * @param perPage page size.
  * @param memberId optional member filter for the My Submissions tab.
  * @param latestOnly whether to retain only the newest attempt per member.
+ * @param orderBy submitted-date direction requested by the interactive table header.
  * @returns normalized submissions page.
  * @throws Propagates Review API and network errors.
  */
@@ -1113,6 +1258,7 @@ export async function getChallengeSubmissions(
     perPage: number,
     memberId?: string,
     latestOnly: boolean = true,
+    orderBy: 'asc' | 'desc' = 'desc',
 ): Promise<OpportunityPage<ChallengeSubmission>> {
     const url = new URL(`${V6_URL}/submissions`)
     url.searchParams.set('challengeId', challengeId)
@@ -1120,7 +1266,7 @@ export async function getChallengeSubmissions(
     url.searchParams.set('perPage', String(perPage))
     if (latestOnly) url.searchParams.set('isLatest', 'true')
     url.searchParams.set('sortBy', 'submittedDate')
-    url.searchParams.set('orderBy', 'desc')
+    url.searchParams.set('orderBy', orderBy)
     if (memberId) url.searchParams.set('memberId', memberId)
     const response = await xhrGetAsync<SubmissionApiResponse | ChallengeSubmission[]>(url.toString())
     return normalizeSubmissionPage(response, page, perPage)
@@ -1155,7 +1301,10 @@ export async function deleteChallengeSubmission(submissionId: string): Promise<v
 
 /**
  * Loads every submission attempt for one challenge member for the History
- * dialog. The latest-only flag is deliberately omitted on this request.
+ * dialog. The latest-only and server-side member filters are deliberately
+ * omitted: Review API authorizes challenge-wide reads but rejects another
+ * member's ID filter for ordinary challenge participants. Matching member rows
+ * are retained locally after the authorized challenge page is loaded.
  *
  * @param challengeId challenge UUID.
  * @param memberId submitter member ID from the selected latest submission.
@@ -1172,12 +1321,11 @@ export async function getChallengeSubmissionHistory(
      * Builds one non-latest submission-history request.
      *
      * @param page one-based Review API page.
-     * @returns absolute submissions URL for the selected member and type.
+     * @returns absolute submissions URL for the selected challenge and type.
      */
     const makeUrl = (page: number): string => {
         const url = new URL(`${V6_URL}/submissions`)
         url.searchParams.set('challengeId', challengeId)
-        url.searchParams.set('memberId', memberId)
         url.searchParams.set('page', String(page))
         url.searchParams.set('perPage', String(SUBMISSION_HISTORY_PAGE_SIZE))
         url.searchParams.set('sortBy', 'submittedDate')
@@ -1199,6 +1347,9 @@ export async function getChallengeSubmissionHistory(
         )
         : []
     return [...firstPage.items, ...additionalPages.flat()]
+        .filter(submission => String(
+            submission.memberId ?? submission.registrant?.userId ?? '',
+        ) === memberId)
         .sort((first, second) => {
             const firstDate = Date.parse(first.submittedDate ?? first.createdAt ?? '')
             const secondDate = Date.parse(second.submittedDate ?? second.createdAt ?? '')
@@ -1346,6 +1497,8 @@ export async function getChallengeSubmissionPreviews(
  * @param perPage bounded page size.
  * @param memberId optional authenticated member ID.
  * @param roleId optional canonical resource-role ID.
+ * @param sortBy Resource API field used by an interactive table header.
+ * @param sortOrder Resource API direction used by an interactive table header.
  * @returns paginated challenge resources visible to the caller.
  * @throws Propagates Resource API and network errors.
  */
@@ -1355,6 +1508,8 @@ export async function getChallengeResources(
     perPage: number,
     memberId?: string,
     roleId?: string,
+    sortBy?: 'created' | 'memberHandle',
+    sortOrder?: 'asc' | 'desc',
 ): Promise<OpportunityPage<ChallengeResource>> {
     const url = new URL(`${V6_URL}/resources`)
     url.searchParams.set('challengeId', challengeId)
@@ -1362,6 +1517,8 @@ export async function getChallengeResources(
     url.searchParams.set('perPage', String(Math.max(1, perPage)))
     if (memberId) url.searchParams.set('memberId', memberId)
     if (roleId) url.searchParams.set('roleId', roleId)
+    if (sortBy) url.searchParams.set('sortBy', sortBy)
+    if (sortOrder) url.searchParams.set('sortOrder', sortOrder)
     const response = await xhrGlobalInstance.get(url.toString()) as AxiosResponse<
         ChallengeResource[] | ApiEnvelope<ChallengeResource[]> | ApiListResponse<ChallengeResource>
     >
@@ -1393,6 +1550,7 @@ export async function getSubmitterRole(): Promise<ChallengeResourceRole> {
  * @param page one-based Resource API page.
  * @param perPage bounded page size.
  * @param memberId optional authenticated member ID.
+ * @param sortOrder registration-date direction requested by the interactive table header.
  * @returns paginated resources whose role matches the canonical Submitter role.
  * @throws Propagates role resolution, Resource API, and network errors.
  */
@@ -1401,9 +1559,10 @@ export async function getChallengeSubmitters(
     page: number,
     perPage: number,
     memberId?: string,
+    sortOrder: 'asc' | 'desc' = 'desc',
 ): Promise<OpportunityPage<ChallengeResource>> {
     const role = await getSubmitterRole()
-    return getChallengeResources(challengeId, page, perPage, memberId, role.id)
+    return getChallengeResources(challengeId, page, perPage, memberId, role.id, 'created', sortOrder)
 }
 
 /**

--- a/src/apps/opportunities/src/utils/engagement-status.utils.ts
+++ b/src/apps/opportunities/src/utils/engagement-status.utils.ts
@@ -19,7 +19,7 @@ const STATUS_LABELS: Record<string, string> = {
     pendingassignment: 'On Hold',
     rejected: 'Rejected',
     selected: 'Selected',
-    shortlisted: 'Under Review',
+    shortlisted: 'Shortlisted',
     submitted: 'Applied',
     terminated: 'Terminated',
     underreview: 'Under Review',

--- a/src/apps/opportunities/src/utils/opportunity-learning.utils.ts
+++ b/src/apps/opportunities/src/utils/opportunity-learning.utils.ts
@@ -23,3 +23,15 @@ export const CHECKPOINT_FEEDBACK_LEARNING_URL = `${EnvironmentConfig.TOPCODER_UR
 /** Published screening guidance on the environment's main site. */
 export const SCREENING_LEARNING_URL = `${EnvironmentConfig.TOPCODER_URL}`
     + '/thrive/search?title=How%20to%20Pass%20Screening'
+
+/** Published Design screening guide required by the challenge-details rail. */
+export const DESIGN_SCREENING_LEARNING_URL
+    = 'https://www.topcoder.com/blog/ultimate-guide-pass-screening-design-challenges'
+
+/** Published Design submission-format FAQ required by the challenge-details rail. */
+export const DESIGN_SUBMISSION_FORMAT_URL
+    = 'https://www.topcoder.com/thrive/articles/Formatting%20Your%20Submission%20for%20Design%20Challenges'
+
+/** Published Marathon Match competition guide required by the challenge-details rail. */
+export const MARATHON_MATCH_LEARNING_URL
+    = 'https://www.topcoder.com/thrive/articles/How%20To%20Compete%20in%20a%20Marathon%20Match'


### PR DESCRIPTION
## Summary

- hydrate public Engagement cards with the signed-in member application/assignment state and preserve the clarified Shortlisted label (PM-6075, PM-6084)
- hydrate Review Opportunity cards with standardized Challenge skills (PM-6080)
- correct Design and Marathon Match guidance links/copy, external-link indicators, and submission-upload icons/progress state (PM-6101, PM-6102, PM-6103, PM-6108, PM-6109, PM-6119, PM-6120, PM-6121)
- align challenge-detail tables and actions with QA: responsive overflow, server-backed date sorting, Design privacy, submission history, icons, Review App routing, phase-aware deletion, plain submission IDs, and empty-state sizing/type (PM-6107, PM-6110, PM-6113 through PM-6118, PM-6122 through PM-6125)
- align forum typography with the latest annotated QA screenshots (PM-6127)

PM-6126 is not masked in this UI change: the UI create/list/detail routes match the current forums-api-v6 controllers, while the deployed topic-detail read is failing. That requires forums service/gateway deployment diagnosis.

The PM-6046 canonical submission DMZ fix was merged separately in #2223 while this follow-up was being completed.

## Validation

- 140 focused Opportunities tests pass
- yarn lint
- yarn run build (passes with existing repository source-map/CSS-order warnings)
- broader Opportunities run: 32 of 33 suites and all 213 executed tests pass; the remaining suite has a pre-existing Jest resolution failure for the unchanged ~/apps/copilots import in opportunity.utils.spec.ts