### PR TITLE
PM-6192: Stop the challenge editor spinning on unresolved lookups

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewConfigurationSummary.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewConfigurationSummary.tsx
@@ -2,6 +2,7 @@ import {
     FC,
     useEffect,
     useMemo,
+    useRef,
     useState,
 } from 'react'
 import classNames from 'classnames'
@@ -401,6 +402,12 @@ export const ReviewConfigurationSummary: FC<ReviewConfigurationSummaryProps> = (
     const [scorecards, setScorecards] = useState<Scorecard[]>([])
     const [workflowError, setWorkflowError] = useState<string | undefined>()
     const [workflows, setWorkflows] = useState<Workflow[]>([])
+    /*
+     * Member ids whose handle lookup already ran. Retrying by "still missing a handle" instead would
+     * spin whenever the member API cannot supply one, because each lookup publishes a new handle map
+     * that reruns the effect while the member stays unresolved.
+     */
+    const requestedUserIdsRef = useRef<Set<string>>(new Set<string>())
 
     const reviewerRows = useMemo(
         () => (Array.isArray(props.reviewers)
@@ -556,7 +563,7 @@ export const ReviewConfigurationSummary: FC<ReviewConfigurationSummaryProps> = (
                     const memberId = normalizeReviewerText(resource.memberId)
                     const memberHandle = normalizeReviewerText(resource.memberHandle)
 
-                    return memberId && !memberHandle && !memberHandlesByUserId[memberId.toLowerCase()]
+                    return memberId && !memberHandle && !requestedUserIdsRef.current.has(memberId.toLowerCase())
                         ? memberId
                         : ''
                 })),
@@ -565,7 +572,7 @@ export const ReviewConfigurationSummary: FC<ReviewConfigurationSummaryProps> = (
                     const memberId = normalizeReviewerText(assignedMember.memberId)
                     const memberHandle = normalizeReviewerText(assignedMember.memberHandle)
 
-                    return memberId && !memberHandle && !memberHandlesByUserId[memberId.toLowerCase()]
+                    return memberId && !memberHandle && !requestedUserIdsRef.current.has(memberId.toLowerCase())
                         ? memberId
                         : ''
                 })),
@@ -577,6 +584,10 @@ export const ReviewConfigurationSummary: FC<ReviewConfigurationSummaryProps> = (
                 mounted = false
             }
         }
+
+        unresolvedUserIds.forEach(userId => {
+            requestedUserIdsRef.current.add(userId.toLowerCase())
+        })
 
         searchProfilesByUserIds(unresolvedUserIds)
             .then(users => {
@@ -609,7 +620,6 @@ export const ReviewConfigurationSummary: FC<ReviewConfigurationSummaryProps> = (
     }, [
         assignedResourcesByReviewer,
         fallbackAssignedMembersByReviewer,
-        memberHandlesByUserId,
     ])
 
     useEffect(() => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionTypeField/SubmissionTypeField.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionTypeField/SubmissionTypeField.spec.tsx
@@ -3,6 +3,7 @@ import {
     FC,
 } from 'react'
 import {
+    act,
     render,
     screen,
     waitFor,
@@ -186,6 +187,84 @@ describe('SubmissionTypeField', () => {
                 name: 'submission_type',
                 value: 'zip',
             }]))
+    })
+
+    it('stops looking up a group the Groups API cannot return', async () => {
+        mockedFetchGroupById.mockRejectedValue(new Error('Failed to fetch group'))
+
+        render(
+            <TestHarness defaultGroups={['unreadable-group-id']} />,
+        )
+
+        await waitFor(() => {
+            expect(mockedFetchGroupById)
+                .toHaveBeenCalledWith('unreadable-group-id')
+        })
+
+        // The unresolved group must not be requested again, or the editor spins on the Groups API
+        // and locks up the challenge edit page.
+        await act(async () => {
+            await new Promise(resolve => {
+                setTimeout(resolve, 200)
+            })
+        })
+
+        expect(mockedFetchGroupById)
+            .toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('radio', { name: 'Zip file' }))
+            .toBeChecked()
+    })
+
+    it('stops looking up a group the Groups API resolves as missing', async () => {
+        mockedFetchGroupById.mockResolvedValue(undefined)
+
+        render(
+            <TestHarness defaultGroups={['missing-group-id']} />,
+        )
+
+        await waitFor(() => {
+            expect(mockedFetchGroupById)
+                .toHaveBeenCalledWith('missing-group-id')
+        })
+
+        await act(async () => {
+            await new Promise(resolve => {
+                setTimeout(resolve, 200)
+            })
+        })
+
+        expect(mockedFetchGroupById)
+            .toHaveBeenCalledTimes(1)
+    })
+
+    it('looks up each selected group only once', async () => {
+        mockedFetchGroupById.mockImplementation(async (groupId: string) => ({
+            id: groupId,
+            name: 'Topgear - Internal',
+        }))
+
+        render(
+            <TestHarness
+                defaultGroups={[
+                    'topgear-group-id',
+                    'other-group-id',
+                ]}
+            />,
+        )
+
+        await waitFor(() => {
+            expect(screen.getByRole('radio', { name: 'URL' }))
+                .toBeChecked()
+        })
+
+        await act(async () => {
+            await new Promise(resolve => {
+                setTimeout(resolve, 200)
+            })
+        })
+
+        expect(mockedFetchGroupById)
+            .toHaveBeenCalledTimes(2)
     })
 
     it('writes submission_type metadata when the selected radio changes', async () => {

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionTypeField/SubmissionTypeField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/SubmissionTypeField/SubmissionTypeField.tsx
@@ -3,6 +3,7 @@ import {
     useCallback,
     useEffect,
     useMemo,
+    useRef,
     useState,
 } from 'react'
 import {
@@ -184,6 +185,20 @@ export const SubmissionTypeField: FC = () => {
     }) as string | undefined
     const [groupsById, setGroupsById] = useState<Record<string, Group | undefined>>({})
     const [hasUserSelectedSubmissionType, setHasUserSelectedSubmissionType] = useState(false)
+    /*
+     * Groups whose lookup already ran, so a group the Groups API cannot return - a deleted group, a
+     * group the copilot cannot read, or a failed request - is not requested again. Keying the lookup
+     * off the resolved groups instead would retry those forever, because an unresolved group stays
+     * missing from the resolved map and every retry publishes a new map that reruns the lookup.
+     */
+    const requestedGroupIdsRef = useRef<Set<string>>(new Set<string>())
+    const isMountedRef = useRef<boolean>(true)
+
+    useEffect(() => (
+        (): void => {
+            isMountedRef.current = false
+        }
+    ), [])
 
     const selectedGroupIds = useMemo(
         () => normalizeGroupIds(groupIds),
@@ -202,22 +217,24 @@ export const SubmissionTypeField: FC = () => {
 
     useEffect(() => {
         if (explicitSubmissionType) {
-            return undefined
+            return
         }
 
         const currentSelectedGroupIds = selectedGroupKey
             ? selectedGroupKey.split('|')
             : []
-        const missingGroupIds = currentSelectedGroupIds
-            .filter(groupId => !groupsById[groupId])
+        const pendingGroupIds = currentSelectedGroupIds
+            .filter(groupId => !requestedGroupIdsRef.current.has(groupId))
 
-        if (!missingGroupIds.length) {
-            return undefined
+        if (!pendingGroupIds.length) {
+            return
         }
 
-        let isMounted = true
+        pendingGroupIds.forEach(groupId => {
+            requestedGroupIdsRef.current.add(groupId)
+        })
 
-        Promise.all(missingGroupIds.map(async groupId => {
+        Promise.all(pendingGroupIds.map(async groupId => {
             try {
                 return {
                     group: await fetchGroupById(groupId),
@@ -231,7 +248,7 @@ export const SubmissionTypeField: FC = () => {
             }
         }))
             .then(resolvedGroups => {
-                if (!isMounted) {
+                if (!isMountedRef.current) {
                     return
                 }
 
@@ -246,13 +263,9 @@ export const SubmissionTypeField: FC = () => {
                     ),
                 }))
             })
-
-        return () => {
-            isMounted = false
-        }
+            .catch(() => undefined)
     }, [
         explicitSubmissionType,
-        groupsById,
         selectedGroupKey,
     ])
 


### PR DESCRIPTION
Fixes [PM-6192](https://topcoder.atlassian.net/browse/PM-6192) — *Work app get stuck on challenge draft edit mode*.

## Problem

The challenge edit page in the work subapp could lock up the browser tab ("Page Unresponsive" / "This page isn't responding"), with the tab pinned at 100% and DevTools unable to inspect it.

Two lookups in the editor retried forever whenever their API call could not produce a result.

**`SubmissionTypeField`** (rendered under *Advanced Options* for every challenge) resolves the selected challenge groups to decide the default submission flow (zip vs. URL for Wipro/Topgear groups). It kept the resolved groups in state, listed that state as an effect dependency, and treated *"not present in the resolved map"* as *"not fetched yet"*:

```ts
const missingGroupIds = currentSelectedGroupIds.filter(groupId => !groupsById[groupId])
// ...
setGroupsById(previous => ({ ...previous, ...resolved }))   // always a new object
}, [explicitSubmissionType, groupsById, selectedGroupKey])
```

`fetchGroupById` rejects on every failure — a deleted group, a group the copilot cannot read (403), or any transient error. Such a group never lands in the map, so it stays "missing", while each attempt publishes a new map object that reruns the effect. The result is an unbounded loop of requests and re-renders.

Measured by rendering the real `ChallengeEditorForm` against the design challenge from the ticket, with one selected group whose lookup fails:

| | `fetchGroupById` calls in 5s |
|---|---|
| before | 4,748 (and still climbing) |
| after | 1 |

**`ReviewConfigurationSummary`** (the read-only review summary on the same page) resolves reviewer handles with exactly the same shape and can spin the same way when the member API returns a record without a handle.

## Fix

Both lookups now track the ids they have already requested in a ref, so each id is requested at most once and the "already requested" test no longer depends on the request having succeeded. `SubmissionTypeField` falls back to the normal zip upload default for a group it cannot resolve, which is what `resolveSubmissionType` already did. Dropping the resolved map from the dependency array also stops the effect from re-running on every render of the (very large) editor form.

## Testing

- `SubmissionTypeField.spec.tsx`: three new regression tests — a rejected lookup, a lookup that resolves as missing, and the normal multi-group path — each asserting one request per group.
- `yarn test` for `SubmissionTypeField` and `ReviewConfigurationSummary`: 18 passed.
- `eslint` and `tsc --noEmit`: clean.
- Full `src/apps/work` suite: the 12 pre-existing failures (10 suites, all in files untouched here) are identical before and after this change on `dev`.

## Note for reviewers

The freeze was reproduced and measured in a temporary harness that renders the real `ChallengeEditorForm`, not in the deployed app, so please confirm on dev that the reported challenge no longer hangs. The linked example challenge reports `groups: []` over the public API, so if it still freezes there may be a second trigger; the browser console on the frozen page (React logs a "Maximum update depth exceeded" warning naming the component) would pin it down quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PM-6192]: https://topcoder.atlassian.net/browse/PM-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ