### PR TITLE
PM-6193 Keep checkpoint feedback arrow with its label

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -331,10 +331,12 @@ handoff. Review Style uses the authored document-search rail icon. Development
 challenges omit Challenge Links, Source files, and Submission limit while
 adding the published AI Reviewers help and Usable Code rules to Educational
 Materials; the latter two submission sections remain Design-only. Learning
-arrows flow immediately after wrapped labels, and the AI Exponential promo
-keeps a distinct gap before its action. Marathon Match challenges replace the
-general AI Exponential promo with the Marathon Match Tournament heading and
-copy. Its Explore the program link opens the environment's Marathon Match
+arrows flow immediately after wrapped labels. The Design link reads “How to
+approach checkpoint feedback” and keeps “feedback” and its arrow together when
+wrapping. The AI Exponential promo keeps a distinct gap before its action.
+Marathon Match challenges replace the general AI Exponential promo with the
+Marathon Match Tournament heading and copy. Its Explore the program link opens
+the environment's Marathon Match
 Tournament page in a new tab, while the Educational Materials link retains the
 published competition guide.
 

--- a/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.module.scss
@@ -143,6 +143,10 @@
     }
 }
 
+.learningLinkEnd {
+    white-space: nowrap;
+}
+
 .infoSection {
     display: flex;
     flex-direction: column;

--- a/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx
@@ -208,7 +208,7 @@ describe('ChallengeSidebar Review Style', () => {
             .toHaveAttribute('target', '_blank')
         expect(screen.queryByRole('heading', { name: 'Join the AI Exponential league' }))
             .not.toBeInTheDocument()
-        expect(screen.getByRole('link', { name: 'How to Compete on Marathon Match' }))
+        expect(screen.getByRole('link', { name: 'How to Compete in a Marathon Match' }))
             .toHaveAttribute('href', marathonMatchLearningUrl)
         expect(screen.getByRole('link', { name: 'Topcoder Challenges Explained' })
             .querySelector('img'))
@@ -238,7 +238,7 @@ describe('ChallengeSidebar Review Style', () => {
             .toHaveAttribute('href', usableCodeRulesUrl)
         expect(screen.queryByRole('link', { name: 'How to compete in design challenges' }))
             .not.toBeInTheDocument()
-        expect(screen.queryByRole('link', { name: 'How to approach the checkpoint feedback' }))
+        expect(screen.queryByRole('link', { name: 'How to approach checkpoint feedback' }))
             .not.toBeInTheDocument()
         expect(screen.queryByRole('heading', { name: 'Submission Format' }))
             .not.toBeInTheDocument()
@@ -309,12 +309,12 @@ describe('ChallengeSidebar Review Style', () => {
                 'href',
                 designChallengeLearningUrl,
             )
-        expect(screen.getByRole('link', { name: 'How to approach the checkpoint feedback' }))
+        expect(screen.getByRole('link', { name: 'How to approach checkpoint feedback' }))
             .toHaveAttribute(
                 'href',
                 checkpointFeedbackLearningUrl,
             )
-        expect(screen.getByRole('link', { name: 'How to approach the checkpoint feedback' }).className)
+        expect(screen.getByRole('link', { name: 'How to approach checkpoint feedback' }).className)
             .toContain('learningLink')
         expect(screen.getByRole('heading', { name: 'Source files' }))
             .toBeInTheDocument()

--- a/src/apps/opportunities/src/components/ChallengeSidebar.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSidebar.tsx
@@ -382,8 +382,12 @@ export const ChallengeSidebar: FC<ChallengeSidebarProps> = props => {
                             rel='noreferrer'
                             target='_blank'
                         >
-                            How to approach the checkpoint feedback
-                            <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
+                            How to approach checkpoint
+                            {' '}
+                            <span className={styles.learningLinkEnd}>
+                                feedback
+                                <img alt='' aria-hidden='true' src={sidebarArrowIcon} />
+                            </span>
                         </a>
                     </>
                 )}


### PR DESCRIPTION
QA reported that the checkpoint-feedback link's arrow could wrap onto a line by itself after the earlier PM-6193 fix. The link now reads **How to approach checkpoint feedback**, as requested in the latest ticket reply, and groups **feedback** with the arrow so they wrap together with the existing 4px spacing.

Updates the sidebar documentation and existing link-label assertions. Also corrects the sidebar suite's stale Marathon Match label expectation to match the wording already on `dev`.

Validation:
- `yarn lint`
- `yarn run build` — passed with dependency source-map and unrelated CSS-order warnings.
- `yarn test:no-watch --runInBand --runTestsByPath src/apps/opportunities/src/components/ChallengeSidebar.spec.tsx` — 13 tests passed.
- Chromium layout check using the actual Educational Materials JSX, compiled sidebar SCSS, and Nunito Sans font at card widths of 384, 340, 320, 288, and 260px. The checkpoint link fits on one line at 384px; at narrower widths, the final word and arrow wrap together without overflow and retain a 4px gap.

Ticket: [PM-6193](https://topcoder.atlassian.net/browse/PM-6193)


[PM-6193]: https://topcoder.atlassian.net/browse/PM-6193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ