### PR TITLE
PM-5777 Hide history for unlimited Design submissions -> dev

### DIFF
--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentSubmissions.spec.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentSubmissions.spec.tsx
@@ -8,6 +8,9 @@ import {
     waitFor,
 } from '@testing-library/react'
 
+import { useWindowSize } from '~/libs/shared'
+import type { TableColumn } from '~/libs/ui'
+
 import type {
     BackendSubmission,
     ChallengeDetailContextModel,
@@ -61,7 +64,14 @@ jest.mock('~/apps/admin/src/lib', () => ({
 }), { virtual: true })
 
 jest.mock('~/apps/admin/src/lib/components/common/TableMobile', () => ({
-    TableMobile: () => <div>Mobile table</div>,
+    TableMobile: (props: {
+        columns: TableColumn<BackendSubmission>[][]
+        data: BackendSubmission[]
+    }) => {
+        const { Table }: typeof import('~/libs/ui') = jest.requireMock('~/libs/ui')
+
+        return <Table columns={props.columns.map(columns => columns[1])} data={props.data} />
+    },
 }), { virtual: true })
 
 jest.mock('~/apps/admin/src/lib/utils', () => ({
@@ -70,10 +80,7 @@ jest.mock('~/apps/admin/src/lib/utils', () => ({
 
 jest.mock('~/libs/shared', () => ({
     copyTextToClipboard: () => Promise.resolve(),
-    useWindowSize: () => ({
-        height: 800,
-        width: 1200,
-    }),
+    useWindowSize: jest.fn(),
 }), { virtual: true })
 
 jest.mock('~/libs/ui', () => ({
@@ -181,6 +188,7 @@ jest.mock('../TableWrapper', () => ({
 }))
 
 const mockedReprocessTopgearSubmission = reprocessTopgearSubmission as jest.Mock
+const mockedUseWindowSize = useWindowSize as jest.Mock
 
 const submission = {
     challengeId: 'challenge-1',
@@ -241,15 +249,31 @@ const reviewAppContextValue = {
     },
 } as ReviewAppContextModel
 
-function renderSubmissions(): ReturnType<typeof render> {
+/**
+ * Render the submissions tab with optional challenge settings and submission history.
+ *
+ * @param challengeOverrides - Challenge fields to override for a visibility scenario.
+ * @param submissions - Backend rows supplied to the tab and challenge context.
+ * @returns Testing Library's render result for assertions and interactions.
+ * @throws Propagates rendering errors from the component under test.
+ */
+function renderSubmissions(
+    challengeOverrides: Partial<ChallengeInfo> = {},
+    submissions: BackendSubmission[] = [submission],
+): ReturnType<typeof render> {
     return render(
         <ReviewAppContext.Provider value={reviewAppContextValue}>
-            <ChallengeDetailContext.Provider value={challengeDetailContextValue}>
+            <ChallengeDetailContext.Provider value={{
+                ...challengeDetailContextValue,
+                challengeInfo: { ...challengeInfo, ...challengeOverrides },
+                challengeSubmissions: submissions,
+            }}
+            >
                 <TabContentSubmissions
                     downloadSubmission={jest.fn()}
                     isDownloading={{}}
                     isLoading={false}
-                    submissions={[submission]}
+                    submissions={submissions}
                 />
             </ChallengeDetailContext.Provider>
         </ReviewAppContext.Provider>,
@@ -260,6 +284,7 @@ describe('TabContentSubmissions', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockedReprocessTopgearSubmission.mockResolvedValue('ok')
+        mockedUseWindowSize.mockReturnValue({ height: 800, width: 1200 })
     })
 
     it('confirms before reprocessing a Topgear submission', async () => {
@@ -296,6 +321,61 @@ describe('TabContentSubmissions', () => {
                         id: 'submission-1',
                     }),
                 })
+        })
+    })
+
+    describe.each([1200, 768])('submission history at viewport width %i', width => {
+        const unlimited = JSON.stringify({ count: '', limit: 'false', unlimited: 'true' })
+        const limited = JSON.stringify({ count: '2', limit: 'true', unlimited: 'false' })
+        const submissionsWithHistory = [
+            {
+                ...submission,
+                isLatest: true,
+                type: 'CONTEST_SUBMISSION',
+            },
+            {
+                ...submission,
+                id: 'older-submission',
+                isLatest: false,
+                submittedDate: '2026-04-30T00:00:00.000Z',
+                type: 'CONTEST_SUBMISSION',
+            },
+        ]
+
+        beforeEach(() => {
+            mockedUseWindowSize.mockReturnValue({ height: 800, width })
+        })
+
+        it.each([unlimited, undefined])('shows all unlimited Design rows without history for %s', value => {
+            renderSubmissions({
+                metadata: value ? [{ name: 'submissionLimit', value }] : [],
+                track: { id: 'design-track', name: 'Design' },
+                type: { id: 'challenge-type', name: 'Challenge' },
+            }, submissionsWithHistory)
+
+            expect(screen.queryAllByRole('button', { name: 'View Submission History' }))
+                .toHaveLength(0)
+            for (const entry of submissionsWithHistory) {
+                expect(screen.getByText(entry.id))
+                    .toBeTruthy()
+            }
+        })
+
+        it.each([
+            ['Design', 'Challenge', limited],
+            ['Development', 'Challenge', unlimited],
+            ['Development', 'First2Finish', unlimited],
+            ['Data Science', 'Marathon Match', unlimited],
+            ['Quality Assurance', 'Challenge', unlimited],
+        ])('preserves history for %s / %s', (track, type, value) => {
+            renderSubmissions({
+                metadata: [{ name: 'submissionLimit', value }],
+                track: { id: 'track-1', name: track },
+                type: { id: 'type-1', name: type },
+            }, submissionsWithHistory)
+
+            expect(screen.getAllByRole('button', { name: 'View Submission History' }).length)
+                .toBeGreaterThan(0)
         })
     })
 })

--- a/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentSubmissions.tsx
+++ b/src/apps/review/src/lib/components/ChallengeDetailsContent/TabContentSubmissions.tsx
@@ -1,5 +1,6 @@
 /**
  * Tab content for submissions during the submission phase.
+ * Unlimited Design challenges show every submission without history actions.
  */
 import {
     FC,
@@ -38,6 +39,7 @@ import type { UseSubmissionDownloadAccessResult } from '../../hooks/useSubmissio
 import { ChallengeDetailContext, ReviewAppContext } from '../../contexts'
 import {
     challengeHasSubmissionLimit,
+    getChallengeSubmissionSelectionLimit,
     getSubmissionHistoryKey,
     hasIsLatestFlag,
     partitionSubmissionHistory,
@@ -173,9 +175,14 @@ export const TabContentSubmissions: FC<Props> = props => {
         [latestSubmissions, submissionMetaById],
     )
 
-    const restrictToLatest = useMemo(
-        () => challengeHasSubmissionLimit(challengeInfo),
+    const isUnlimitedDesignChallenge = useMemo(
+        () => getChallengeSubmissionSelectionLimit(challengeInfo) === undefined,
         [challengeInfo],
+    )
+
+    const restrictToLatest = useMemo(
+        () => !isUnlimitedDesignChallenge && challengeHasSubmissionLimit(challengeInfo),
+        [challengeInfo, isUnlimitedDesignChallenge],
     )
 
     const hasLatestFlag = useMemo(
@@ -184,8 +191,8 @@ export const TabContentSubmissions: FC<Props> = props => {
     )
 
     const shouldShowHistoryActions = useMemo(
-        () => historyByMember.size > 0,
-        [historyByMember],
+        () => !isUnlimitedDesignChallenge && historyByMember.size > 0,
+        [historyByMember, isUnlimitedDesignChallenge],
     )
 
     const [historyKey, setHistoryKey] = useState<string | undefined>(undefined)

--- a/src/apps/review/src/lib/hooks/useSubmissionHistory.spec.ts
+++ b/src/apps/review/src/lib/hooks/useSubmissionHistory.spec.ts
@@ -1,0 +1,89 @@
+/* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { act, renderHook } from '@testing-library/react'
+import type { RenderHookResult } from '@testing-library/react'
+
+import type { SubmissionInfo } from '../models'
+import { getChallengeSubmissionSelectionLimit } from '../utils/challenge'
+
+import { useSubmissionHistory, UseSubmissionHistoryResult } from './useSubmissionHistory'
+
+const submissions: SubmissionInfo[] = [
+    {
+        id: 'latest-submission',
+        isLatest: true,
+        memberId: 'member-1',
+        submittedDate: '2026-09-07T12:00:00.000Z',
+        type: 'CONTEST_SUBMISSION',
+    },
+    {
+        id: 'older-submission',
+        isLatest: false,
+        memberId: 'member-1',
+        submittedDate: '2026-09-07T11:00:00.000Z',
+        type: 'CONTEST_SUBMISSION',
+    },
+    {
+        id: 'oldest-submission',
+        isLatest: false,
+        memberId: 'member-1',
+        submittedDate: '2026-09-07T10:00:00.000Z',
+        type: 'CONTEST_SUBMISSION',
+    },
+]
+const unlimited = JSON.stringify({ count: '', limit: 'false', unlimited: 'true' })
+const limited = JSON.stringify({ count: '2', limit: 'true', unlimited: 'false' })
+
+describe('useSubmissionHistory for reviewer and submitter tables', () => {
+    it.each([unlimited, undefined])('hides history for unlimited Design metadata %s', value => {
+        const { result }: RenderHookResult<UseSubmissionHistoryResult, unknown> = renderHook(
+            () => useSubmissionHistory({
+                datas: submissions,
+                filteredAll: submissions,
+                isSubmissionTab: true,
+                maxVisibleSubmissions: getChallengeSubmissionSelectionLimit({
+                    metadata: value ? [{ name: 'submissionLimit', value }] : [],
+                    track: { id: 'design-track', name: 'Design' },
+                }),
+            }),
+        )
+
+        expect(result.current.shouldShowHistoryActions)
+            .toBe(false)
+    })
+
+    it.each([
+        ['Design', limited, ['oldest-submission']],
+        ['Development', unlimited, ['older-submission', 'oldest-submission']],
+        ['Data Science', unlimited, ['older-submission', 'oldest-submission']],
+        ['Quality Assurance', unlimited, ['older-submission', 'oldest-submission']],
+    ])('keeps history available and usable for %s', (track, value, expectedHistoryIds) => {
+        const { result }: RenderHookResult<UseSubmissionHistoryResult, unknown> = renderHook(
+            () => useSubmissionHistory({
+                datas: submissions,
+                filteredAll: submissions,
+                isSubmissionTab: true,
+                maxVisibleSubmissions: getChallengeSubmissionSelectionLimit({
+                    metadata: [{ name: 'submissionLimit', value: value as string }],
+                    track: { id: 'track-1', name: track as string },
+                }),
+            }),
+        )
+
+        expect(result.current.shouldShowHistoryActions)
+            .toBe(true)
+
+        act(() => {
+            result.current.openHistoryModal('member-1', 'latest-submission')
+        })
+
+        expect(result.current.historyEntriesForModal.map(entry => entry.id))
+            .toEqual(expectedHistoryIds)
+
+        act(() => {
+            result.current.closeHistoryModal()
+        })
+
+        expect(result.current.historyKey)
+            .toBeUndefined()
+    })
+})

--- a/src/apps/review/src/lib/hooks/useSubmissionHistory.ts
+++ b/src/apps/review/src/lib/hooks/useSubmissionHistory.ts
@@ -15,8 +15,8 @@ interface UseSubmissionHistoryParams {
     filteredAll: SubmissionInfo[]
     /** Whether the consuming table supports submission-history actions. */
     isSubmissionTab: boolean
-    /** Positive latest-submission count per member/type group. Defaults to one. */
-    maxVisibleSubmissions?: number
+    /** Positive count per member/type group, or undefined for unlimited Design submissions without history actions. */
+    maxVisibleSubmissions: number | undefined
 }
 
 export interface UseSubmissionHistoryResult {
@@ -32,6 +32,7 @@ export interface UseSubmissionHistoryResult {
 
 /**
  * Encapsulate submission-history ranking and modal state for Review tables.
+ * Hide history actions when unlimited Design submissions are already displayed separately.
  *
  * @param params - Primary rows, complete matching history, table mode, and visible count.
  * @returns Latest selected rows and IDs, older member/type history, and modal callbacks.
@@ -57,8 +58,8 @@ export function useSubmissionHistory({
     }: SubmissionHistoryPartition = submissionHistory
 
     const shouldShowHistoryActions = useMemo<boolean>(
-        () => isSubmissionTab && hasIsLatestFlag(datas),
-        [datas, isSubmissionTab],
+        () => maxVisibleSubmissions !== undefined && isSubmissionTab && hasIsLatestFlag(datas),
+        [datas, isSubmissionTab, maxVisibleSubmissions],
     )
 
     const [historyKey, setHistoryKey] = useState<string | undefined>(undefined)


### PR DESCRIPTION
## Related JIRA Ticket:
[PM-5777](https://topcoder.atlassian.net/browse/PM-5777)

# What's in this PR?
Unlimited Design challenges display submissions separately but still offer View Submission History, which repeats entries already visible in the table. Hide that action in the submissions tab and the shared reviewer/submitter history logic when the existing challenge selection policy identifies unlimited Design submissions.

Design challenges that default to unlimited because submission-limit metadata is absent also keep every submission visible. Limited Design challenges and other tracks retain their existing submission rows and history actions, including Development, First2Finish, Marathon Match, and QA scenarios with unlimited metadata.

Validation: all 54 tests across five focused suites pass, including desktop/mobile rendering and opening history for unaffected challenges. `yarn lint` and `yarn run build` pass; the build reports existing dependency source-map and lint warnings.


[PM-5777]: https://topcoder.atlassian.net/browse/PM-5777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ