### PR TITLE
[PM-6184] Fix Marathon submission date alignment -> dev

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -280,6 +280,9 @@ as Failed in the Provisional process with explicit 0% progress; later review
 failures remain System failures. Their actions include the clean submission,
 scorer artifacts, and submission history, while the single page-level button
 owns the Review App handoff.
+The Marathon Match My Submissions table reserves enough width for the complete
+submission timestamp and keeps its date heading and sort icon on one line,
+aligned with the dates beneath it. Score columns remain right aligned.
 Submission history replaces the unreliable status field with Final Score and
 uses a responsive table that scrolls only on narrow viewports. Design
 submissions can be deleted only while Submission or Checkpoint Submission is

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
@@ -459,13 +459,22 @@
 
 .myMarathonTable {
     th:first-child { width: 138px; }
-    th:nth-child(2) { width: 160px; }
-    th:nth-child(3),
-    th:nth-child(4) { width: 168px; }
+    th:nth-child(2) { width: 208px; }
+    th:nth-child(3) { width: 168px; }
+    th:nth-child(4) { width: 120px; }
     th:nth-child(5) { width: 149px; }
     th:nth-child(6) { width: 120px; }
     th:nth-child(7) { width: 141px; }
     th:nth-child(8) { width: 108px; }
+
+    th:nth-child(2),
+    td:nth-child(2) {
+        white-space: nowrap;
+    }
+
+    .sortedHeader svg {
+        flex-shrink: 0;
+    }
 
     .scoreColumn {
         text-align: right;


### PR DESCRIPTION
## Related JIRA Ticket

[PM-6184](https://topcoder.atlassian.net/browse/PM-6184)

## What's in this PR?

QA's September 7 follow-up to #2228 reports that the Marathon Match My Submissions date column is still misaligned. Its 160px width forces the sortable heading onto two lines and wraps the timestamps.

Give the date column 208px by reallocating unused Test Status space, keeping the table's total width unchanged. Keep the heading and timestamps on one line and prevent the sort icon from shrinking. The change is scoped to Marathon Match My Submissions and preserves the right-aligned scores and failed-test `0%` display that QA confirmed were resolved.

## Validation

- `yarn lint` passed.
- `yarn run build` passed with the existing source-map and CSS-order warnings.
- Two existing focused suites: 37 tests passed (challenge-detail flows and Marathon Match utilities).
- Chromium layout verification using compiled application SCSS and representative table markup at 1500, 1280, 1024, 768, 620, and 375px: single-line date heading and timestamps, matching left alignment, 16px sort icon, and right-aligned score cells. Mobile table scrolling remains contained within its card.

## QA verification

Open a Marathon Match challenge's My Submissions tab with September timestamps. Confirm that Submission Date shares the other headings' line, dates align beneath it, and both date sort directions still work. Check that failed attempts display `0%` and that both score columns remain right aligned.


[PM-6184]: https://topcoder.atlassian.net/browse/PM-6184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ