### PR TITLE
fix(opportunities): address PM-5997 QA follow-ups

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -14,7 +14,7 @@ The August 2026 masthead has two destinations. Browse Opportunities renders
 the four dark category cards and the active owner-backed listing. My Work
 renders the four light member-summary cards and combines the authenticated
 member's competitions, engagements, copilot work, and review work into one
-newest-first list. Anonymous visitors receive an in-page sign-in handoff; no
+shared sortable list. Anonymous visitors receive an in-page sign-in handoff; no
 member-scoped request is issued until a profile ID is available.
 
 My Work requests at most the first 100 member records from each owning API in
@@ -57,9 +57,13 @@ buttons remain keyboard accessible and expose their active state with
 Opportunity cards preserve same-tab navigation. External role-learning links
 open in a separate tab and include `rel="noreferrer"`.
 
-Completed Engagements omit `Starting soon`, since a future-start ordering is
-not meaningful for closed work. Changing to Completed while that sort is active
-resets the listing to `Newest first`.
+Every domain exposes the same four product-authored options: `Newest first`,
+`Prize high to low`, `Prize low to high`, and `Title A-Z`. Challenge API owns
+global competition prize/title ordering, Engagements owns title ordering, and
+Review API owns payment ordering. The shared page comparator supplies the same
+visible behavior where an owner API does not expose the selected field.
+Selecting a different result page scrolls the browser back to the top so the
+new page begins at its heading rather than at the prior page's footer.
 
 Review cards include the Review API's first role payment, falling back to its
 base payment. Missing amounts are labeled `TBD` rather than presented as free
@@ -224,10 +228,15 @@ Figma keeps separate Provisional Score and Final Score columns and uses `-`
 when a final value is not yet available. Winners use Review API's canonical
 `GET /v6/projectResult` member-and-placement result instead of inferring a
 score from Challenge API winners or a sibling submission; protected winner
-scores are requested only for authenticated members.
+scores are requested only for authenticated members. Marathon winner cards
+prefer an exact-member final Review Summation when legacy project-result rows
+contain a zero placeholder. Their separators use the corresponding podium
+placement color. Winner stats mirror the profile grouping by adding migrated
+AI Engineering wins to the Development total.
 
-Registered members submit without leaving challenge details. The My
-Submissions flow accepts one `.zip` archive up to 500MB, requires the authored
+Registered members submit without leaving challenge details. My Submissions
+also exposes the environment-specific Review App handoff before and after an
+upload. The flow accepts one `.zip` archive up to 500MB, requires the authored
 declaration, and reports live upload progress. The browser uploads to
 Filestack's S3 endpoint using the environment's canonical submissions DMZ
 bucket, then sends the resulting storage URL to `POST /v6/submissions`. The
@@ -243,14 +252,19 @@ open.
 
 Challenge Discussion reads and writes use the authenticated
 `/v6/forums` API. Topic creation, comments and nested replies, owner edits and
-soft deletes, per-member thumbs-up/thumbs-down reactions, watch state, and read
-state remain inside the challenge detail page. Each visible post shows shared
+soft deletes use in-app dialogs rather than browser prompts; per-member
+thumbs-up/thumbs-down reactions, watch state, and read state remain inside the
+challenge detail page. The Markdown editor continues ordered and unordered
+lists on Enter; safe Markdown styling is retained in topic excerpts and full
+posts. Each visible post shows shared
 reaction counts and the current member's selected state; clicking the selected
 thumb again removes it, while clicking the other thumb switches it. Topic
 summaries expose bounded starter excerpts, participant snapshots, unique
 authenticated view counts, and current-member watch state. The
 environment-specific Vanilla URL is retained only as a recovery link when the
-v6 API is unavailable or the member is signed out. Unregistered administrators
+v6 API is unavailable or the member is signed out. Forum counts come from the
+complete API result, including topics created by the current member.
+Unregistered administrators
 receive the registered read and monitoring tabs, including Submissions, the
 metadata-enabled Marathon Dashboard, and Forum, while My Submissions and upload
 actions remain registration-only. Administrators may create ordinary topics or
@@ -270,4 +284,5 @@ The challenge rail parses case-insensitive `fileTypes`, `submissionLimit`,
 and attachments, and fails closed for unsafe or retired-host URLs. Positive
 legacy screening and review scorecard IDs link through the environment-specific
 `ADMIN.ONLINE_REVIEW_URL`; Review App remains the primary authenticated review
-handoff.
+handoff. Marathon Match challenges replace the general AI Exponential promo
+with the Marathon Match Tournament heading, copy, and guide destination.

--- a/src/apps/opportunities/src/components/ChallengeDetailHeader.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeDetailHeader.spec.tsx
@@ -124,6 +124,35 @@ describe('ChallengeDetailHeader actions and presentation', () => {
             .toBeDisabled()
     })
 
+    it('labels a challenge without an active phase as completed', () => {
+        render(
+            <MemoryRouter>
+                <ChallengeDetailHeader
+                    busy={false}
+                    challenge={challengeFixture({
+                        currentPhase: undefined,
+                        currentPhaseNames: [],
+                        phases: [],
+                        status: 'COMPLETED',
+                    })}
+                    isRegistered={false}
+                    onRegister={jest.fn()}
+                    onSubmit={jest.fn()}
+                    onUnregister={jest.fn()}
+                />
+            </MemoryRouter>,
+        )
+
+        expect(screen.getByText('Challenge completed'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Timeline complete'))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Register' }))
+            .toBeDisabled()
+        expect(screen.getByRole('button', { name: 'Submit a solution' }))
+            .toBeDisabled()
+    })
+
     it('avoids flashing Register while member registration is unresolved', () => {
         render(
             <MemoryRouter>

--- a/src/apps/opportunities/src/components/ChallengeDetailHeader.tsx
+++ b/src/apps/opportunities/src/components/ChallengeDetailHeader.tsx
@@ -127,7 +127,7 @@ function typeIcon(type: string): string {
  * @throws Does not throw; absent and malformed dates use stable fallbacks.
  */
 function phaseSummary(phase: ChallengePhase | undefined): ChallengePhaseSummary {
-    if (!phase) return { phase: 'Timeline complete' }
+    if (!phase) return { phase: 'Challenge completed' }
     const endValue = phase.actualEndDate ?? phase.scheduledEndDate
     const end = endValue ? new Date(endValue) : undefined
     if (!end || Number.isNaN(end.getTime())) {
@@ -414,6 +414,7 @@ export const ChallengeDetailHeader: FC<ChallengeDetailHeaderProps> = props => {
     const trackKey = challengeCatalogKey(props.challenge.track)
     const registrationOpen = challengeRegistrationIsOpen(props.challenge)
     const submissionOpen = challengeSubmissionIsOpen(props.challenge)
+    const completedChallenge = challengeCatalogKey(props.challenge.status) === 'completed'
     const registrationUnavailable = props.registrationLoading || props.registrationError
     const canUnregister = props.isRegistered && registrationOpen && !registrationUnavailable && !props.busy
     const canSubmit = props.isRegistered && submissionOpen && !registrationUnavailable && !props.busy
@@ -552,17 +553,21 @@ export const ChallengeDetailHeader: FC<ChallengeDetailHeaderProps> = props => {
                             </div>
                         </div>
                         <div className={styles.actions}>
-                            {props.isRegistered ? (
+                            {props.isRegistered || completedChallenge ? (
                                 <>
                                     <button
                                         className={styles.secondary}
-                                        data-analytics-id='challenge-unregister'
+                                        data-analytics-id={props.isRegistered
+                                            ? 'challenge-unregister'
+                                            : 'challenge-register'}
                                         data-analytics-placement='challenge-header'
-                                        disabled={!canUnregister}
-                                        onClick={props.onUnregister}
+                                        disabled={props.isRegistered
+                                            ? !canUnregister
+                                            : !registrationOpen || registrationUnavailable || props.busy}
+                                        onClick={props.isRegistered ? props.onUnregister : props.onRegister}
                                         type='button'
                                     >
-                                        Unregister
+                                        {props.isRegistered ? 'Unregister' : 'Register'}
                                     </button>
                                     <button
                                         className={styles.primary}

--- a/src/apps/opportunities/src/components/ChallengeForum.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeForum.module.scss
@@ -430,9 +430,9 @@
 }
 
 .newPost {
-    background: #fff;
+    background: #c1294f;
     border: 1px solid #c1294f;
-    color: #c1294f;
+    color: #fff;
 }
 
 .locked {
@@ -870,6 +870,27 @@
     margin: 20px 0 0;
     overflow: hidden;
     -webkit-box-orient: vertical;
+
+    article {
+        font-size: inherit;
+        line-height: inherit;
+
+        h1,
+        h2,
+        h3,
+        h4,
+        p,
+        ul,
+        ol,
+        blockquote,
+        pre {
+            margin: 0 0 4px;
+        }
+
+        h1 { font-size: 22px; line-height: 30px; }
+        h2 { font-size: 20px; line-height: 28px; }
+        h3 { font-size: 18px; line-height: 26px; }
+    }
 }
 
 .topicFooter {
@@ -1258,6 +1279,68 @@
         line-height: 16px;
         margin-left: auto;
     }
+}
+
+.editModal {
+    border-radius: 8px !important;
+    box-sizing: border-box;
+    color: #161616;
+    font-family: 'Nunito Sans', sans-serif;
+    max-height: calc(100vh - 32px) !important;
+    max-width: calc(100vw - 24px) !important;
+    padding: 32px !important;
+    width: 720px !important;
+}
+
+.modalTitle {
+    color: #161616;
+    font-family: 'Figtree', sans-serif;
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 38px;
+    margin: 0 0 24px;
+    text-transform: none;
+}
+
+.editModalBody {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    min-width: 0;
+}
+
+.previewButton,
+.modalPrimary,
+.modalSecondary {
+    align-items: center;
+    border: 1px solid #007d79;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-flex;
+    font: 700 16px/20px 'Nunito Sans', sans-serif;
+    height: 38px;
+    justify-content: center;
+    padding: 8px 24px;
+
+    &:disabled {
+        cursor: wait;
+        opacity: .6;
+    }
+}
+
+.previewButton,
+.modalSecondary {
+    background: #fff;
+    color: #007d79;
+}
+
+.previewButton {
+    align-self: flex-start;
+}
+
+.modalPrimary {
+    background: #007d79;
+    color: #fff;
 }
 
 .post,

--- a/src/apps/opportunities/src/components/ChallengeForum.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeForum.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports, unicorn/no-null */
 import '@testing-library/jest-dom'
 import { readFileSync } from 'fs'
-import { act } from 'react'
+import { act, PropsWithChildren } from 'react'
 import {
     fireEvent,
     render,
@@ -19,6 +19,7 @@ import {
 } from '../models'
 import {
     ChallengeForum,
+    continueMarkdownList,
     flattenForumPosts,
     forumRatingClass,
     formatForumDate,
@@ -30,6 +31,7 @@ const mockCreateForumPost = jest.fn()
 const mockCreateForumTopic = jest.fn()
 const mockDeleteForumPost = jest.fn()
 const mockDeleteForumTopic = jest.fn()
+const mockGetForumTopicDetail = jest.fn()
 const mockMarkForumTopicRead = jest.fn()
 const mockSetForumPostReaction = jest.fn()
 const mockSetForumTopicWatching = jest.fn()
@@ -49,6 +51,32 @@ jest.mock('swr', () => ({
 jest.mock('~/libs/ui', () => {
     const Icon = (): JSX.Element => <svg />
     return {
+        BaseModal: (props: PropsWithChildren<{
+            buttons?: JSX.Element
+            onClose: () => void
+            open: boolean
+            title?: JSX.Element
+        }>): JSX.Element => (props.open ? (
+            <div role='dialog'>
+                {props.title}
+                {props.children}
+                {props.buttons}
+                <button aria-label='Close modal' onClick={props.onClose} type='button' />
+            </div>
+        ) : <></>),
+        ConfirmModal: (props: PropsWithChildren<{
+            action?: string
+            onClose: () => void
+            onConfirm: () => void
+            open: boolean
+            title: string
+        }>): JSX.Element => (props.open ? (
+            <div aria-label={props.title} role='dialog'>
+                {props.children}
+                <button onClick={props.onClose} type='button'>Cancel</button>
+                <button onClick={props.onConfirm} type='button'>{props.action ?? 'Confirm'}</button>
+            </div>
+        ) : <></>),
         IconOutline: new Proxy({}, { get: () => Icon }),
         LoadingSpinner: (): JSX.Element => <span>Loading forum</span>,
     }
@@ -60,7 +88,7 @@ jest.mock('../services', () => ({
     deleteForumPost: (...args: unknown[]) => mockDeleteForumPost(...args),
     deleteForumTopic: (...args: unknown[]) => mockDeleteForumTopic(...args),
     getChallengeForumTopics: jest.fn(),
-    getForumTopicDetail: jest.fn(),
+    getForumTopicDetail: (...args: unknown[]) => mockGetForumTopicDetail(...args),
     getMemberProfilesByUserIds: jest.fn(),
     markForumTopicRead: (...args: unknown[]) => mockMarkForumTopicRead(...args),
     setForumPostReaction: (...args: unknown[]) => mockSetForumPostReaction(...args),
@@ -167,6 +195,7 @@ describe('ChallengeForum', () => {
             topic: { id: 'topic-3' },
         })
         mockMarkForumTopicRead.mockResolvedValue(undefined)
+        mockGetForumTopicDetail.mockResolvedValue(topicDetail)
         mockSetForumPostReaction.mockResolvedValue({
             postId: 'post-1',
             thumbsDownCount: 1,
@@ -186,6 +215,7 @@ describe('ChallengeForum', () => {
             truncated: false,
         }
         topicDetail = { posts: [starterPost], topic: announcement }
+        mockGetForumTopicDetail.mockResolvedValue(topicDetail)
         mockUseSWR.mockImplementation((key: unknown) => {
             if (Array.isArray(key) && key[0] === 'opportunities:forum-topics') {
                 return {
@@ -249,6 +279,19 @@ describe('ChallengeForum', () => {
             .not.toBeInTheDocument()
     })
 
+    it('uses the API source total for topic counters', () => {
+        topicCollection = {
+            data: [announcement, discussion],
+            sourceTotalCount: 4,
+            truncated: true,
+        }
+
+        render(<ChallengeForum challenge={{ id: 'challenge-id', name: 'Challenge' }} memberId='10' />)
+
+        expect(screen.getByText('4 topics'))
+            .toBeInTheDocument()
+    })
+
     it('opens an embedded post tree and keeps replies and comments in-page', async () => {
         render(<ChallengeForum challenge={{ id: 'challenge-id', name: 'Challenge' }} memberId='10' />)
         await act(async () => fireEvent.click(screen.getByRole('button', { name: announcement.title })))
@@ -293,6 +336,38 @@ describe('ChallengeForum', () => {
                 content: 'Can the maintainers clarify the response type?',
                 title: 'Clarify the API contract',
             }))
+    })
+
+    it('edits topic titles and starter content in an in-app modal', async () => {
+        render(<ChallengeForum challenge={{ id: 'challenge-id', name: 'Challenge' }} memberId='1' />)
+
+        await act(async () => fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]))
+        await waitFor(() => expect(screen.getByRole('heading', { name: 'Edit topic' }))
+            .toBeInTheDocument())
+        fireEvent.change(screen.getByLabelText('Topic Title'), {
+            target: { value: 'Updated announcement' },
+        })
+        fireEvent.change(screen.getByLabelText('Topic Content'), {
+            target: { value: 'Updated **formatted** content.' },
+        })
+        await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Save changes' })))
+
+        expect(mockUpdateForumTopic)
+            .toHaveBeenCalledWith('topic-1', 'Updated announcement')
+        expect(mockUpdateForumPost)
+            .toHaveBeenCalledWith('post-1', 'Updated **formatted** content.')
+    })
+
+    it('confirms topic deletion inside the application', async () => {
+        render(<ChallengeForum challenge={{ id: 'challenge-id', name: 'Challenge' }} memberId='1' />)
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0])
+        expect(screen.getByRole('dialog', { name: 'Delete topic?' }))
+            .toBeInTheDocument()
+        await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Delete topic' })))
+
+        expect(mockDeleteForumTopic)
+            .toHaveBeenCalledWith('topic-1')
     })
 
     it('lets an administrator create a challenge announcement', async () => {
@@ -454,6 +529,29 @@ describe('forum presentation helpers', () => {
                 selectionStart: 8,
                 value: 'hello **world**',
             })
+    })
+
+    it('continues ordered and unordered Markdown lists and exits an empty marker', () => {
+        expect(continueMarkdownList('- first', 7, 7))
+            .toEqual({
+                selectionEnd: 10,
+                selectionStart: 10,
+                value: '- first\n- ',
+            })
+        expect(continueMarkdownList('3. third', 8, 8))
+            .toEqual({
+                selectionEnd: 12,
+                selectionStart: 12,
+                value: '3. third\n4. ',
+            })
+        expect(continueMarkdownList('intro\n- ', 8, 8))
+            .toEqual({
+                selectionEnd: 6,
+                selectionStart: 6,
+                value: 'intro\n',
+            })
+        expect(continueMarkdownList('plain text', 10, 10))
+            .toBeUndefined()
     })
 
     it('maps public ratings to the August 2026 handle palette', () => {

--- a/src/apps/opportunities/src/components/ChallengeForum.tsx
+++ b/src/apps/opportunities/src/components/ChallengeForum.tsx
@@ -1,15 +1,16 @@
-/* eslint-disable no-alert, no-use-before-define, ordered-imports/ordered-imports, react/jsx-no-bind */
+/* eslint-disable no-use-before-define, ordered-imports/ordered-imports, react/jsx-no-bind */
 import {
     ChangeEvent,
     FC,
     FormEvent,
+    KeyboardEvent,
     useMemo,
     useRef,
     useState,
 } from 'react'
 import useSWR, { SWRResponse } from 'swr'
 
-import { IconOutline } from '~/libs/ui'
+import { BaseModal, ConfirmModal, IconOutline } from '~/libs/ui'
 
 import {
     ChallengeOpportunity,
@@ -64,10 +65,53 @@ interface ForumParticipant {
     memberId: string
 }
 
-interface MarkdownSelectionResult {
+export interface MarkdownSelectionResult {
     selectionEnd: number
     selectionStart: number
     value: string
+}
+
+/**
+ * Continues the Markdown list marker on the current line when Enter is pressed.
+ * An empty marker exits the list, matching conventional Markdown editors.
+ *
+ * @param value complete editor value.
+ * @param selectionStart inclusive selection start.
+ * @param selectionEnd exclusive selection end.
+ * @returns updated value/caret, or undefined when the current line is not a list item.
+ * @throws Does not throw; selection bounds are clamped to the input length.
+ */
+export function continueMarkdownList(
+    value: string,
+    selectionStart: number,
+    selectionEnd: number,
+): MarkdownSelectionResult | undefined {
+    const start = Math.max(0, Math.min(selectionStart, value.length))
+    const end = Math.max(start, Math.min(selectionEnd, value.length))
+    const lineStart = value.lastIndexOf('\n', start - 1) + 1
+    const lineBeforeCaret = value.slice(lineStart, start)
+    const unordered = /^(\s*)([-+*])\s+(.*)$/.exec(lineBeforeCaret)
+    const ordered = /^(\s*)(\d+)\.\s+(.*)$/.exec(lineBeforeCaret)
+    const match = unordered ?? ordered
+    if (!match) return undefined
+
+    if (!match[3].trim()) {
+        const nextValue = `${value.slice(0, lineStart)}${value.slice(end)}`
+        return {
+            selectionEnd: lineStart,
+            selectionStart: lineStart,
+            value: nextValue,
+        }
+    }
+
+    const marker = unordered ? match[2] : `${Number(match[2]) + 1}.`
+    const insertion = `\n${match[1]}${marker} `
+    const nextSelection = start + insertion.length
+    return {
+        selectionEnd: nextSelection,
+        selectionStart: nextSelection,
+        value: `${value.slice(0, start)}${insertion}${value.slice(end)}`,
+    }
 }
 
 type MemberProfilesById = ReadonlyMap<string, MemberProfileSummary>
@@ -514,7 +558,7 @@ const ForumTopicCard: FC<{
     topic: ForumTopicSummary
 }> = props => {
     const participants = topicParticipants(props.topic)
-    const excerpt = plainForumExcerpt(props.topic.starterPostExcerpt)
+    const excerpt = props.topic.starterPostExcerpt?.trim()
     const owner = props.topic.authorMemberId === props.memberId
     const cardClass = props.topic.isAnnouncement
         ? `${styles.topicCard} ${styles.announcementCard}`
@@ -547,7 +591,11 @@ const ForumTopicCard: FC<{
                         {formatForumDate(props.topic.createdAt)}
                     </span>
                 </div>
-                {excerpt && <p className={styles.topicExcerpt}>{excerpt}</p>}
+                {excerpt && (
+                    <div className={styles.topicExcerpt}>
+                        <ChallengeMarkdown markdown={excerpt} />
+                    </div>
+                )}
                 <div className={styles.topicFooter}>
                     <span>
                         Last post at
@@ -653,6 +701,25 @@ const MarkdownEditor: FC<MarkdownEditorProps> = props => {
         ['Quote', '> ', ''],
     ]
 
+    /** Continues or exits the active Markdown list without a toolbar round trip. */
+    const continueList = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+        if (event.key !== 'Enter' || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
+        const result = continueMarkdownList(
+            props.value,
+            event.currentTarget.selectionStart,
+            event.currentTarget.selectionEnd,
+        )
+        if (!result) return
+        event.preventDefault()
+        const value = result.value.slice(0, props.maxLength)
+        const selection = Math.min(result.selectionStart, value.length)
+        props.onChange(value)
+        window.setTimeout(() => {
+            textareaRef.current?.focus()
+            textareaRef.current?.setSelectionRange(selection, selection)
+        })
+    }
+
     return (
         <div className={styles.markdownField}>
             <label htmlFor={props.id}>{props.label}</label>
@@ -691,6 +758,7 @@ const MarkdownEditor: FC<MarkdownEditorProps> = props => {
                             id={props.id}
                             maxLength={props.maxLength}
                             onChange={event => props.onChange(event.target.value)}
+                            onKeyDown={continueList}
                             placeholder={props.placeholder}
                             ref={textareaRef}
                             value={props.value}
@@ -820,6 +888,207 @@ const ForumCreateTopicView: FC<{
                 </form>
             </div>
         </div>
+    )
+}
+
+interface ForumTopicEditModalProps {
+    detail: ForumTopicDetail
+    onClose: () => void
+    onSave: (title: string, content: string, starterPost: ForumPost) => Promise<void>
+}
+
+/**
+ * Renders an in-app topic editor for both the title and starter-post content.
+ *
+ * @param props loaded topic detail and controlled save/close actions.
+ * @returns modal Markdown form for an owned discussion.
+ * @throws Does not throw; mutation failures remain visible inside the modal.
+ */
+const ForumTopicEditModal: FC<ForumTopicEditModalProps> = props => {
+    const starterPost = props.detail.posts.find(post => (
+        post.parentType === 'TOPIC' && post.parentId === props.detail.topic.id
+    )) ?? props.detail.posts[0]
+    const [content, setContent] = useState(starterPost?.content ?? '')
+    const [error, setError] = useState<string>()
+    const [pending, setPending] = useState(false)
+    const [preview, setPreview] = useState(false)
+    const [title, setTitle] = useState(props.detail.topic.title)
+
+    /** Validates and saves both editable topic fields. */
+    const save = async (): Promise<void> => {
+        if (!title.trim() || !content.trim() || !starterPost) {
+            setError('Add a topic title and description before saving your changes.')
+            return
+        }
+
+        setError(undefined)
+        setPending(true)
+        try {
+            await props.onSave(title.trim(), content.trim(), starterPost)
+            props.onClose()
+        } catch (mutationError) {
+            setError(forumErrorMessage(mutationError))
+        } finally {
+            setPending(false)
+        }
+    }
+
+    return (
+        <BaseModal
+            ariaLabelledby='forum-edit-topic-title'
+            buttons={(
+                <>
+                    <button
+                        className={styles.modalSecondary}
+                        disabled={pending}
+                        onClick={props.onClose}
+                        type='button'
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className={styles.modalPrimary}
+                        disabled={pending}
+                        onClick={save}
+                        type='button'
+                    >
+                        {pending ? 'Saving…' : 'Save changes'}
+                    </button>
+                </>
+            )}
+            center
+            classNames={{ modal: styles.editModal }}
+            onClose={props.onClose}
+            open
+            showCloseIcon={!pending}
+            size='md'
+            spacer={false}
+            title={<h2 className={styles.modalTitle} id='forum-edit-topic-title'>Edit topic</h2>}
+        >
+            <div className={styles.editModalBody}>
+                <label className={styles.titleField}>
+                    <span>Topic Title</span>
+                    <input
+                        disabled={pending}
+                        maxLength={255}
+                        onChange={event => setTitle(event.target.value)}
+                        value={title}
+                    />
+                </label>
+                <MarkdownEditor
+                    id='forum-edit-topic-content'
+                    label='Topic Content'
+                    maxLength={TOPIC_CHARACTER_LIMIT}
+                    onChange={setContent}
+                    placeholder='Describe your topic'
+                    preview={preview}
+                    value={content}
+                />
+                <button
+                    className={styles.previewButton}
+                    disabled={pending}
+                    onClick={() => setPreview(value => !value)}
+                    type='button'
+                >
+                    {preview ? 'Write' : 'Preview'}
+                </button>
+                {error && <p className={styles.actionError} role='alert'>{error}</p>}
+            </div>
+        </BaseModal>
+    )
+}
+
+interface ForumPostEditModalProps {
+    onClose: () => void
+    onSave: (content: string) => Promise<void>
+    post: ForumPost
+}
+
+/**
+ * Renders an in-app Markdown editor for an owned forum post.
+ *
+ * @param props selected post and controlled save/close actions.
+ * @returns modal comment editor.
+ * @throws Does not throw; mutation failures remain visible inside the modal.
+ */
+const ForumPostEditModal: FC<ForumPostEditModalProps> = props => {
+    const [content, setContent] = useState(props.post.content ?? '')
+    const [error, setError] = useState<string>()
+    const [pending, setPending] = useState(false)
+    const [preview, setPreview] = useState(false)
+
+    /** Validates and saves the replacement post content. */
+    const save = async (): Promise<void> => {
+        if (!content.trim()) {
+            setError('Add comment text before saving your changes.')
+            return
+        }
+
+        setError(undefined)
+        setPending(true)
+        try {
+            await props.onSave(content.trim())
+            props.onClose()
+        } catch (mutationError) {
+            setError(forumErrorMessage(mutationError))
+        } finally {
+            setPending(false)
+        }
+    }
+
+    return (
+        <BaseModal
+            ariaLabelledby='forum-edit-post-title'
+            buttons={(
+                <>
+                    <button
+                        className={styles.modalSecondary}
+                        disabled={pending}
+                        onClick={props.onClose}
+                        type='button'
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className={styles.modalPrimary}
+                        disabled={pending}
+                        onClick={save}
+                        type='button'
+                    >
+                        {pending ? 'Saving…' : 'Save changes'}
+                    </button>
+                </>
+            )}
+            center
+            classNames={{ modal: styles.editModal }}
+            onClose={props.onClose}
+            open
+            showCloseIcon={!pending}
+            size='md'
+            spacer={false}
+            title={<h2 className={styles.modalTitle} id='forum-edit-post-title'>Edit comment</h2>}
+        >
+            <div className={styles.editModalBody}>
+                <MarkdownEditor
+                    id='forum-edit-post-content'
+                    label='Comment'
+                    maxLength={COMMENT_CHARACTER_LIMIT}
+                    onChange={setContent}
+                    placeholder='Type here'
+                    preview={preview}
+                    value={content}
+                />
+                <button
+                    className={styles.previewButton}
+                    disabled={pending}
+                    onClick={() => setPreview(value => !value)}
+                    type='button'
+                >
+                    {preview ? 'Write' : 'Preview'}
+                </button>
+                {error && <p className={styles.actionError} role='alert'>{error}</p>}
+            </div>
+        </BaseModal>
     )
 }
 
@@ -986,6 +1255,8 @@ const ForumTopicView: FC<{
     const [preview, setPreview] = useState(false)
     const [reactionPendingPostId, setReactionPendingPostId] = useState<string>()
     const [replyTarget, setReplyTarget] = useState<ForumPost>()
+    const [postToDelete, setPostToDelete] = useState<ForumPost>()
+    const [postToEdit, setPostToEdit] = useState<ForumPost>()
     const flatPosts = flattenForumPosts(props.detail.posts)
     const postById = new Map(flatPosts.map(item => [item.post.id, item.post]))
     const participants = topicParticipants(props.detail.topic)
@@ -1011,31 +1282,29 @@ const ForumTopicView: FC<{
         focusComposer()
     }
 
-    /** Updates an owned post after native confirmation of the replacement copy. */
-    const editPost = async (post: ForumPost): Promise<void> => {
-        const content = window.prompt('Edit your comment', post.content ?? '')
-            ?.trim()
-        if (!content || content === post.content) return
+    /** Opens the in-app editor for an owned post. */
+    const editPost = (post: ForumPost): void => setPostToEdit(post)
+
+    /** Persists replacement content from the in-app post editor. */
+    const savePost = async (content: string): Promise<void> => {
+        if (!postToEdit || content === postToEdit.content) return
         setError(undefined)
-        setPending(true)
-        try {
-            await updateForumPost(post.id, content)
-            await props.onChanged()
-        } catch (mutationError) {
-            setError(forumErrorMessage(mutationError))
-        } finally {
-            setPending(false)
-        }
+        await updateForumPost(postToEdit.id, content)
+        await props.onChanged()
     }
 
-    /** Soft-deletes an owned post after explicit member confirmation. */
-    const removePost = async (post: ForumPost): Promise<void> => {
-        if (!window.confirm('Delete this comment? Replies will remain in the discussion.')) return
+    /** Opens the in-app delete confirmation for an owned post. */
+    const removePost = (post: ForumPost): void => setPostToDelete(post)
+
+    /** Soft-deletes the selected owned post after in-app confirmation. */
+    const confirmRemovePost = async (): Promise<void> => {
+        if (!postToDelete) return
         setError(undefined)
         setPending(true)
         try {
-            await deleteForumPost(post.id)
+            await deleteForumPost(postToDelete.id)
             await props.onChanged()
+            setPostToDelete(undefined)
         } catch (mutationError) {
             setError(forumErrorMessage(mutationError))
         } finally {
@@ -1208,6 +1477,25 @@ const ForumTopicView: FC<{
                     )}
                 </div>
             </div>
+            {postToEdit && (
+                <ForumPostEditModal
+                    key={postToEdit.id}
+                    onClose={() => setPostToEdit(undefined)}
+                    onSave={savePost}
+                    post={postToEdit}
+                />
+            )}
+            <ConfirmModal
+                action='Delete comment'
+                isLoading={pending}
+                isProcessing={pending}
+                onClose={() => setPostToDelete(undefined)}
+                onConfirm={confirmRemovePost}
+                open={!!postToDelete}
+                title='Delete comment?'
+            >
+                <p>Replies will remain in the discussion. This action cannot be undone.</p>
+            </ConfirmModal>
         </div>
     )
 }
@@ -1227,6 +1515,7 @@ const ForumTopicView: FC<{
 export const ChallengeForum: FC<ChallengeForumProps> = props => {
     const externalUrl = challengeForumUrl(props.challenge)
     const [creatingTopic, setCreatingTopic] = useState(false)
+    const [editingTopicDetail, setEditingTopicDetail] = useState<ForumTopicDetail>()
     const [mutationError, setMutationError] = useState<string>()
     const [page, setPage] = useState(1)
     const [pendingAction, setPendingAction] = useState<string>()
@@ -1235,6 +1524,7 @@ export const ChallengeForum: FC<ChallengeForumProps> = props => {
     const [search, setSearch] = useState('')
     const [selectedTopicId, setSelectedTopicId] = useState<string>()
     const [sort, setSort] = useState<ForumSort>('recent')
+    const [topicToDelete, setTopicToDelete] = useState<ForumTopicSummary>()
     const response: SWRResponse<ForumTopicCollection, Error> = useSWR(
         props.memberId ? ['opportunities:forum-topics', props.challenge.id] : undefined,
         () => getChallengeForumTopics(props.challenge.id),
@@ -1354,16 +1644,12 @@ export const ChallengeForum: FC<ChallengeForumProps> = props => {
         }
     }
 
-    /** Updates one owned topic title through the v6 API. */
+    /** Loads an owned topic into the in-app title and Markdown editor. */
     const editTopic = async (topic: ForumTopicSummary): Promise<void> => {
-        const title = window.prompt('Edit topic title', topic.title)
-            ?.trim()
-        if (!title || title === topic.title) return
         setPendingAction(`edit:${topic.id}`)
         setMutationError(undefined)
         try {
-            await updateForumTopic(topic.id, title)
-            await refreshForum()
+            setEditingTopicDetail(await getForumTopicDetail(topic.id))
         } catch (error) {
             setMutationError(forumErrorMessage(error))
         } finally {
@@ -1371,15 +1657,38 @@ export const ChallengeForum: FC<ChallengeForumProps> = props => {
         }
     }
 
-    /** Soft-deletes one owned topic after explicit confirmation. */
-    const removeTopic = async (topic: ForumTopicSummary): Promise<void> => {
-        if (!window.confirm(`Delete “${topic.title}” and its discussion?`)) return
-        setPendingAction(`delete:${topic.id}`)
+    /** Saves the editable topic title and starter-post body through their owning endpoints. */
+    const saveTopic = async (
+        title: string,
+        content: string,
+        starterPost: ForumPost,
+    ): Promise<void> => {
+        if (!editingTopicDetail) return
+
+        if (title !== editingTopicDetail.topic.title) {
+            await updateForumTopic(editingTopicDetail.topic.id, title)
+        }
+
+        if (content !== starterPost.content) {
+            await updateForumPost(starterPost.id, content)
+        }
+
+        await refreshForum()
+    }
+
+    /** Opens the in-app delete confirmation for an owned topic. */
+    const removeTopic = (topic: ForumTopicSummary): void => setTopicToDelete(topic)
+
+    /** Soft-deletes the selected owned topic after in-app confirmation. */
+    const confirmRemoveTopic = async (): Promise<void> => {
+        if (!topicToDelete) return
+        setPendingAction(`delete:${topicToDelete.id}`)
         setMutationError(undefined)
         try {
-            await deleteForumTopic(topic.id)
-            if (selectedTopicId === topic.id) setSelectedTopicId(undefined)
+            await deleteForumTopic(topicToDelete.id)
+            if (selectedTopicId === topicToDelete.id) setSelectedTopicId(undefined)
             await response.mutate()
+            setTopicToDelete(undefined)
         } catch (error) {
             setMutationError(forumErrorMessage(error))
         } finally {
@@ -1485,7 +1794,7 @@ export const ChallengeForum: FC<ChallengeForumProps> = props => {
                         setCreatingTopic(true)
                     }}
                     topics={topics}
-                    total={topics.length}
+                    total={response.data?.sourceTotalCount ?? topics.length}
                 />
                 <ForumFilters
                     onReset={resetFilters}
@@ -1561,6 +1870,29 @@ export const ChallengeForum: FC<ChallengeForumProps> = props => {
                     />
                 )}
             </section>
+            {editingTopicDetail && (
+                <ForumTopicEditModal
+                    detail={editingTopicDetail}
+                    key={editingTopicDetail.topic.id}
+                    onClose={() => setEditingTopicDetail(undefined)}
+                    onSave={saveTopic}
+                />
+            )}
+            <ConfirmModal
+                action='Delete topic'
+                isLoading={pendingAction === `delete:${topicToDelete?.id}`}
+                isProcessing={pendingAction === `delete:${topicToDelete?.id}`}
+                onClose={() => setTopicToDelete(undefined)}
+                onConfirm={confirmRemoveTopic}
+                open={!!topicToDelete}
+                title='Delete topic?'
+            >
+                <p>
+                    <span>Delete “</span>
+                    <strong>{topicToDelete?.title}</strong>
+                    <span>” and its discussion? This action cannot be undone.</span>
+                </p>
+            </ConfirmModal>
         </div>
     )
 }

--- a/src/apps/opportunities/src/components/ChallengeMarkdown.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeMarkdown.spec.tsx
@@ -6,11 +6,20 @@ import {
     isHtmlDescriptionFormat,
 } from './ChallengeMarkdown'
 
-jest.mock('react-markdown', () => function MarkdownMock(props: { children?: string }) {
-    return <div data-testid='markdown-renderer'>{props.children}</div>
+const mockMarkdownProps: Array<Record<string, unknown>> = []
+
+jest.mock('react-markdown', () => function MarkdownMock(props: Record<string, unknown>) {
+    mockMarkdownProps.push(props)
+    return <div data-testid='markdown-renderer'>{props.children as string}</div>
 })
+jest.mock('rehype-raw', () => jest.fn())
+jest.mock('rehype-sanitize', () => jest.fn())
 jest.mock('remark-breaks', () => jest.fn())
 jest.mock('remark-gfm', () => jest.fn())
+
+beforeEach(() => {
+    mockMarkdownProps.length = 0
+})
 
 describe('ChallengeDescription', () => {
     it('sanitizes case-insensitive HTML descriptions and omits a Markdown interpretation', () => {
@@ -37,6 +46,18 @@ describe('ChallengeDescription', () => {
 
         expect(screen.getByTestId('markdown-renderer').textContent)
             .toBe('## Markdown requirements')
+    })
+
+    it('parses and sanitizes safe inline forum HTML such as underline markup', () => {
+        render(<ChallengeDescription content='A <u>formatted</u> note' format='markdown' />)
+
+        expect(mockMarkdownProps)
+            .toEqual(expect.arrayContaining([expect.objectContaining({
+                rehypePlugins: expect.arrayContaining([
+                    expect.any(Function),
+                    expect.any(Function),
+                ]),
+            })]))
     })
 
     it('preserves authored bold and italic elements in sanitized HTML', () => {

--- a/src/apps/opportunities/src/components/ChallengeMarkdown.tsx
+++ b/src/apps/opportunities/src/components/ChallengeMarkdown.tsx
@@ -9,6 +9,8 @@ import {
 import DOMPurify from 'dompurify'
 import ReactMarkdown, { Components, Options as ReactMarkdownOptions } from 'react-markdown'
 import type { HeadingProps } from 'react-markdown/lib/ast-to-react'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 
@@ -149,6 +151,7 @@ export const ChallengeMarkdown: FC<ChallengeMarkdownProps> = props => {
         <article className={styles.markdown}>
             <Markdown
                 components={MARKDOWN_COMPONENTS}
+                rehypePlugins={[rehypeRaw as any, rehypeSanitize as any]}
                 remarkPlugins={[
                     [remarkGfm, { singleTilde: false }],
                     remarkBreaks,

--- a/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
@@ -45,6 +45,9 @@ jest.mock('~/libs/ui', () => {
 jest.mock('../utils', () => ({
     challengeFileTypes: (): string[] => [],
     challengeForumUrl: (): undefined => undefined,
+    challengeReviewAppUrl: (challengeId: string): string => (
+        `https://review.topcoder-dev.com/active-challenges/${challengeId}/challenge-details`
+    ),
     challengeSidebarLinks: (): { attachments: []; challengeLinks: [] } => ({
         attachments: [],
         challengeLinks: [],
@@ -173,11 +176,31 @@ describe('ChallengeSidebar Review Style', () => {
     it('adds the authored Marathon Match guide and arrow indicators', () => {
         renderSidebar(undefined, marathonChallenge)
 
-        expect(screen.getByRole('link', { name: 'How to Compete in a Marathon Match' }))
+        expect(screen.getByRole('heading', { name: 'Marathon Match Tournament' }))
+            .toBeInTheDocument()
+        expect(screen.getByText('Join the battle of competitors in a series of challenging Marathon Matches.'))
+            .toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'Explore the program' }))
+            .toHaveAttribute('href', marathonMatchLearningUrl)
+        expect(screen.queryByRole('heading', { name: 'Join the AI Exponential league' }))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'How to Compete on Marathon Match' }))
             .toHaveAttribute('href', marathonMatchLearningUrl)
         expect(screen.getByRole('link', { name: 'Topcoder Challenges Explained' })
             .querySelector('img'))
             .not.toBeNull()
+    })
+
+    it('uses the dedicated Review App host and hides Review Style for Marathon Matches', () => {
+        renderSidebar(undefined, marathonChallenge)
+
+        expect(screen.getByRole('link', { name: 'View Review App' }))
+            .toHaveAttribute(
+                'href',
+                'https://review.topcoder-dev.com/active-challenges/challenge-id/challenge-details',
+            )
+        expect(screen.queryByRole('heading', { name: 'Review Style' }))
+            .not.toBeInTheDocument()
     })
 
     it('keeps design-only educational links and copy out of development challenges', () => {

--- a/src/apps/opportunities/src/components/ChallengeSidebar.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.tsx
@@ -13,6 +13,7 @@ import {
 import {
     challengeFileTypes,
     challengeForumUrl,
+    challengeReviewAppUrl,
     ChallengeSidebarLink,
     challengeSidebarLinks,
     challengeSubmissionLimit,
@@ -281,9 +282,13 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
             <section className={styles.promo}>
                 <img alt='' aria-hidden='true' className={styles.promoArt} src={programBanner} />
                 <div>
-                    <h3>Join the AI Exponential league</h3>
-                    <p>Where elite AI builders compete to solve real-world challenges and grow fast.</p>
-                    <Link to='/thrive'>
+                    <h3>{marathonMatch ? 'Marathon Match Tournament' : 'Join the AI Exponential league'}</h3>
+                    <p>
+                        {marathonMatch
+                            ? 'Join the battle of competitors in a series of challenging Marathon Matches.'
+                            : 'Where elite AI builders compete to solve real-world challenges and grow fast.'}
+                    </p>
+                    <Link to={marathonMatch ? MARATHON_MATCH_LEARNING_URL : '/thrive'}>
                         Explore the program
                         <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
                     </Link>
@@ -291,10 +296,14 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
             </section>
             <SidebarCard icon={<img alt='' aria-hidden='true' src={sidebarReviewIcon} />} title='Review App'>
                 <p>The place to see your scores and feedback, and improve before the final review.</p>
-                <Link to={`/review/active-challenges/${props.challenge.id}/challenge-details`}>
+                <a
+                    href={challengeReviewAppUrl(props.challenge.id)}
+                    rel='noreferrer'
+                    target='_blank'
+                >
                     View Review App
                     <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
-                </Link>
+                </a>
             </SidebarCard>
             <SidebarCard icon={<img alt='' aria-hidden='true' src={sidebarBookIcon} />} title='Educational Materials'>
                 <p>Read educational material in Topcoder Thrive.</p>
@@ -304,7 +313,7 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                 </a>
                 {marathonMatch && (
                     <a href={MARATHON_MATCH_LEARNING_URL} rel='noreferrer' target='_blank'>
-                        How to Compete in a Marathon Match
+                        How to Compete on Marathon Match
                         <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
                     </a>
                 )}
@@ -420,11 +429,13 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                         </div>
                     </>
                 )}
-                <ReviewStyleSection
-                    config={props.aiReviewConfig}
-                    loading={props.reviewStyleLoading}
-                    unavailable={props.reviewStyleUnavailable}
-                />
+                {!marathonMatch && (
+                    <ReviewStyleSection
+                        config={props.aiReviewConfig}
+                        loading={props.reviewStyleLoading}
+                        unavailable={props.reviewStyleUnavailable}
+                    />
+                )}
                 <div className={styles.infoSection}>
                     <h3>
                         <img alt='' aria-hidden='true' src={sidebarPolicyIcon} />

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
@@ -314,24 +314,24 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                     </section>
                     <section className={styles.infoCard}>
                         <h3>
-                            <IconOutline.CogIcon aria-hidden='true' />
+                            <IconOutline.BadgeCheckIcon aria-hidden='true' />
                             Submission tips
                         </h3>
                         <ul className={styles.tips}>
                             <li>
-                                <IconOutline.LightBulbIcon aria-hidden='true' />
+                                <IconOutline.SunIcon aria-hidden='true' />
                                 Upload a single ZIP file only
                             </li>
                             <li>
-                                <IconOutline.LightBulbIcon aria-hidden='true' />
+                                <IconOutline.SunIcon aria-hidden='true' />
                                 Do not password protect the files
                             </li>
                             <li>
-                                <IconOutline.LightBulbIcon aria-hidden='true' />
+                                <IconOutline.SunIcon aria-hidden='true' />
                                 Include all files as per guidelines
                             </li>
                             <li>
-                                <IconOutline.LightBulbIcon aria-hidden='true' />
+                                <IconOutline.SunIcon aria-hidden='true' />
                                 Keep your handle out of your files and file names
                             </li>
                         </ul>

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -76,6 +76,27 @@ describe('ChallengeTermsModal', () => {
             .toBeInTheDocument()
     })
 
+    it('does not flash stale hydrated terms while a new registration request is loading', () => {
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [{ id: 'previous-terms', title: 'Challenge Terms' }],
+            isValidating: true,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onAccept={jest.fn()}
+                onClose={jest.fn()}
+                open
+                terms={[{ id: 'current-terms', title: 'Challenge Terms' }]}
+            />,
+        )
+
+        expect(screen.queryByRole('dialog'))
+            .not.toBeInTheDocument()
+    })
+
     it('still opens a retryable dialog when accepted-term hydration fails', () => {
         mockSWRResponse = {
             ...mockSWRResponse,

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -96,7 +96,6 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const hydratingRegistration = registrationMode
         && shouldLoad
         && response.isValidating
-        && !response.data
     const fullTitle = terms[0]?.title || props.terms[0]?.title || 'Challenge Terms'
 
     useEffect(() => {

--- a/src/apps/opportunities/src/components/MyWorkListing.tsx
+++ b/src/apps/opportunities/src/components/MyWorkListing.tsx
@@ -28,6 +28,7 @@ import {
 import { getOpportunityPage } from '../services'
 import {
     defaultSort,
+    compareOpportunityItems,
     opportunitySortOptions,
 } from '../utils/opportunity-listing.utils'
 import { myEngagementBucket, myEngagementState } from '../utils/engagement-status.utils'
@@ -350,9 +351,13 @@ export const MyWorkListing: FC<MyWorkListingProps> = props => {
             .filter(result => !tracks.length || tracks.includes(myWorkTrack(result) ?? ''))
             .filter(result => !types.length || types.includes(myWorkType(result) ?? ''))
         const startingSoon = sort === 'startingSoon'
-        return [...items].sort((first, second) => (startingSoon
-            ? myWorkDate(first, true) - myWorkDate(second, true)
-            : myWorkDate(second, false) - myWorkDate(first, false)))
+        return [...items].sort((first, second) => {
+            const semanticDifference = compareOpportunityItems(first.item, second.item, sort)
+            if (semanticDifference !== 0) return semanticDifference
+            return startingSoon
+                ? myWorkDate(first, true) - myWorkDate(second, true)
+                : myWorkDate(second, false) - myWorkDate(first, false)
+        })
     }, [deferredSearch, props.kinds, response.data, sort, status, tracks, types])
 
     const totalPages = filtered.length ? Math.ceil(filtered.length / perPage) : 0
@@ -471,7 +476,7 @@ export const MyWorkListing: FC<MyWorkListingProps> = props => {
                         <strong>Sort by</strong>
                         <span className={styles.sortSelect}>
                             <select aria-label='Sort my work' onChange={updateSort} value={sort}>
-                                {opportunitySortOptions('competitions')
+                                {opportunitySortOptions()
                                     .map(option => (
                                         <option key={option.value} value={option.value}>{option.label}</option>
                                     ))}

--- a/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
+++ b/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
@@ -609,6 +609,28 @@ describe('OpportunityListCard owner-specific grid presentation', () => {
             .not.toBeInTheDocument()
     })
 
+    it('does not let an undated selected assignment mask an offer decline', () => {
+        const item: EngagementOpportunity = {
+            assignments: [
+                { id: 'assignment-selected', status: 'SELECTED' },
+                { id: 'assignment-declined', status: 'OFFER_DECLINED' },
+            ],
+            id: 'declined-engagement',
+            status: 'OPEN',
+            title: 'Declined engagement',
+        }
+        render(
+            <MemoryRouter>
+                <OpportunityListCard item={item} kind='engagements' />
+            </MemoryRouter>,
+        )
+
+        expect(screen.getByText('Offer Declined'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Selected'))
+            .not.toBeInTheDocument()
+    })
+
     it('lets My Work override the owning API state with the selected treatment', () => {
         const item: EngagementOpportunity = {
             id: 'accepted-engagement',

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -26,6 +26,7 @@ let mockRegistration: { id: string } | undefined
 let mockRegistrationRemoved: boolean
 let mockChallenge: Record<string, unknown>
 let mockMemberProfiles: Record<string, unknown>[]
+let mockMemberResource: { id: string } | undefined
 let mockProjectResults: Record<string, unknown>[]
 let mockPreviewSubmissions: Record<string, unknown>[]
 let mockRegistrants: Record<string, unknown>[]
@@ -162,11 +163,19 @@ jest.mock('../utils', () => ({
             ...summations.filter(summation => summation.submissionId === submission.id),
         ],
     })),
+    challengeReviewAppUrl: (challengeId: string): string => (
+        `https://review.topcoder-dev.com/active-challenges/${challengeId}/challenge-details`
+    ),
     challengeTrackLabel: (track?: string): string => track ?? 'challenge',
     challengeTrackWins: (stats?: {
+        DATA_SCIENCE?: Record<string, { wins?: number } | number>
         DEVELOP?: { wins?: number }
         wins?: number
-    }): number | undefined => stats?.DEVELOP?.wins ?? stats?.wins,
+    }): number | undefined => (stats?.DEVELOP?.wins ?? 0)
+        + (typeof stats?.DATA_SCIENCE?.['AI Engineering'] === 'object'
+            ? stats.DATA_SCIENCE['AI Engineering'].wins ?? 0
+            : 0)
+        || stats?.wins,
     formatMarathonFinalScore: (score: number | undefined, fallback: string): string => (
         score === undefined ? fallback : String(Math.max(0, score))
     ),
@@ -229,7 +238,16 @@ jest.mock('../utils', () => ({
     winnerFinalScore: (
         winner: { placement?: number; userId?: string },
         projectResults: Array<{ finalScore?: number; placement?: number; userId?: string }>,
-    ): number | undefined => projectResults.find(result => (
+        reviewSummations: Array<{
+            aggregateScore?: number
+            isFinal?: boolean
+            memberId?: string
+            submitterId?: string
+        }> = [],
+    ): number | undefined => reviewSummations.find(summation => (
+        summation.isFinal
+        && [summation.memberId, summation.submitterId].includes(winner.userId)
+    ))?.aggregateScore ?? projectResults.find(result => (
         result.userId === winner.userId && result.placement === winner.placement
     ))?.finalScore,
 }))
@@ -272,6 +290,7 @@ describe('ChallengeDetailsPage member flows', () => {
         mockRegistration = undefined
         mockRegistrationRemoved = false
         mockMemberProfiles = []
+        mockMemberResource = undefined
         mockProjectResults = []
         mockPreviewSubmissions = []
         mockRegistrants = []
@@ -303,6 +322,10 @@ describe('ChallengeDetailsPage member flows', () => {
                     ...swrResponse(mockRegistration),
                     mutate: mockRegistrationMutate,
                 }
+            }
+
+            if (Array.isArray(key) && key[0] === 'opportunities:challenge-member-resource') {
+                return swrResponse(mockMemberResource)
             }
 
             if (Array.isArray(key) && key[0] === 'opportunities:submissions') {
@@ -394,6 +417,21 @@ describe('ChallengeDetailsPage member flows', () => {
             .not.toBeInTheDocument()
         expect(screen.queryByRole('tab', { name: 'Forum' }))
             .not.toBeInTheDocument()
+    })
+
+    it('shows the member forum to a copilot resource without treating it as registration', () => {
+        mockProfile = { handle: 'copilot', roles: ['Copilot'], userId: 123 }
+        mockMemberResource = { id: 'copilot-resource' }
+
+        renderPage()
+
+        expect(screen.getByRole('tab', { name: 'Forum 3' }))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('tab', { name: 'My Submissions' }))
+            .not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('tab', { name: 'Forum 3' }))
+        expect(screen.getByText('Forum content'))
+            .toBeInTheDocument()
     })
 
     it('keeps the metadata-gated Design submissions gallery public', () => {
@@ -609,10 +647,16 @@ describe('ChallengeDetailsPage member flows', () => {
             .toBeInTheDocument()
         expect(screen.getByText('In Review'))
             .toBeInTheDocument()
-        expect(screen.queryByRole('link', { name: /^Open Review App$/ }))
-            .not.toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /^Open Review App$/ }))
+            .toHaveAttribute(
+                'href',
+                'https://review.topcoder-dev.com/active-challenges/challenge-id/challenge-details',
+            )
         expect(screen.getByRole('link', { name: 'Open submission submission-1 in Review App' }))
-            .toHaveAttribute('href', '/review/challenge-id?tab=submission')
+            .toHaveAttribute(
+                'href',
+                'https://review.topcoder-dev.com/active-challenges/challenge-id/challenge-details',
+            )
         expect(screen.getByText('submission-1')
             .closest('a'))
             .toBeNull()
@@ -956,6 +1000,35 @@ describe('ChallengeDetailsPage member flows', () => {
         expect(within(fourthRow as HTMLElement)
             .getByText('You'))
             .toBeInTheDocument()
+    })
+
+    it('uses an exact-member final summation when a Marathon project result contains zero', () => {
+        mockProfile = { handle: 'viewer', userId: 123 }
+        mockChallenge = {
+            ...mockChallenge,
+            phases: [{
+                isOpen: false,
+                name: 'Review',
+                scheduledStartDate: '2026-06-04T09:30:00.000Z',
+            }],
+            status: 'COMPLETED',
+            type: 'Marathon Match',
+            winners: [{ handle: 'winner', placement: 1, userId: '42' }],
+        }
+        mockProjectResults = [{ finalScore: 0, placement: 1, userId: '42' }]
+        mockReviewSummations = [{
+            aggregateScore: 100,
+            isFinal: true,
+            submitterId: '42',
+        }]
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'Winners' }))
+
+        expect(screen.getByRole('article'))
+            .toHaveTextContent('with a final score of 100')
+        expect(screen.getByRole('article'))
+            .not.toHaveTextContent('with a final score of 0')
     })
 
     it('omits ratings from the exact three-winner podium state', () => {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
@@ -722,6 +722,7 @@
     > svg {
         background: #e9ecef;
         border-radius: 50%;
+        box-sizing: content-box;
         color: #161616;
         height: 24px;
         padding: 8px;
@@ -848,18 +849,30 @@
         font-size: 30px;
         line-height: 38px;
     }
+
+    .winnerDivider {
+        background: #f1c21b;
+    }
 }
 
 .place2 {
     background: #f7fbff;
     border-color: #82cfff;
     order: 1;
+
+    .winnerDivider {
+        background: #82cfff;
+    }
 }
 
 .place3 {
     background: #fff3eb;
     border-color: #ffb784;
     order: 3;
+
+    .winnerDivider {
+        background: #ffb784;
+    }
 }
 
 .otherPlace {
@@ -891,14 +904,19 @@
 }
 
 .winnerPlacement {
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 22px;
 }
 
 .winnerScore {
     font-size: 14px;
     line-height: 20px;
     margin-top: 8px;
+
+    strong {
+        font-weight: 700;
+    }
 }
 
 .winnerPrize {
@@ -1012,6 +1030,10 @@
     justify-content: center;
     line-height: 20px;
     margin: 0;
+
+    strong {
+        font-weight: 700;
+    }
 
     img {
         background: #d9fbfb;

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -50,6 +50,7 @@ import {
     ChallengeReviewSummation,
     ChallengeSubmission,
     ChallengeTerm,
+    ForumTopicCollection,
     MemberProfileSummary,
     OpportunityPage,
 } from '../models'
@@ -57,6 +58,8 @@ import {
     agreeToChallengeTerms,
     deleteChallengeSubmission,
     getChallengeAiReviewConfig,
+    getChallengeForumTopics,
+    getChallengeMemberResource,
     getChallengeOpportunity,
     getChallengeProjectResults,
     getChallengeRegistration,
@@ -71,6 +74,7 @@ import {
 } from '../services'
 import {
     attachMarathonReviewSummations,
+    challengeReviewAppUrl,
     challengeTrackLabel,
     challengeTrackWins,
     formatMarathonFinalScore,
@@ -95,21 +99,6 @@ type ChallengeTab = 'requirements' | 'registrants' | 'submissions' | 'mine' | 'd
 
 const STALE_REGISTRATION_MESSAGE
     = 'Your registration is no longer active. Register again before submitting.'
-
-/**
- * Builds the challenge-scoped Review App destination used by authored actions.
- *
- * @param challengeId Challenge API UUID.
- * @param submissionType optional checkpoint or standard submission type.
- * @returns encoded Review App challenge-detail URL.
- * @throws Does not throw.
- */
-function challengeReviewUrl(challengeId: string, submissionType?: string): string {
-    const tab = submissionType === 'CHECKPOINT_SUBMISSION'
-        ? 'checkpoint-submission'
-        : 'submission'
-    return `/review/${encodeURIComponent(challengeId)}?tab=${tab}`
-}
 
 /**
  * Determines whether a Design submission can still be removed while an
@@ -267,8 +256,11 @@ export const ChallengeDetailsPage: FC = () => {
         () => getChallengeOpportunity(challengeId),
         { revalidateOnFocus: false },
     )
+    const challenge = challengeResponse.data
     const aiReviewConfigResponse: SWRResponse<ChallengeAiReviewConfig | undefined, Error> = useSWR(
-        challengeId && profile ? ['opportunities:challenge-review-style', challengeId] : undefined,
+        challengeId && profile && challenge && !isMarathonMatchChallenge(challenge)
+            ? ['opportunities:challenge-review-style', challengeId]
+            : undefined,
         () => getChallengeAiReviewConfig(challengeId),
         { revalidateOnFocus: false, shouldRetryOnError: false },
     )
@@ -278,12 +270,23 @@ export const ChallengeDetailsPage: FC = () => {
         () => getChallengeRegistration(challengeId, memberId as string),
         { revalidateOnFocus: false },
     )
+    const memberResourceResponse: SWRResponse<ChallengeResource | undefined, Error> = useSWR(
+        challengeId && memberId ? ['opportunities:challenge-member-resource', challengeId, memberId] : undefined,
+        () => getChallengeMemberResource(challengeId, memberId as string),
+        { revalidateOnFocus: false, shouldRetryOnError: false },
+    )
     const registration = registrationResponse.data
-    const challenge = challengeResponse.data
     const isAdministrator = profile?.roles?.some(role => role.trim()
         .toLowerCase() === 'administrator') ?? false
     const isRegistered = !!registration
     const hasMemberTabAccess = isRegistered || isAdministrator
+    const hasForumAccess = hasMemberTabAccess || !!memberResourceResponse.data
+    const forumResponse: SWRResponse<ForumTopicCollection, Error> = useSWR(
+        hasForumAccess && challengeId ? ['opportunities:forum-topics', challengeId] : undefined,
+        () => getChallengeForumTopics(challengeId),
+        { revalidateOnFocus: false, shouldRetryOnError: false },
+    )
+    const forumTopicCount = forumResponse.data?.sourceTotalCount ?? challenge?.numOfPosts
     const tabs = useMemo<TabConfig[]>(() => {
         const designChallenge = catalogName(challenge?.track)
             .toLowerCase() === 'design'
@@ -301,12 +304,12 @@ export const ChallengeDetailsPage: FC = () => {
             ...(hasMemberTabAccess && challenge && marathonDashboardIsEnabled(challenge)
                 ? [{ id: 'dashboard' as ChallengeTab, label: 'Dashboard' }]
                 : []),
-            ...(hasMemberTabAccess
-                ? [{ count: challenge?.numOfPosts, id: 'forum' as ChallengeTab, label: 'Forum' }]
+            ...(hasForumAccess
+                ? [{ count: forumTopicCount, id: 'forum' as ChallengeTab, label: 'Forum' }]
                 : []),
             { id: 'winners', label: 'Winners' },
         ]
-    }, [challenge, hasMemberTabAccess, isRegistered, memberId])
+    }, [challenge, forumTopicCount, hasForumAccess, hasMemberTabAccess, isRegistered, memberId])
 
     /**
      * Selects a challenge tab and closes the transient in-tab submission form.
@@ -1101,6 +1104,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
             return (
                 <MySubmissionsEmpty
                     onStartSubmission={props.onStartSubmission}
+                    reviewUrl={challengeReviewAppUrl(props.challenge.id)}
                 />
             )
         }
@@ -1135,6 +1139,17 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                     <h2>{props.mine ? 'My Submissions' : 'All Submissions'}</h2>
                     {props.mine && <p>Manage your submissions or upload new.</p>}
                 </div>
+                {props.mine && (
+                    <a
+                        className={styles.reviewAppButton}
+                        href={challengeReviewAppUrl(props.challenge.id)}
+                        rel='noreferrer'
+                        target='_blank'
+                    >
+                        Open Review App
+                        <IconOutline.ExternalLinkIcon aria-hidden='true' />
+                    </a>
+                )}
                 {!props.mine && isMarathonMatch && (
                     <div aria-label='Submission view' className={styles.submissionViewToggle} role='group'>
                         <button
@@ -1211,7 +1226,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                             {submissions.map(submission => {
                                 const scores = marathonSubmissionScores(submission)
                                 const progress = marathonSubmissionTestProgress(submission)
-                                const reviewUrl = challengeReviewUrl(props.challenge.id, submission.type)
+                                const reviewUrl = challengeReviewAppUrl(props.challenge.id)
                                 const statusClass = progress.status
                                     ? styles[`testStatus${progress.status.replace(' ', '')}`]
                                     : ''
@@ -1724,6 +1739,13 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
         () => getChallengeProjectResults(props.challenge.id),
         { revalidateOnFocus: false, shouldRetryOnError: false },
     )
+    const winnerReviewSummationResponse: SWRResponse<ChallengeReviewSummation[], Error> = useSWR(
+        winners?.length && props.memberId && isMarathonMatchChallenge(props.challenge)
+            ? ['opportunities:mm-review-summations', props.challenge.id]
+            : undefined,
+        () => getChallengeReviewSummations(props.challenge.id),
+        { revalidateOnFocus: false, shouldRetryOnError: false },
+    )
 
     if (!winners?.length) {
         return (
@@ -1753,7 +1775,10 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
     const showWinnerFinalScores = !!props.memberId && shouldShowFinalSubmissionScores(
         props.challenge,
         [],
-        (projectResultResponse.data ?? []).map(result => result.finalScore),
+        [
+            ...(projectResultResponse.data ?? []).map(result => result.finalScore),
+            ...(winnerReviewSummationResponse.data ?? []).map(result => result.aggregateScore),
+        ],
     )
     const rankedWinners = ranked.map(entry => {
         const profile = profilesById.get(String(entry.winner.userId ?? ''))
@@ -1768,6 +1793,7 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
                 ? winnerFinalScore(
                     { ...entry.winner, placement: entry.placement },
                     projectResultResponse.data ?? [],
+                    winnerReviewSummationResponse.data ?? [],
                 )
                 : undefined,
             handle,
@@ -1873,6 +1899,7 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
  */
 const MySubmissionsEmpty: FC<{
     onStartSubmission?: () => void
+    reviewUrl: string
 }> = props => (
     <section className={styles.mySubmissionsEmpty}>
         <div className={styles.submissionHeading}>
@@ -1880,6 +1907,15 @@ const MySubmissionsEmpty: FC<{
                 <h2>My Submissions</h2>
                 <p>Manage your submissions or upload new.</p>
             </div>
+            <a
+                className={styles.reviewAppButton}
+                href={props.reviewUrl}
+                rel='noreferrer'
+                target='_blank'
+            >
+                Open Review App
+                <IconOutline.ExternalLinkIcon aria-hidden='true' />
+            </a>
         </div>
         <EmptyTab
             action={(

--- a/src/apps/opportunities/src/pages/OpportunitiesPage.spec.tsx
+++ b/src/apps/opportunities/src/pages/OpportunitiesPage.spec.tsx
@@ -57,7 +57,9 @@ jest.mock('../components', () => ({
     OpportunityListCard: (props: { item: { id: string }; registered?: boolean }) => (
         <output data-testid={`registration-${props.item.id}`}>{String(!!props.registered)}</output>
     ),
-    OpportunityPagination: () => undefined,
+    OpportunityPagination: (props: { onPageChange: (page: number) => void }) => (
+        <button aria-label='Go to page 2' onClick={() => props.onPageChange(2)} type='button' />
+    ),
     OpportunitySortSelect: () => undefined,
     OpportunityViewToggle: () => undefined,
 }))
@@ -143,6 +145,42 @@ describe('OpportunitiesPage', () => {
 
         await waitFor(() => expect(screen.getByTestId('registration-challenge-id'))
             .toHaveTextContent('true'))
+    })
+
+    it('scrolls to the top when the member selects another results page', async () => {
+        const scrollTo = jest.spyOn(window, 'scrollTo')
+            .mockImplementation()
+        mockedGetOpportunitySummary.mockResolvedValue({
+            competitions: { count: 20 },
+            copilots: { count: 0 },
+            engagements: { count: 0 },
+            reviews: { count: 0 },
+        })
+        mockedGetOpportunityPage.mockResolvedValue({
+            items: [{ id: 'challenge-id', name: 'Challenge' }],
+            page: 1,
+            perPage: 10,
+            total: 20,
+            totalPages: 2,
+        })
+
+        render(
+            <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+                <MemoryRouter initialEntries={['/opportunities/competitions']}>
+                    <Routes>
+                        <Route element={<OpportunitiesPage />} path='/opportunities/:kind' />
+                    </Routes>
+                </MemoryRouter>
+            </SWRConfig>,
+        )
+
+        fireEvent.click((await screen.findAllByRole('button', { name: 'Go to page 2' }))[0])
+
+        expect(scrollTo)
+            .toHaveBeenCalledWith({ left: 0, top: 0 })
+        await waitFor(() => expect(mockedGetOpportunityPage)
+            .toHaveBeenLastCalledWith('competitions', expect.objectContaining({ page: 2 })))
+        scrollTo.mockRestore()
     })
 
     it('does not label a non-submitter My competition as registered', async () => {

--- a/src/apps/opportunities/src/pages/OpportunitiesPage.tsx
+++ b/src/apps/opportunities/src/pages/OpportunitiesPage.tsx
@@ -45,6 +45,7 @@ import {
     defaultSort,
     normalizeOpportunitySort,
     opportunitySortOptions,
+    sortOpportunityItems,
 } from '../utils/opportunity-listing.utils'
 import { opportunityViewContext, OpportunityViewContextData } from '../opportunities.context'
 
@@ -208,6 +209,10 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
         { revalidateOnFocus: false },
     )
     const data = pageResponse.data
+    const displayedItems = useMemo(
+        () => sortOpportunityItems(data?.items ?? [], sort),
+        [data?.items, sort],
+    )
     const registrationIds = useMemo(
         () => new Set(registrationIdsResponse.data ?? []),
         [registrationIdsResponse.data],
@@ -257,7 +262,7 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
     /** Updates the active status and starts again at page one. */
     const updateStatus = (value: string): void => {
         setStatus(value)
-        setSort(current => normalizeOpportunitySort(kind, value, current))
+        setSort(current => normalizeOpportunitySort(current))
         setPage(1)
     }
 
@@ -279,6 +284,12 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
         setPage(1)
     }
 
+    /** Changes result pages and returns the member to the top of the listing. */
+    const updatePage = (value: number): void => {
+        setPage(value)
+        window.scrollTo({ left: 0, top: 0 })
+    }
+
     /** Applies list sorting selected in the toolbar. */
     const updateSort = (value: string): void => {
         setSort(value)
@@ -295,7 +306,7 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
                         <strong>Sort by</strong>
                         <OpportunitySortSelect
                             onChange={updateSort}
-                            options={opportunitySortOptions(kind, status)}
+                            options={opportunitySortOptions()}
                             value={sort}
                         />
                     </div>
@@ -338,7 +349,7 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
                 </div>
                 <div className={styles.results} aria-live='polite'>
                     <OpportunityPagination
-                        onPageChange={setPage}
+                        onPageChange={updatePage}
                         onPerPageChange={updatePerPage}
                         page={data?.page ?? page}
                         perPage={data?.perPage ?? perPage}
@@ -374,7 +385,7 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
                         [styles.grid]: props.view === 'grid',
                     })}
                     >
-                        {data?.items.map((item: OpportunityItem) => (
+                        {displayedItems.map((item: OpportunityItem) => (
                             <OpportunityListCard
                                 item={item}
                                 key={item.id}
@@ -389,7 +400,7 @@ const OpportunityListing: FC<OpportunityListingProps> = (props: OpportunityListi
                     </div>
                     {(data?.items.length ?? 0) > 0 && (
                         <OpportunityPagination
-                            onPageChange={setPage}
+                            onPageChange={updatePage}
                             onPerPageChange={updatePerPage}
                             page={data?.page ?? page}
                             perPage={data?.perPage ?? perPage}

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -12,6 +12,7 @@ import {
     createChallengeSubmission,
     deleteChallengeSubmission,
     getChallengeAiReviewConfig,
+    getChallengeMemberResource,
     getChallengeProjectResults,
     getChallengeReviewSummations,
     getChallengeSubmissionHistory,
@@ -216,6 +217,28 @@ describe('opportunities service normalization', () => {
             .toBeGreaterThan(0)
     })
 
+    it('maps the clarified competition prize and title sorts to Challenge API fields', () => {
+        const prize = new URL(buildOpportunityPageUrl('competitions', {
+            page: 1,
+            perPage: 10,
+            sort: 'prizeLowToHigh',
+        }))
+        const title = new URL(buildOpportunityPageUrl('competitions', {
+            page: 1,
+            perPage: 10,
+            sort: 'titleAZ',
+        }))
+
+        expect(prize.searchParams.get('sortBy'))
+            .toBe('overview.totalPrizes')
+        expect(prize.searchParams.get('sortOrder'))
+            .toBe('asc')
+        expect(title.searchParams.get('sortBy'))
+            .toBe('name')
+        expect(title.searchParams.get('sortOrder'))
+            .toBe('asc')
+    })
+
     it('keeps scheduled challenges out of public active results without hiding member competitions', () => {
         const publicUrl = new URL(buildOpportunityPageUrl('competitions', {
             page: 1,
@@ -262,6 +285,19 @@ describe('opportunities service normalization', () => {
             .toBe('2')
         expect(url.searchParams.get('sortOrder'))
             .toBe('desc')
+    })
+
+    it('maps the clarified low-prize sort to Review API payment ordering', () => {
+        const url = new URL(buildOpportunityPageUrl('reviews', {
+            page: 1,
+            perPage: 10,
+            sort: 'prizeLowToHigh',
+        }))
+
+        expect(url.searchParams.get('sortBy'))
+            .toBe('basePayment')
+        expect(url.searchParams.get('sortOrder'))
+            .toBe('asc')
     })
 
     it('maps engagement filters to its scalar status, skill IDs, and semantic sort', () => {
@@ -1089,6 +1125,38 @@ describe('opportunities service normalization', () => {
             .resolves.toBeUndefined()
         await expect(getChallengeRegistration('challenge', '123'))
             .resolves.toBeUndefined()
+    })
+
+    it('accepts any exact caller-owned challenge resource for member forum access', async () => {
+        const globalGet = xhrGlobalInstance.get as jest.MockedFunction<typeof xhrGlobalInstance.get>
+        globalGet
+            .mockResolvedValueOnce({
+                data: [{
+                    challengeId: 'challenge',
+                    id: 'copilot-resource',
+                    memberId: '123',
+                    roleId: 'copilot-role',
+                }],
+                headers: { get: () => undefined },
+            })
+            .mockResolvedValueOnce({
+                data: [{
+                    challengeId: 'another-challenge',
+                    id: 'stale-resource',
+                    memberId: '123',
+                    roleId: 'copilot-role',
+                }],
+                headers: { get: () => undefined },
+            })
+
+        await expect(getChallengeMemberResource('challenge', '123'))
+            .resolves.toMatchObject({ id: 'copilot-resource', roleId: 'copilot-role' })
+        await expect(getChallengeMemberResource('challenge', '123'))
+            .resolves.toBeUndefined()
+        expect(globalGet)
+            .toHaveBeenLastCalledWith(
+                'https://api.example/v6/resources?challengeId=challenge&page=1&perPage=1&memberId=123',
+            )
     })
 
     it('loads all Submitter challenge IDs used by public competition cards', async () => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -587,8 +587,14 @@ export function buildOpportunityPageUrl(
         url.searchParams.set('page', String(page))
         url.searchParams.set('perPage', String(perPage))
         const startingSoon = filters.sort === 'startingSoon'
-        url.searchParams.set('sortBy', startingSoon ? 'startDate' : 'updatedAt')
-        url.searchParams.set('sortOrder', startingSoon ? 'asc' : 'desc')
+        const prizeSort = filters.sort === 'prizeHighToLow' || filters.sort === 'prizeLowToHigh'
+        const titleSort = filters.sort === 'titleAZ'
+        url.searchParams.set('sortBy', prizeSort
+            ? 'overview.totalPrizes'
+            : titleSort ? 'name' : startingSoon ? 'startDate' : 'updatedAt')
+        url.searchParams.set('sortOrder', filters.sort === 'prizeLowToHigh' || titleSort || startingSoon
+            ? 'asc'
+            : 'desc')
         if (startingSoon) {
             url.searchParams.set('startDateStart', new Date()
                 .toISOString())
@@ -621,8 +627,9 @@ export function buildOpportunityPageUrl(
         url.searchParams.set('page', String(page))
         url.searchParams.set('perPage', String(perPage))
         const startingSoon = filters.sort === 'startingSoon'
-        url.searchParams.set('sortBy', startingSoon ? 'anticipatedStart' : 'createdAt')
-        url.searchParams.set('sortOrder', startingSoon ? 'asc' : 'desc')
+        const titleSort = filters.sort === 'titleAZ'
+        url.searchParams.set('sortBy', titleSort ? 'title' : startingSoon ? 'anticipatedStart' : 'createdAt')
+        url.searchParams.set('sortOrder', titleSort || startingSoon ? 'asc' : 'desc')
         if (filters.search) url.searchParams.set('search', filters.search)
         if (filters.statuses?.[0]) url.searchParams.set('status', filters.statuses[0])
         appendValues(url, 'requiredSkills', filters.skills)
@@ -654,12 +661,13 @@ export function buildOpportunityPageUrl(
         url.pathname = new URL(endpoint).pathname
         url.searchParams.set('offset', String((page - 1) * perPage))
         url.searchParams.set('limit', String(perPage))
-        const highestPayment = filters.sort === 'highestPayment'
+        const highestPayment = filters.sort === 'highestPayment' || filters.sort === 'prizeHighToLow'
+        const lowestPayment = filters.sort === 'prizeLowToHigh'
         const startingSoon = filters.sort === 'startingSoon'
-        url.searchParams.set('sortBy', highestPayment
+        url.searchParams.set('sortBy', highestPayment || lowestPayment
             ? 'basePayment'
             : startingSoon ? 'startDate' : 'createdAt')
-        url.searchParams.set('sortOrder', startingSoon ? 'asc' : 'desc')
+        url.searchParams.set('sortOrder', startingSoon || lowestPayment ? 'asc' : 'desc')
         if (filters.search) url.searchParams.set('search', filters.search)
         appendValues(url, 'status', filters.statuses)
         appendValues(url, 'tracks', filters.tracks)
@@ -1583,6 +1591,29 @@ export async function getChallengeRegistration(
     const resources = await getChallengeResources(challengeId, 1, 1, memberId, role.id)
     return resources.items.find(resource => (
         String(resource.memberId) === memberId && resource.roleId === role.id
+    ))
+}
+
+/**
+ * Resolves any challenge resource belonging to the authenticated member.
+ *
+ * This membership check intentionally does not restrict the resource role so
+ * copilots, managers, reviewers, and submitters can reach member-only forum
+ * communication. The response is rechecked defensively because a broad or
+ * stale Resource API page must not grant access for another member/challenge.
+ *
+ * @param challengeId challenge UUID.
+ * @param memberId authenticated member ID.
+ * @returns caller-owned challenge resource, or undefined when absent/mismatched.
+ * @throws Propagates authorization, Resource API, and network errors.
+ */
+export async function getChallengeMemberResource(
+    challengeId: string,
+    memberId: string,
+): Promise<ChallengeResource | undefined> {
+    const resources = await getChallengeResources(challengeId, 1, 1, memberId)
+    return resources.items.find(resource => (
+        resource.challengeId === challengeId && String(resource.memberId) === memberId
     ))
 }
 

--- a/src/apps/opportunities/src/utils/challenge-detail.utils.spec.ts
+++ b/src/apps/opportunities/src/utils/challenge-detail.utils.spec.ts
@@ -2,6 +2,7 @@
 import {
     challengeFileTypes,
     challengeForumUrl,
+    challengeReviewAppUrl,
     challengeScorecardUrl,
     challengeSidebarLinks,
     challengeSubmissionLimit,
@@ -11,6 +12,8 @@ import {
 jest.mock('~/config', () => ({
     EnvironmentConfig: {
         ADMIN: { ONLINE_REVIEW_URL: 'https://software.topcoder-dev.com/review' },
+        REVIEW_APP_URL: 'https://review.topcoder-dev.com',
+        TC_DOMAIN: 'topcoder-dev.com',
         URLS: { USER_PROFILE: 'https://profiles.topcoder-dev.com' },
         VANILLA_FORUM: { V2_URL: 'https://vanilla.topcoder-dev.com/api/v2' },
     },
@@ -35,6 +38,14 @@ jest.mock('~/libs/cms', () => ({
 }), { virtual: true })
 
 describe('challenge detail utilities', () => {
+    it('builds Review App links on the dedicated configured host', () => {
+        expect(challengeReviewAppUrl('challenge with/slash'))
+            .toBe('https://review.topcoder-dev.com/active-challenges/'
+                + 'challenge%20with%2Fslash/challenge-details')
+        expect(challengeReviewAppUrl('challenge-id', 'https://review.example/'))
+            .toBe('https://review.example/active-challenges/challenge-id/challenge-details')
+    })
+
     it('builds encoded links on the configured Profiles app host', () => {
         expect(memberProfileUrl('handle with/slash'))
             .toBe('https://profiles.topcoder-dev.com/handle%20with%2Fslash')

--- a/src/apps/opportunities/src/utils/challenge-detail.utils.ts
+++ b/src/apps/opportunities/src/utils/challenge-detail.utils.ts
@@ -12,6 +12,26 @@ export interface ChallengeSidebarLink {
 }
 
 /**
+ * Builds the canonical Review App challenge-detail destination.
+ *
+ * The Review App uses its own configured origin in deployed environments, so
+ * Opportunities must not route these links through the current www host.
+ *
+ * @param challengeId Challenge API UUID.
+ * @param reviewAppUrl configured Review App origin, optionally overridden by tests.
+ * @returns absolute, safely encoded active-challenge detail URL.
+ * @throws Does not throw.
+ */
+export function challengeReviewAppUrl(
+    challengeId: string,
+    reviewAppUrl: string = EnvironmentConfig.REVIEW_APP_URL
+        ?? `https://review.${EnvironmentConfig.TC_DOMAIN}`,
+): string {
+    return `${reviewAppUrl.replace(/\/+$/, '')}`
+        + `/active-challenges/${encodeURIComponent(challengeId)}/challenge-details`
+}
+
+/**
  * Builds a member profile URL on the environment-specific Profiles app.
  *
  * @param handle public Topcoder handle.

--- a/src/apps/opportunities/src/utils/challenge-winner.utils.spec.ts
+++ b/src/apps/opportunities/src/utils/challenge-winner.utils.spec.ts
@@ -11,7 +11,7 @@ describe('challenge winner utilities', () => {
         const stats = {
             DEVELOP: { wins: 7 },
             wins: 12,
-        } as UserStats
+        } as unknown as UserStats
 
         expect(challengeTrackWins(stats, 'Development'))
             .toBe(7)
@@ -23,6 +23,22 @@ describe('challenge winner utilities', () => {
             .toBe('DATA_SCIENCE')
     })
 
+    it('matches profile Development wins by including migrated AI Engineering contests', () => {
+        const stats = {
+            DATA_SCIENCE: {
+                'AI Engineering': { wins: 5 },
+                wins: 26,
+            },
+            DEVELOP: { wins: 80 },
+            wins: 126,
+        } as unknown as UserStats
+
+        expect(challengeTrackWins(stats, 'Development'))
+            .toBe(85)
+        expect(challengeTrackWins(stats, 'Data Science'))
+            .toBe(26)
+    })
+
     it('uses the canonical result matching both winner ID and placement', () => {
         expect(winnerFinalScore(
             { handle: 'Winner', placement: 1, userId: '42' },
@@ -32,6 +48,18 @@ describe('challenge winner utilities', () => {
             ],
         ))
             .toBe(98.98)
+    })
+
+    it('prefers the exact winner final summation over a legacy zero project result', () => {
+        expect(winnerFinalScore(
+            { handle: 'Winner', placement: 1, userId: '42' },
+            [{ finalScore: 0, placement: 1, userId: '42' }],
+            [
+                { aggregateScore: 75, isFinal: true, submitterId: '99' },
+                { aggregateScore: 100, isFinal: true, submitterId: 42 },
+            ],
+        ))
+            .toBe(100)
     })
 
     it('does not infer a result from a handle or placement alone', () => {

--- a/src/apps/opportunities/src/utils/challenge-winner.utils.ts
+++ b/src/apps/opportunities/src/utils/challenge-winner.utils.ts
@@ -3,7 +3,10 @@ import { UserStats } from '~/libs/core'
 import {
     ChallengeCatalogValue,
     ChallengeProjectResult,
+    ChallengeReviewSummation,
 } from '../models'
+
+import { marathonSubmissionScores } from './marathon-match.utils'
 
 export interface ChallengeWinnerIdentity {
     handle?: string
@@ -55,7 +58,14 @@ export function challengeTrackWins(
         .toLowerCase()
     let trackWins: unknown
     if (trackKey === 'development' || trackKey === 'develop') {
-        trackWins = stats.DEVELOP?.wins
+        const developmentWins = finiteNumber(stats.DEVELOP?.wins)
+        const migratedAiEngineeringStats = stats.DATA_SCIENCE?.['AI Engineering']
+        const migratedAiEngineeringWins = typeof migratedAiEngineeringStats === 'object'
+            ? finiteNumber(migratedAiEngineeringStats?.wins)
+            : undefined
+        trackWins = developmentWins === undefined && migratedAiEngineeringWins === undefined
+            ? undefined
+            : (developmentWins ?? 0) + (migratedAiEngineeringWins ?? 0)
     } else if (trackKey === 'design') {
         trackWins = stats.DESIGN?.wins
     } else if (trackKey === 'datascience') {
@@ -94,22 +104,36 @@ function normalizedPlacement(value: unknown): number | undefined {
 }
 
 /**
- * Resolves a winner's final score from Review API's canonical project result.
- * Both member ID and placement must match, preventing a sibling submission or
- * a same-placement record from being attributed to the wrong winner.
+ * Resolves a winner's final score from Review API's exact-member aggregates or
+ * canonical project result. The final summation is preferred for Marathon
+ * records whose legacy project-result score is a zero placeholder. Both member
+ * ID and placement still gate project results, preventing a sibling submission
+ * or a same-placement record from being attributed to the wrong winner.
  *
  * @param winner Challenge API winner identity.
  * @param projectResults authorized Review API final-placement results.
+ * @param reviewSummations authorized Review API aggregates for the challenge.
  * @returns canonical finite final score, or undefined.
  * @throws Does not throw.
  */
 export function winnerFinalScore(
     winner: ChallengeWinnerIdentity,
     projectResults: ChallengeProjectResult[],
+    reviewSummations: ChallengeReviewSummation[] = [],
 ): number | undefined {
     const winnerId = normalizedIdentifier(winner.userId)
     const winnerPlacement = normalizedPlacement(winner.placement)
     if (!winnerId || winnerPlacement === undefined) return undefined
+    const matchingSummations = reviewSummations.filter(summation => (
+        [summation.submitterId, summation.memberId]
+            .some(identifier => normalizedIdentifier(identifier) === winnerId)
+    ))
+    const summationScore = marathonSubmissionScores({
+        id: `winner-${winnerId}`,
+        reviewSummation: matchingSummations,
+    }).finalScore
+    if (summationScore !== undefined) return summationScore
+
     const result = projectResults.find(candidate => (
         normalizedIdentifier(candidate.userId) === winnerId
         && normalizedPlacement(candidate.placement) === winnerPlacement

--- a/src/apps/opportunities/src/utils/engagement-status.utils.ts
+++ b/src/apps/opportunities/src/utils/engagement-status.utils.ts
@@ -28,6 +28,7 @@ const STATUS_LABELS: Record<string, string> = {
 const ASSIGNMENT_STATUS_PRIORITY: Record<string, number> = {
     assigned: 2,
     completed: 3,
+    offerdeclined: 5,
     offerrejected: 5,
     selected: 1,
     terminated: 4,
@@ -77,7 +78,7 @@ function compareAssignments(
     right: EngagementAssignmentSummary,
 ): number {
     const timestampDifference = assignmentTimestamp(right) - assignmentTimestamp(left)
-    if (timestampDifference !== 0) return timestampDifference
+    if (timestampDifference !== 0 && !Number.isNaN(timestampDifference)) return timestampDifference
 
     const priorityDifference = (ASSIGNMENT_STATUS_PRIORITY[statusKey(right.status)] ?? 0)
         - (ASSIGNMENT_STATUS_PRIORITY[statusKey(left.status)] ?? 0)

--- a/src/apps/opportunities/src/utils/opportunity-listing.utils.spec.ts
+++ b/src/apps/opportunities/src/utils/opportunity-listing.utils.spec.ts
@@ -2,40 +2,65 @@ import {
     defaultSort,
     normalizeOpportunitySort,
     opportunitySortOptions,
+    sortOpportunityItems,
 } from './opportunity-listing.utils'
 
 describe('opportunity listing sorting', () => {
-    it('uses and displays Newest first as the Review default', () => {
+    it('uses the clarified four shared sort choices', () => {
         expect(defaultSort())
             .toBe('newest')
-        expect(opportunitySortOptions('reviews'))
+        expect(opportunitySortOptions())
             .toEqual([
                 { label: 'Newest first', value: 'newest' },
-                { label: 'Starting soon', value: 'startingSoon' },
-                { label: 'Highest payment', value: 'highestPayment' },
+                { label: 'Prize high to low', value: 'prizeHighToLow' },
+                { label: 'Prize low to high', value: 'prizeLowToHigh' },
+                { label: 'Title A-Z', value: 'titleAZ' },
             ])
     })
 
-    it('keeps the common sorts concise on non-Review listings', () => {
-        expect(opportunitySortOptions('engagements'))
+    it('uses the same product vocabulary on non-Review listings', () => {
+        expect(opportunitySortOptions())
             .toEqual([
                 { label: 'Newest first', value: 'newest' },
-                { label: 'Starting soon', value: 'startingSoon' },
+                { label: 'Prize high to low', value: 'prizeHighToLow' },
+                { label: 'Prize low to high', value: 'prizeLowToHigh' },
+                { label: 'Title A-Z', value: 'titleAZ' },
             ])
     })
 
-    it('removes Starting soon and normalizes it for completed engagements only', () => {
-        expect(opportunitySortOptions('engagements', 'CLOSED'))
+    it('normalizes retired sort values to Newest first', () => {
+        expect(opportunitySortOptions())
             .toEqual([
                 { label: 'Newest first', value: 'newest' },
+                { label: 'Prize high to low', value: 'prizeHighToLow' },
+                { label: 'Prize low to high', value: 'prizeLowToHigh' },
+                { label: 'Title A-Z', value: 'titleAZ' },
             ])
-        expect(normalizeOpportunitySort('engagements', 'CLOSED', 'startingSoon'))
+        expect(normalizeOpportunitySort('startingSoon'))
             .toBe('newest')
-        expect(opportunitySortOptions('reviews', 'CLOSED'))
+        expect(opportunitySortOptions())
             .toEqual([
                 { label: 'Newest first', value: 'newest' },
-                { label: 'Starting soon', value: 'startingSoon' },
-                { label: 'Highest payment', value: 'highestPayment' },
+                { label: 'Prize high to low', value: 'prizeHighToLow' },
+                { label: 'Prize low to high', value: 'prizeLowToHigh' },
+                { label: 'Title A-Z', value: 'titleAZ' },
             ])
+    })
+
+    it('sorts the visible owner page by numeric prize and title', () => {
+        const items = [
+            { id: 'b', name: 'Zulu', overview: { totalPrizes: 100 } },
+            { id: 'a', name: 'alpha', overview: { totalPrizes: 500 } },
+        ]
+
+        expect(sortOpportunityItems(items, 'prizeHighToLow')
+            .map(item => item.id))
+            .toEqual(['a', 'b'])
+        expect(sortOpportunityItems(items, 'prizeLowToHigh')
+            .map(item => item.id))
+            .toEqual(['b', 'a'])
+        expect(sortOpportunityItems(items, 'titleAZ')
+            .map(item => item.id))
+            .toEqual(['a', 'b'])
     })
 })

--- a/src/apps/opportunities/src/utils/opportunity-listing.utils.ts
+++ b/src/apps/opportunities/src/utils/opportunity-listing.utils.ts
@@ -1,4 +1,4 @@
-import { OpportunityKind } from '../models'
+import { OpportunityItem } from '../models'
 
 /** A semantic sort value and the label authored in the Opportunities toolbar. */
 export interface OpportunitySortOption {
@@ -17,37 +17,118 @@ export function defaultSort(): string {
 }
 
 /**
- * Builds the authored toolbar options for one opportunity domain.
+ * Builds the authored toolbar options shared by every opportunity domain.
  *
- * @param kind active opportunity domain.
- * @param status active owner status, used to remove time-forward sorting from completed engagements.
- * @returns valid sort options plus the review-only highest-payment choice.
+ * @returns the product-authored common sort options.
  * @throws Does not throw.
  */
-export function opportunitySortOptions(kind: OpportunityKind, status?: string): OpportunitySortOption[] {
-    const statusKey = String(status ?? '')
-        .trim()
-        .toLowerCase()
-    const completedEngagement = kind === 'engagements'
-        && (statusKey === 'closed' || statusKey === 'completed')
+export function opportunitySortOptions(): OpportunitySortOption[] {
     return [
         { label: 'Newest first', value: 'newest' },
-        ...(!completedEngagement ? [{ label: 'Starting soon', value: 'startingSoon' }] : []),
-        ...(kind === 'reviews' ? [{ label: 'Highest payment', value: 'highestPayment' }] : []),
+        { label: 'Prize high to low', value: 'prizeHighToLow' },
+        { label: 'Prize low to high', value: 'prizeLowToHigh' },
+        { label: 'Title A-Z', value: 'titleAZ' },
     ]
+}
+
+/**
+ * Reads the comparable displayed prize/payment from an owner-specific item.
+ *
+ * @param item challenge, engagement, copilot, or review opportunity.
+ * @returns finite numeric value; opportunities without numeric compensation sort last.
+ * @throws Does not throw; malformed strings and missing amounts return negative infinity.
+ */
+function opportunityPrizeValue(item: OpportunityItem): number {
+    const value = item as OpportunityItem & Record<string, any>
+    const placementTotal = (value.prizeSets ?? [])
+        .filter((prizeSet: { type?: string }) => prizeSet.type?.toUpperCase() === 'PLACEMENT')
+        .flatMap((prizeSet: { prizes?: Array<{ value?: number }> }) => prizeSet.prizes ?? [])
+        .reduce((total: number, prize: { value?: number }) => total + (Number(prize.value) || 0), 0)
+    const paymentValues = (value.payments ?? [])
+        .map((payment: { payment?: number }) => Number(payment.payment))
+        .filter(Number.isFinite)
+    const compensationValues = String(value.compensationRange ?? value.otherPaymentType ?? '')
+        .match(/[\d,.]+/g)
+        ?.map((part: string) => Number(part.replace(/,/g, '')))
+        .filter(Number.isFinite) ?? []
+    const candidates = [
+        Number(value.overview?.totalPrizes),
+        placementTotal || Number.NaN,
+        Number(value.basePayment),
+        ...paymentValues,
+        ...compensationValues,
+    ].filter(Number.isFinite)
+    return candidates.length ? Math.max(...candidates) : Number.NEGATIVE_INFINITY
+}
+
+/**
+ * Reads the authored display title shared by owner-specific opportunity rows.
+ *
+ * @param item challenge, engagement, copilot, or review opportunity.
+ * @returns normalized title used by the A-Z comparator.
+ * @throws Does not throw.
+ */
+function opportunityTitle(item: OpportunityItem): string {
+    const value = item as OpportunityItem & Record<string, any>
+    return String(value.name ?? value.title ?? value.opportunityTitle ?? value.challengeName ?? '')
+}
+
+/**
+ * Compares two owner-specific opportunities using the shared semantic sort.
+ *
+ * API adapters provide server ordering where supported; this comparator keeps
+ * the visible page deterministic for owners whose APIs lack a matching field.
+ *
+ * @param first first opportunity.
+ * @param second second opportunity.
+ * @param sort selected shared semantic sort.
+ * @returns standard Array.sort comparison value.
+ * @throws Does not throw.
+ */
+export function compareOpportunityItems(
+    first: OpportunityItem,
+    second: OpportunityItem,
+    sort: string,
+): number {
+    if (sort === 'titleAZ') {
+        return opportunityTitle(first)
+            .localeCompare(opportunityTitle(second), undefined, { sensitivity: 'base' })
+            || String(first.id)
+                .localeCompare(String(second.id))
+    }
+
+    if (sort === 'prizeHighToLow' || sort === 'prizeLowToHigh') {
+        const difference = opportunityPrizeValue(first) - opportunityPrizeValue(second)
+
+        if (difference !== 0 && !Number.isNaN(difference)) {
+            return sort === 'prizeLowToHigh' ? difference : -difference
+        }
+    }
+
+    return 0
+}
+
+/**
+ * Applies the shared product sort without mutating an owning API response.
+ *
+ * @param items current normalized owner page.
+ * @param sort selected shared semantic sort.
+ * @returns copied, deterministically sorted items.
+ * @throws Does not throw.
+ */
+export function sortOpportunityItems<T extends OpportunityItem>(items: T[], sort: string): T[] {
+    return [...items].sort((first, second) => compareOpportunityItems(first, second, sort))
 }
 
 /**
  * Keeps a selected sort valid when another filter changes its available choices.
  *
- * @param kind active opportunity domain.
- * @param status newly selected owner status.
  * @param value currently selected sort value.
  * @returns the current value when still supported, otherwise the default sort.
  * @throws Does not throw.
  */
-export function normalizeOpportunitySort(kind: OpportunityKind, status: string, value: string): string {
-    return opportunitySortOptions(kind, status)
+export function normalizeOpportunitySort(value: string): string {
+    return opportunitySortOptions()
         .some(option => option.value === value)
         ? value
         : defaultSort()


### PR DESCRIPTION
## Summary

- align opportunity sorting, pagination, registration, submission, review, and winner behavior with the latest PM-5997 QA clarifications
- complete the in-page forum experience: counts, access, editing/deletion, safe formatting, list continuation, and styling
- correct Marathon Match review links, scores, stats, promo content, empty states, and podium presentation
- document the changed Opportunities behavior

## Jira

PM-6041, PM-6075, PM-6116, PM-6118, PM-6120, PM-6122, PM-6133, PM-6134, PM-6135, PM-6136, PM-6137, PM-6138, PM-6139, PM-6140, PM-6141, PM-6142, PM-6143, PM-6144, PM-6145, PM-6146, PM-6147, PM-6148, PM-6149, PM-6150, PM-6152, PM-6153, PM-6156

PM-6095 was investigated separately. Its latest QA response is generated by support-api-v6 when FILESTACK_API_KEY is absent, so it requires dev deployment configuration rather than a platform-ui change.

## Validation

- changed-area Jest run: 13 suites / 171 tests passed
- final ChallengeDetailsPage flow suite: 24 tests passed
- yarn lint
- yarn run build (passes with existing source-map, CSS-order, and bundle-size warnings)