### PR TITLE
Refine analytics campaign reporting

### DIFF
--- a/docs/adr/0002-aws-product-analytics.md
+++ b/docs/adr/0002-aws-product-analytics.md
@@ -202,11 +202,21 @@ non-cacheable.
 
 The Campaigns tab exposes the ordered landing, click, registration, and
 submission funnel with UTM, landing-page, and privacy-safe click-location
-breakdowns. The General tab exposes page views, visitors, and clicks in
+breakdowns. Click locations are ranked and paginated twenty rows at a time;
+the API combines viewport-position buckets for the same semantic item, and the
+table does not display position.
+The General tab exposes page views, visitors, and clicks in
 separate daily charts plus paginated page and traffic-source tables. Both
 report warehouse freshness and limit callers to 366 inclusive days. QuickSight
 remains the AWS native exploratory dashboard; the Platform UI app is the
 narrowly scoped daily operational interface.
+
+To avoid making a user wait for Redshift Serverless to resume after idle, an
+EventBridge rule starts the default Campaigns and filter-option statements at
+the beginning of each four-hour Data API idempotency window. Interactive
+requests reuse the completed statements by their query fingerprint. This adds
+only bounded scheduled queries and does not keep development RPUs continuously
+active.
 
 ## Configuration
 
@@ -260,6 +270,15 @@ and role-gated API returned an ordered 30 landing visitors, 22 clickers, 14
 registrations, and 8 submissions. Three landing paths and three semantic click
 placements provide non-empty table data. These aggregates are synthetic UI
 test data and must not be interpreted as member traffic.
+
+On 2026-09-04, the same standard pipeline loaded a second pseudonymous fixture,
+UTM ID `dev_fixture_multiday_20260904`, into the September 2 and 3 cohorts. The
+reporting views verified 38 landing visitors, 29 clickers, 19 registrations, and
+13 submissions across those dates, plus 29 distinct semantic clicked items.
+Combined with the original fixture, `aws_analytics` now spans three reporting
+dates and contains 68 landing visitors, 51 clickers, 33 registrations, and 21
+submissions. The expanded click set intentionally exercises the Campaigns
+table's twenty-row pagination. These aggregates are also synthetic UI test data.
 
 If the daily pipeline misses its freshness objective, first inspect failures and
 job duration. Increasing processing frequency is a cost-bearing design change,

--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -30,16 +30,22 @@ once within the same deadline. Clients can opt into resumable requests with
 returns `202`, `Retry-After`, and a server-generated query token. The browser
 polls with that token until the original statement completes instead of
 starting another warehouse query. Tokens are accepted only for the exact SQL,
-validated parameters, retry attempt, and current or previous thirty-minute
-window, which permits one boundary crossing without making tokens reusable for
-other reports. Browser polling is bounded. Concurrency and API throttles cap
-warehouse pressure, and successful responses use `Cache-Control: private,
-no-store`. Logs contain request IDs and service-owned error categories only.
+validated parameters, retry attempt, and current or previous four-hour window.
+The four-hour window remains below the Data API's eight-hour idempotency
+retention and permits one complete boundary-crossing window without making
+tokens reusable for other reports. An EventBridge schedule invokes the default
+Campaigns report and filter-option queries at each new window, allowing their
+statements to finish before an interactive request while preserving Redshift
+Serverless idle cost controls. Browser polling is bounded. Concurrency and API
+throttles cap warehouse pressure, and successful responses use `Cache-Control:
+private, no-store`. Logs contain request IDs and service-owned error categories
+only.
 
 ## Files
 
 - `template.yaml` registers protected analytics routes on the shared API and
-  provisions the JWT authorizer, Lambda, least-privilege query role, and logs.
+  provisions the JWT authorizer, Lambda, least-privilege query role, scheduled
+  default-report prewarm, and logs.
   The former dedicated API remains during the cutover observation window.
 - `src/handler.py` validates and shapes filter, campaign, and general reports.
 - `bootstrap.sql` creates the read-only Redshift database role and grants only

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -24,7 +24,10 @@ MAX_RESULT_ROWS = 2_000
 MAX_QUERY_ATTEMPTS = 2
 REPORT_CACHE_SECONDS = 60
 FILTER_CACHE_SECONDS = 300
-QUERY_TOKEN_WINDOW_SECONDS = 1_800
+# Redshift Data API retains idempotency tokens for eight hours. Four-hour
+# windows leave a complete prior window available for safe boundary-crossing
+# polls while allowing scheduled requests to prepare the default reports.
+QUERY_TOKEN_WINDOW_SECONDS = 14_400
 QUERY_POLL_DELAY_MILLISECONDS = 1_000
 SAFE_FILTER_PATTERN = re.compile(r"^[A-Za-z0-9._~-]{1,100}$")
 QUERY_TOKEN_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -109,8 +112,6 @@ filtered_clicks AS (
         element_type,
         destination_host,
         destination_path,
-        CAST(FLOOR(click_x_percent / 10.0) * 10 AS integer) AS click_x_bucket,
-        CAST(FLOOR(click_y_percent / 10.0) * 10 AS integer) AS click_y_bucket,
         analytics_user_id
     FROM topcoder_web.product_analytics_events_v1
     WHERE event_name = 'ui_click'
@@ -174,8 +175,6 @@ click_rows AS (
         element_type,
         destination_host,
         destination_path,
-        click_x_bucket,
-        click_y_bucket,
         COUNT(*)::bigint AS click_count,
         COUNT(DISTINCT analytics_user_id)::bigint AS click_users
     FROM filtered_clicks
@@ -185,9 +184,7 @@ click_rows AS (
         element_id,
         element_type,
         destination_host,
-        destination_path,
-        click_x_bucket,
-        click_y_bucket
+        destination_path
     ORDER BY click_count DESC, page_path
     LIMIT 100
 )
@@ -249,8 +246,7 @@ SELECT
     element_type,
     destination_host,
     destination_path,
-    COALESCE(CAST(click_x_bucket AS varchar), '') || ':' ||
-        COALESCE(CAST(click_y_bucket AS varchar), ''),
+    NULL,
     click_count, click_users, NULL, NULL, NULL, NULL, NULL, NULL
 FROM click_rows
 ORDER BY row_type, date_value, metric_1 DESC
@@ -699,13 +695,12 @@ def _click_location(row: dict[str, Any]) -> dict[str, Any]:
         row: Query result row with safe, aggregate click dimensions.
 
     Returns:
-        Camel-cased click-location object with separate coarse coordinates.
+        Camel-cased click-location object grouped by semantic element fields.
 
     Raises:
-        Does not raise; malformed buckets become null coordinates.
+        Does not raise.
     """
 
-    bucket = str(row.get("dimension_7") or ":").split(":", 1)
     return {
         "pagePath": row.get("dimension_1") or "Unknown",
         "placement": row.get("dimension_2"),
@@ -713,8 +708,6 @@ def _click_location(row: dict[str, Any]) -> dict[str, Any]:
         "elementType": row.get("dimension_4"),
         "destinationHost": row.get("dimension_5"),
         "destinationPath": row.get("dimension_6"),
-        "xBucket": _optional_integer(bucket[0]),
-        "yBucket": _optional_integer(bucket[1] if len(bucket) > 1 else ""),
         "clicks": _integer(row.get("metric_1")),
         "clickers": _integer(row.get("metric_2")),
     }
@@ -977,10 +970,10 @@ def _query_client_token(
         sql: Server-owned SQL template.
         parameters: Validated named parameters.
         attempt: Provider retry index; failed statements receive a new token.
-        token_window: Optional explicit thirty-minute bucket used to validate a resume token.
+        token_window: Optional explicit four-hour bucket used to validate a resume token.
 
     Returns:
-        Sixty-four-character SHA-256 token stable within a thirty-minute window.
+        Sixty-four-character SHA-256 token stable within a four-hour window.
 
     Raises:
         Does not raise for validated handler inputs and configured environment values.
@@ -1268,27 +1261,6 @@ def _integer(value: Any) -> int:
         return max(0, int(float(value or 0)))
     except (TypeError, ValueError):
         return 0
-
-
-def _optional_integer(value: Any) -> int | None:
-    """Convert an optional coarse coordinate to an integer.
-
-    Args:
-        value: Data API string or number.
-
-    Returns:
-        Integer coordinate or null when absent/malformed.
-
-    Raises:
-        Does not raise.
-    """
-
-    if value in (None, ""):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _percentage(numerator: int, denominator: int) -> float:

--- a/infrastructure/analytics-api/template.yaml
+++ b/infrastructure/analytics-api/template.yaml
@@ -147,6 +147,30 @@ Resources:
         - Key: Environment
           Value: dev
 
+  AnalyticsPrewarmRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Prepares default analytics results once per four-hour Data API token window.
+      ScheduleExpression: cron(0 0/4 * * ? *)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt AnalyticsFunction.Arn
+          Id: analytics-filter-options
+          Input: !Sub >-
+            {"routeKey":"GET /v1/analytics/filters","queryStringParameters":{"async":"true"},"requestContext":{"requestId":"scheduled-filter-prewarm","authorizer":{"jwt":{"claims":{"${HumanRoleClaim}":["analytics"]}}}}}
+        - Arn: !GetAtt AnalyticsFunction.Arn
+          Id: analytics-default-campaign
+          Input: !Sub >-
+            {"routeKey":"GET /v1/analytics/campaign","queryStringParameters":{"async":"true"},"requestContext":{"requestId":"scheduled-campaign-prewarm","authorizer":{"jwt":{"claims":{"${HumanRoleClaim}":["analytics"]}}}}}
+
+  AnalyticsPrewarmInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref AnalyticsFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt AnalyticsPrewarmRule.Arn
+
   AnalyticsApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Retain

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -297,12 +297,6 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertIn(":campaign = '*' OR", self.module.CAMPAIGN_SQL)
         self.assertIn(":surface = '*' OR", self.module.GENERAL_SQL)
 
-    def test_campaign_sql_uses_redshift_coordinate_concatenation(self) -> None:
-        """Click-coordinate buckets use Redshift-compatible two-operand concatenation."""
-
-        self.assertNotIn("CONCAT(", self.module.CAMPAIGN_SQL)
-        self.assertIn("|| ':' ||", self.module.CAMPAIGN_SQL)
-
     def test_retries_one_failed_redshift_statement(self) -> None:
         """A transient failed statement is retried once inside the request deadline."""
 
@@ -458,7 +452,6 @@ class AnalyticsHandlerTests(unittest.TestCase):
                 "dimension_4": "button",
                 "dimension_5": "www.topcoder-dev.com",
                 "dimension_6": "/challenges/123",
-                "dimension_7": "40:60",
                 "metric_1": 8,
                 "metric_2": 6,
             },
@@ -477,8 +470,14 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertEqual(200, response["statusCode"])
         self.assertEqual(40.0, body["totals"]["clickThroughPercent"])
         self.assertEqual(50.0, body["totals"]["registrationToSubmissionPercent"])
-        self.assertEqual(40, body["clickLocations"][0]["xBucket"])
-        self.assertEqual(60, body["clickLocations"][0]["yBucket"])
+        self.assertNotIn("xBucket", body["clickLocations"][0])
+        self.assertNotIn("yBucket", body["clickLocations"][0])
+
+    def test_campaign_query_groups_clicks_by_semantic_item(self) -> None:
+        """Campaign click rankings do not split one item by viewport position."""
+
+        self.assertNotIn("click_x_bucket", self.module.CAMPAIGN_SQL)
+        self.assertNotIn("click_y_bucket", self.module.CAMPAIGN_SQL)
 
     def test_shapes_general_report(self) -> None:
         """General rows retain page, source, and surface dimensions."""

--- a/src/apps/analytics/README.md
+++ b/src/apps/analytics/README.md
@@ -29,7 +29,9 @@ Campaign Analytics uses UTM attribution and an ordered cohort funnel. Its
 totals answer how many distinct landing visitors clicked, then registered for
 a challenge after clicking, then submitted after registering. It also shows
 campaign and landing-page breakdowns plus aggregate click locations by semantic
-element fields and ten-percentage-point viewport buckets.
+element fields. Click locations are ranked by clicks and paginated twenty rows
+at a time. The API combines coarse viewport-position buckets for the same
+semantic item before returning the ranking.
 
 General Analytics shows page views, distinct visitors, clicks, and distinct
 clickers. Page views, visitors, and clicks use separate daily area charts, and
@@ -43,18 +45,24 @@ ranges are inclusive and limited to 366 days. The UI displays the warehouse's
 Empty dates in a series are not inferred as provider outages.
 
 Development includes a clearly labeled synthetic campaign named
-`aws_analytics` with UTM ID `dev_fixture_20260902`. Its verified ordered funnel
-contains 30 landing visitors, 22 clickers, 14 registrations, and 8 submissions,
-plus multiple landing paths and click placements. Treat it as UI test data, not
-member traffic.
+`aws_analytics`. UTM ID `dev_fixture_20260902` supplies the September 1 cohort
+with 30 landing visitors, 22 clickers, 14 registrations, and 8 submissions.
+UTM ID `dev_fixture_multiday_20260904` supplies September 2–3 cohorts totaling
+38 landing visitors, 29 clickers, 19 registrations, and 13 submissions, with 29
+distinct semantic clicked items. Together they provide three dates and enough
+ranked clicks to exercise table pagination. Treat these fixtures as UI test
+data, not member traffic.
 
 Redshift Serverless can take longer than one HTTP request after an idle period.
 The UI opts into resumable queries and transparently polls `202` responses with
-the server-issued query token. The report spinner stays in a contained region
-below the filters, leaving filters and Analytics navigation usable. Polling is
-bounded to twelve requests (roughly five minutes at the API's maximum query
-wait); after that, or after a genuine failure, the explicit retry action is
-shown.
+the server-issued query token. A low-frequency EventBridge schedule prepares
+the default Campaigns report and filter options at the start of each four-hour
+Data API idempotency window, avoiding an interactive warehouse wake-up in the
+normal case without keeping development Redshift capacity running continuously.
+The report spinner stays in a contained region below the filters, leaving
+filters and Analytics navigation usable. Polling is bounded to twelve requests
+(roughly five minutes at the API's maximum query wait); after that, or after a
+genuine failure, the explicit retry action is shown.
 
 ## Privacy
 

--- a/src/apps/analytics/src/lib/models/analytics.models.ts
+++ b/src/apps/analytics/src/lib/models/analytics.models.ts
@@ -80,8 +80,6 @@ export interface ClickLocation {
     elementType?: string
     destinationHost?: string
     destinationPath?: string
-    xBucket?: number
-    yBucket?: number
     clicks: number
     clickers: number
 }

--- a/src/apps/analytics/src/lib/utils/analytics.utils.spec.ts
+++ b/src/apps/analytics/src/lib/utils/analytics.utils.spec.ts
@@ -6,7 +6,6 @@ import {
     formatAnalyticsInteger,
     formatAnalyticsPercent,
     formatAnalyticsSurface,
-    formatClickBucket,
     validateAnalyticsDateRange,
 } from './analytics.utils'
 
@@ -53,10 +52,6 @@ describe('Analytics utilities', () => {
             .toBe('12.35%')
         expect(formatAnalyticsSurface('topcoder_website'))
             .toBe('Topcoder Website')
-        expect(formatClickBucket(20, 90))
-            .toBe('x 20–29%, y 90–99%')
-        expect(formatClickBucket(undefined, 90))
-            .toBe('Unknown')
         expect(formatAnalyticsFreshness('2026-08-30'))
             .toBe('Aug 30, 2026')
         expect(formatAnalyticsFreshness('not-a-date'))

--- a/src/apps/analytics/src/lib/utils/analytics.utils.ts
+++ b/src/apps/analytics/src/lib/utils/analytics.utils.ts
@@ -117,19 +117,6 @@ export function formatAnalyticsSurface(value: string): string {
 }
 
 /**
- * Formats one privacy-safe ten-percentage-point click bucket.
- *
- * @param x horizontal bucket start or undefined.
- * @param y vertical bucket start or undefined.
- * @returns readable coarse position.
- * @throws Does not throw.
- */
-export function formatClickBucket(x?: number, y?: number): string {
-    if (x === undefined || y === undefined) return 'Unknown'
-    return `x ${x}–${Math.min(100, x + 9)}%, y ${y}–${Math.min(100, y + 9)}%`
-}
-
-/**
  * Builds a stable request identity from applied report filters.
  *
  * @param prefix report type.

--- a/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
+++ b/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
@@ -4,7 +4,11 @@ import { fireEvent, render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
 import { useAnalyticsResource } from '../lib/hooks'
-import { AnalyticsFilterOptions, GeneralReport } from '../lib/models'
+import {
+    AnalyticsFilterOptions,
+    CampaignReport,
+    GeneralReport,
+} from '../lib/models'
 
 import { CampaignAnalyticsPage } from './CampaignAnalyticsPage'
 import { GeneralAnalyticsPage } from './GeneralAnalyticsPage'
@@ -105,6 +109,78 @@ describe('Analytics report pages', () => {
             .toBeEnabled()
         expect(screen.getByRole('button', { name: 'Apply' }))
             .toBeEnabled()
+    })
+
+    it('shows the top twenty click locations without position and paginates the remainder', () => {
+        const data: CampaignReport = {
+            campaigns: [],
+            clickLocations: Array.from({ length: 45 }, (_, index) => ({
+                clickers: 100 - index,
+                clicks: 200 - index,
+                elementId: `clicked-item-${String(index + 1)
+                    .padStart(2, '0')}`,
+                elementType: 'button',
+                pagePath: `/campaign-page-${String(index + 1)
+                    .padStart(2, '0')}`,
+                placement: 'main',
+            })),
+            dataThrough: '2026-09-03',
+            filters: {
+                campaign: '',
+                campaignId: '',
+                from: '2026-08-05',
+                medium: '',
+                source: '',
+                to: '2026-09-03',
+            },
+            generatedAt: '2026-09-04T00:00:00Z',
+            landingPages: [],
+            series: [],
+            totals: {
+                clickThroughPercent: 50,
+                clickToRegistrationPercent: 50,
+                landingClickers: 50,
+                landingToSubmissionPercent: 12,
+                landingUsers: 100,
+                registrations: 25,
+                registrationToSubmissionPercent: 48,
+                submissions: 12,
+            },
+        }
+        mockAnalyticsResources({ data, loading: false, refresh, refreshing: false })
+
+        render(<CampaignAnalyticsPage />)
+
+        const clicksPanel = screen.getByRole('heading', { name: 'Where people clicked' })
+            .closest('article') as HTMLElement
+        expect(within(clicksPanel)
+            .queryByRole('columnheader', { name: 'Position' }))
+            .not.toBeInTheDocument()
+        expect(within(clicksPanel)
+            .getByText('/campaign-page-01'))
+            .toBeInTheDocument()
+        expect(within(clicksPanel)
+            .getByText('/campaign-page-20'))
+            .toBeInTheDocument()
+        expect(within(clicksPanel)
+            .queryByText('/campaign-page-21'))
+            .not.toBeInTheDocument()
+        expect(within(clicksPanel)
+            .getByText('Showing 1–20 of 45 clicked items'))
+            .toBeInTheDocument()
+
+        fireEvent.click(within(clicksPanel)
+            .getByRole('button', { name: 'Next' }))
+
+        expect(within(clicksPanel)
+            .queryByText('/campaign-page-01'))
+            .not.toBeInTheDocument()
+        expect(within(clicksPanel)
+            .getByText('/campaign-page-21'))
+            .toBeInTheDocument()
+        expect(within(clicksPanel)
+            .getByText('Showing 21–40 of 45 clicked items'))
+            .toBeInTheDocument()
     })
 
     it('uses separate area charts, omits surfaces, and paginates visited pages twenty at a time', () => {

--- a/src/apps/analytics/src/pages/CampaignAnalyticsPage.tsx
+++ b/src/apps/analytics/src/pages/CampaignAnalyticsPage.tsx
@@ -36,12 +36,12 @@ import {
     formatAnalyticsFreshness,
     formatAnalyticsInteger,
     formatAnalyticsPercent,
-    formatClickBucket,
     validateAnalyticsDateRange,
 } from '../lib/utils'
 
 import styles from './AnalyticsPages.module.scss'
 
+const CLICK_LOCATION_PAGE_SIZE = 20
 const campaignSeries = [
     { color: '#2c95d7', key: 'landingUsers', label: 'Landing visitors' },
     { color: '#6f42c1', key: 'landingClickers', label: 'Clicked' },
@@ -118,6 +118,7 @@ export const CampaignAnalyticsPage: FC = () => {
     const [draftFilters, setDraftFilters] = useState<CampaignFilters>(initialFilters)
     const [appliedFilters, setAppliedFilters] = useState<CampaignFilters>(initialFilters)
     const [filterError, setFilterError] = useState<string>()
+    const [clickLocationsPage, setClickLocationsPage] = useState(1)
     const filterOptions = useAnalyticsResource<AnalyticsFilterOptions>('analytics-filters', getAnalyticsFilters)
     const reportKey = analyticsRequestKey('campaign', appliedFilters)
     const report = useAnalyticsResource<CampaignReport>(
@@ -134,18 +135,45 @@ export const CampaignAnalyticsPage: FC = () => {
         event.preventDefault()
         const error = validateAnalyticsDateRange(draftFilters)
         setFilterError(error)
-        if (!error) setAppliedFilters({ ...draftFilters })
+        if (!error) {
+            setAppliedFilters({ ...draftFilters })
+            setClickLocationsPage(1)
+        }
     }, [draftFilters])
 
     const resetFilters = useCallback(() => {
         const next = initialCampaignFilters()
         setDraftFilters(next)
         setAppliedFilters(next)
+        setClickLocationsPage(1)
         setFilterError(undefined)
     }, [])
 
     const data = report.data
     const reportPending = report.loading || report.refreshing
+    const clickLocationsTotal = data?.clickLocations.length ?? 0
+    const clickLocationsTotalPages = Math.max(
+        1,
+        Math.ceil(clickLocationsTotal / CLICK_LOCATION_PAGE_SIZE),
+    )
+    const activeClickLocationsPage = Math.min(clickLocationsPage, clickLocationsTotalPages)
+    const visibleClickLocations = data?.clickLocations.slice(
+        (activeClickLocationsPage - 1) * CLICK_LOCATION_PAGE_SIZE,
+        activeClickLocationsPage * CLICK_LOCATION_PAGE_SIZE,
+    ) ?? []
+    const showPreviousClickLocations = useCallback(() => {
+        setClickLocationsPage(current => Math.max(1, current - 1))
+    }, [])
+    const showNextClickLocations = useCallback(() => {
+        setClickLocationsPage(current => Math.min(clickLocationsTotalPages, current + 1))
+    }, [clickLocationsTotalPages])
+    const firstVisibleClickLocation = clickLocationsTotal === 0
+        ? 0
+        : ((activeClickLocationsPage - 1) * CLICK_LOCATION_PAGE_SIZE) + 1
+    const lastVisibleClickLocation = Math.min(
+        clickLocationsTotal,
+        activeClickLocationsPage * CLICK_LOCATION_PAGE_SIZE,
+    )
     return (
         <>
             <PageTitle>Campaign Analytics</PageTitle>
@@ -376,7 +404,7 @@ export const CampaignAnalyticsPage: FC = () => {
                                 <div className={styles.panelHeader}>
                                     <div>
                                         <h2>Where people clicked</h2>
-                                        <p>Safe element, placement, destination, and coarse viewport location.</p>
+                                        <p>Top clicked elements ranked by total clicks.</p>
                                     </div>
                                 </div>
                                 <div className={styles.tableScroll}>
@@ -384,13 +412,12 @@ export const CampaignAnalyticsPage: FC = () => {
                                         <thead>
                                             <tr>
                                                 <th scope='col'>Page / element</th>
-                                                <th scope='col'>Position</th>
                                                 <th scope='col'>Clicks</th>
                                                 <th scope='col'>People</th>
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            {data.clickLocations.map(row => (
+                                            {visibleClickLocations.map(row => (
                                                 <tr
                                                     key={[
                                                         row.pagePath,
@@ -399,8 +426,6 @@ export const CampaignAnalyticsPage: FC = () => {
                                                         row.elementType,
                                                         row.destinationHost,
                                                         row.destinationPath,
-                                                        row.xBucket,
-                                                        row.yBucket,
                                                     ].join('|')}
                                                 >
                                                     <th scope='row'>
@@ -411,15 +436,42 @@ export const CampaignAnalyticsPage: FC = () => {
                                                                 .join(' · ') || 'Unlabelled interactive element'}
                                                         </span>
                                                     </th>
-                                                    <td>{formatClickBucket(row.xBucket, row.yBucket)}</td>
                                                     <td>{formatAnalyticsInteger(row.clicks)}</td>
                                                     <td>{formatAnalyticsInteger(row.clickers)}</td>
                                                 </tr>
                                             ))}
-                                            {data.clickLocations.length === 0 && <EmptyTableRow columns={4} />}
+                                            {visibleClickLocations.length === 0 && <EmptyTableRow columns={3} />}
                                         </tbody>
                                     </table>
                                 </div>
+                                {clickLocationsTotal > 0 && (
+                                    <div className={styles.pagination}>
+                                        <span>
+                                            {`Showing ${firstVisibleClickLocation}–${lastVisibleClickLocation}`
+                                                + ` of ${clickLocationsTotal} clicked items`}
+                                        </span>
+                                        <nav aria-label='Click locations pagination'>
+                                            <button
+                                                disabled={activeClickLocationsPage <= 1}
+                                                onClick={showPreviousClickLocations}
+                                                type='button'
+                                            >
+                                                Previous
+                                            </button>
+                                            <span>
+                                                {`Page ${activeClickLocationsPage}`
+                                                    + ` of ${clickLocationsTotalPages}`}
+                                            </span>
+                                            <button
+                                                disabled={activeClickLocationsPage >= clickLocationsTotalPages}
+                                                onClick={showNextClickLocations}
+                                                type='button'
+                                            >
+                                                Next
+                                            </button>
+                                        </nav>
+                                    </div>
+                                )}
                             </article>
                         </section>
                     </>


### PR DESCRIPTION
## Summary
- prewarm default campaign and filter queries every four hours to avoid interactive Redshift cold-start waits
- paginate clicked items 20 rows at a time and remove position from the report contract
- document and verify multi-day `aws_analytics` QA cohorts

## Validation
- `yarn lint`
- `yarn run build`
- 27 analytics UI tests
- 17 analytics API tests
- CloudFormation template validation
- development Redshift reporting-view verification