### PR TITLE
PM-6171: Route bus API calls to v6

### DIFF
--- a/src/apps/admin/src/lib/services/bus-event.service.ts
+++ b/src/apps/admin/src/lib/services/bus-event.service.ts
@@ -13,7 +13,7 @@ import { CommonRequestBusAPI } from '../models'
  */
 export const reqToBusAPI = async (data: CommonRequestBusAPI): Promise<string> => {
     const resultData = await xhrPostAsync<CommonRequestBusAPI, string>(
-        `${EnvironmentConfig.API.V5}/bus/events`,
+        `${EnvironmentConfig.API.V6}/bus/events`,
         data,
     )
     return resultData

--- a/src/apps/review/src/lib/services/submission-reprocess.service.spec.ts
+++ b/src/apps/review/src/lib/services/submission-reprocess.service.spec.ts
@@ -16,7 +16,8 @@ import {
 jest.mock('~/config', () => ({
     EnvironmentConfig: {
         API: {
-            V5: 'https://api.topcoder.test',
+            V5: 'https://api.topcoder.test/v5',
+            V6: 'https://api.topcoder.test/v6',
         },
     },
 }), { virtual: true })
@@ -131,7 +132,7 @@ describe('submission reprocess service', () => {
 
         expect(mockedPost)
             .toHaveBeenCalledWith(
-                'https://api.topcoder.test/bus/events',
+                'https://api.topcoder.test/v6/bus/events',
                 {
                     'mime-type': 'application/json',
                     originator: 'review-api-v6',

--- a/src/apps/review/src/lib/services/submission-reprocess.service.ts
+++ b/src/apps/review/src/lib/services/submission-reprocess.service.ts
@@ -189,7 +189,7 @@ export async function reprocessTopgearSubmission(
     const payload = createTopgearSubmissionReprocessPayload(input)
 
     return xhrPostAsync<TopgearSubmissionReprocessEvent, string>(
-        `${EnvironmentConfig.API.V5}/bus/events`,
+        `${EnvironmentConfig.API.V6}/bus/events`,
         createTopgearSubmissionReprocessEvent(payload),
     )
 }


### PR DESCRIPTION
## Problem

[PM-6171](https://topcoder.atlassian.net/browse/PM-6171) — Rescanning a submission from the system admin app errors out. The Topcoder bus API calls were still pointed at `/v5` instead of `/v6`.

## Fix

Two bus API call sites moved from `EnvironmentConfig.API.V5` to `API.V6`:

**`src/apps/admin/src/lib/services/bus-event.service.ts`** — `reqToBusAPI` is the single bus entry point for the admin subapp, so this covers:
- AV rescan (`useManageAVScan` → `CREATE_BUS_EVENT_AV_RESCAN`) — the flow reported in the ticket
- Marathon match score events (`CREATE_BUS_EVENT_DATA_SUBMISSION_MARATHON_MATCH`)
- Submission reprocess events (`CREATE_BUS_EVENT_REPROCESS_SUBMISSION`)

**`src/apps/review/src/lib/services/submission-reprocess.service.ts`** — `reprocessTopgearSubmission`, which had the same v5 base.

These are the only two `/bus/events` call sites in the repo; no `API.V5` usages remain in the review subapp.

## Testing

- `submission-reprocess.service.spec.ts` updated and passing (4/4). The mock now exposes distinct `V5`/`V6` bases so a regression back to v5 asserts as a different URL instead of passing on a shared value.
- `tsc --noEmit` and `eslint` clean on all changed files.
- Manual: System Admin → Challenge Management → Manage Submissions, trigger **AV Rescan** on a submission and confirm the success toast (no v5 error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PM-6171]: https://topcoder.atlassian.net/browse/PM-6171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ