### PR TITLE
PM-6192 Fix challenge editor freeze during reviewer hydration -> dev

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/README.md
@@ -28,6 +28,10 @@
 
 ## Validation Rules
 
+In the simplified Design reviewer editor, the selected copilot controls Checkpoint Review, Review,
+and Approval assignments. Resource hydration restores saved screeners without overwriting those
+copilot-controlled assignments, including after a manual save resets the form to clean state.
+
 The form uses `challengeBasicInfoSchema` from `src/apps/work/src/lib/schemas/challenge-editor.schema.ts`.
 
 - `name`: required, max 200 chars; special and non-ASCII characters are allowed.

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.spec.tsx
@@ -273,6 +273,8 @@ function createDeferredPromise<T>(): DeferredPromise<T> {
 interface TestHarnessProps {
     defaultValues?: Partial<ChallengeEditorFormData>
     initialScorecardErrorMessage?: string
+    maxRenders?: number
+    onSave?: (values: ChallengeEditorFormData) => void
     restoreStaleAdditionalMemberIds?: boolean
     restoreStaleScorecardId?: boolean
     showAdditionalMemberIdsValue?: boolean
@@ -413,7 +415,20 @@ const StaleScorecardIdReporter = (): JSX.Element => {
     return <div data-testid='stale-scorecard-renders'>{renderCountRef.current}</div>
 }
 
+/**
+ * Renders the reviewer editor with optional saved-form resets and a bounded render guard.
+ *
+ * @param props initial form data, visible state markers, and optional save/render checks.
+ * @returns the editor and controls used by reviewer regression tests.
+ * @throws when the configured render limit detects an assignment feedback loop.
+ */
 const TestHarness = (props: TestHarnessProps): JSX.Element => {
+    const renderCountRef = useRef<number>(0)
+    renderCountRef.current += 1
+    if (props.maxRenders && renderCountRef.current > props.maxRenders) {
+        throw new Error('Reviewer assignment hydration did not settle')
+    }
+
     const formMethods = useForm<ChallengeEditorFormData>({
         defaultValues: {
             ...baseDefaultValues,
@@ -423,6 +438,10 @@ const TestHarness = (props: TestHarnessProps): JSX.Element => {
     const roleValueIndex = props.showRoleValueIndex ?? 0
     const scorecardValueIndex = props.showScorecardValueIndex ?? 0
     const memberValueIndex = props.showMemberValueIndex ?? 0
+    const saveAndReset = formMethods.handleSubmit(values => {
+        formMethods.reset(values)
+        props.onSave?.(values)
+    })
 
     useEffect(() => {
         if (!props.initialScorecardErrorMessage) {
@@ -441,6 +460,9 @@ const TestHarness = (props: TestHarnessProps): JSX.Element => {
     return (
         <FormProvider {...formMethods}>
             <HumanReviewTab screenerOnly={props.screenerOnly} />
+            {props.onSave
+                ? <button onClick={saveAndReset} type='button'>Update Challenge</button>
+                : undefined}
             {props.restoreStaleAdditionalMemberIds
                 ? <StaleAdditionalMemberIdsReporter />
                 : undefined}
@@ -1209,6 +1231,91 @@ describe('HumanReviewTab', () => {
                 ]))
         })
     })
+
+    it.each(['current.copilot', 'new.copilot', '12345', ''])(
+        'keeps simplified copilot assignments stable with persisted resources and copilot "%s"',
+        async copilot => {
+            const phaseNames = ['Checkpoint Screening', 'Checkpoint Review', 'Screening', 'Review', 'Approval']
+            const roleNames = ['Checkpoint Screener', 'Checkpoint Reviewer', 'Screener', 'Reviewer', 'Approver']
+            const phases = phaseNames.map((name, index) => ({ name, phaseId: `phase-${index}` }))
+            const reviewers = phases.map(phase => ({
+                isMemberReview: true,
+                memberReviewerCount: 1,
+                phaseId: phase.phaseId,
+                scorecardId: `scorecard-${phase.phaseId}`,
+                shouldOpenOpportunity: false,
+            }))
+            const onSave = jest.fn()
+
+            mockedUseFetchChallengeTracks.mockReturnValue({
+                tracks: [{ id: 'track-1', name: 'Design', track: 'DESIGN' }],
+            })
+            mockedUseFetchResourceRoles.mockReturnValue({
+                isLoading: false,
+                resourceRoles: roleNames.map((name, index) => ({ id: `role-${index}`, name })),
+            })
+            mockedUseFetchResources.mockReturnValue({
+                isLoading: false,
+                mutate: jest.fn()
+                    .mockResolvedValue(undefined),
+                resources: roleNames.map((name, index) => ({
+                    memberHandle: name.includes('Screener') ? 'saved.screener' : 'current.copilot',
+                    memberId: name.includes('Screener') ? '67890' : '12345',
+                    roleId: `role-${index}`,
+                })),
+            })
+            mockedFetchDefaultReviewers.mockResolvedValue(reviewers)
+            mockedFetchScorecards.mockResolvedValue(phases.map(phase => ({
+                id: `scorecard-${phase.phaseId}`,
+                name: `${phase.name} Scorecard`,
+                type: phase.name.toUpperCase()
+                    .replace(/ /g, '_'),
+            })))
+
+            render(
+                <TestHarness
+                    defaultValues={{ copilot, phases, reviewers }}
+                    maxRenders={30}
+                    onSave={onSave}
+                    screenerOnly
+                    showReviewersValue
+                />,
+            )
+
+            await waitFor(() => {
+                const rows = JSON.parse(screen.getByTestId('reviewers-value').textContent || '[]') as Reviewer[]
+                expect(rows.filter(row => ['phase-0', 'phase-2'].includes(row.phaseId || '')))
+                    .toEqual([
+                        expect.objectContaining({ memberId: '67890' }),
+                        expect.objectContaining({ memberId: '67890' }),
+                    ])
+                expect(rows.filter(row => ['phase-1', 'phase-3', 'phase-4'].includes(row.phaseId || '')))
+                    .toEqual([1, 3, 4].map(index => expect.objectContaining({
+                        memberReviewerCount: 1,
+                        phaseId: `phase-${index}`,
+                        shouldOpenOpportunity: false,
+                    })))
+                rows.filter(row => ['phase-1', 'phase-3', 'phase-4'].includes(row.phaseId || ''))
+                    .forEach(row => {
+                        expect(row.handle)
+                            .toBe(copilot && copilot !== '12345' ? copilot : undefined)
+                        expect(row.memberId)
+                            .toBe(copilot === '12345' ? copilot : undefined)
+                    })
+            })
+
+            // Manual saves reset the form to clean state, which re-enables resource hydration.
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: 'Update Challenge' }))
+            })
+            await waitFor(() => {
+                expect(onSave)
+                    .toHaveBeenCalledTimes(1)
+                expect(JSON.parse(screen.getByTestId('reviewers-value').textContent || '[]'))
+                    .toEqual(JSON.parse(JSON.stringify(onSave.mock.calls[0][0].reviewers)))
+            })
+        },
+    )
 
     it('marks Screening and Checkpoint Screening member assignments optional', () => {
         mockedUseFetchChallengeTracks.mockReturnValue({

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/HumanReviewTab.tsx
@@ -851,7 +851,8 @@ function mapDefaultReviewerToReviewer(
  * assignments and valid custom selections while repairing missing, duplicate, or stale rows.
  * @remarks Checkpoint Review, Review, and Approval are always private and assigned to the selected
  * copilot. The helper is used before save validation because those rows are hidden in simplified
- * mode and cannot be repaired manually by the user.
+ * mode and cannot be repaired manually by the user. Resource hydration must leave these assignments
+ * to this helper so persisted member ids cannot conflict with the selected copilot handle.
  * @throws Does not throw.
  */
 function reconcileSimplifiedDesignReviewerDefaults(params: {
@@ -1895,6 +1896,18 @@ export const HumanReviewTab: FC<HumanReviewTabProps> = (props: HumanReviewTabPro
                     return
                 }
 
+                // Simplified Design defaults own these assignments. Restoring a persisted member id
+                // here would fight the copilot handle normalization on every subsequent render.
+                if (
+                    props.screenerOnly
+                    && isDesignTrackSelected
+                    && DESIGN_COPILOT_REVIEW_PHASE_KEYS.has(
+                        normalizeKey(phaseNameById.get(normalizeText(reviewer.phaseId))),
+                    )
+                ) {
+                    return
+                }
+
                 const assignedResources = assignedResourcesByReviewer[reviewerIndex] || []
                 const assignment = getHydratedReviewerAssignment(
                     reviewer,
@@ -1926,9 +1939,11 @@ export const HumanReviewTab: FC<HumanReviewTabProps> = (props: HumanReviewTabPro
         challengeResourcesResult.resources,
         formContext,
         getReviewerFieldIndex,
+        isDesignTrackSelected,
         isFormDirty,
         normalizedChallengeId,
         phaseNameById,
+        props.screenerOnly,
         resourceRoles,
         reviewerRows,
     ])


### PR DESCRIPTION
## Related JIRA Ticket:

[PM-6192](https://topcoder.atlassian.net/browse/PM-6192)

# What's in this PR?

Fixes the remaining Design challenge editor freeze when clicking **Update Challenge** or editing final deliverable file types. The simplified reviewer defaults cleared private reviewers' numeric member IDs in favor of the selected copilot handle, while resource hydration restored those IDs on every render, creating an endless update loop.

Resource hydration now leaves Checkpoint Review, Review, and Approval assignments to the selected copilot in the simplified Design editor. Saved screeners and the full reviewer editor retain their existing hydration behavior. Adds bounded regression coverage for existing, changed, numeric, and missing copilot selections, including manual save/reset, and documents assignment ownership.

## Validation

- Reproduced the freeze on the supplied challenge using the deployed app and unmodified `dev` locally; the browser profile identified the conflicting reviewer effects.
- Verified the fixed local app against the dev API: **Update Challenge** returned HTTP 200, navigated to `/view`, and remained responsive with no JavaScript errors.
- Verified adding and removing a final deliverable file type remains responsive with no JavaScript errors.
- All 143 tests passed across `HumanReviewTab`, `ReviewersField`, and `ChallengeEditorForm`, including the new regression cases.
- `yarn lint` passed.
- `yarn run build` passed with existing warnings.


[PM-6192]: https://topcoder.atlassian.net/browse/PM-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ