### PR TITLE
PM-5206 - allow admin to re-queue workflows if they were missed on vi…

### DIFF
--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 /* eslint-disable max-len */
-import { FC, MouseEvent as ReactMouseEvent, useCallback, useContext, useMemo, useState } from 'react'
+import { FC, MouseEvent as ReactMouseEvent, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import { useSWRConfig } from 'swr'
@@ -20,6 +20,8 @@ import {
     AiWorkflowRunsResponse,
     AiWorkflowRunStatusEnum,
     getAiWorkflowRunsCacheKey,
+    queueAiWorkflowRuns,
+    QueueAiWorkflowRunsResponse,
     retriggerAiWorkflowRun,
     useFetchAiWorkflowsRuns,
     useRolePermissions,
@@ -331,6 +333,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
     const { isAdmin, hasSubmitterRole, hasCopilotRole, isProjectManager }: UseRolePermissionsResult = rolePermissions
     const { mutate }: FullConfiguration = useSWRConfig()
     const [, setRerunningRunId] = useState<string | undefined>(undefined)
+    const [queueingRuns, setQueueingRuns] = useState<boolean>(false)
 
     /**
      * Only Copilot, Project Manager, and Admin can see WHO performed the action.
@@ -354,6 +357,66 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
             setRerunningRunId(undefined)
         }
     }, [mutate, props.submission.id])
+
+    /**
+     * Queues the AI workflow runs that are configured for the submission but were
+     * never queued, e.g. because the virus scan / AI phase opened event was missed.
+     */
+    const handleQueueMissingRuns = useCallback(async (): Promise<void> => {
+        setQueueingRuns(true)
+        try {
+            const result: QueueAiWorkflowRunsResponse = await queueAiWorkflowRuns(props.submission.id)
+            await mutate(getAiWorkflowRunsCacheKey(props.submission.id))
+
+            if (result.queued) {
+                toast.success(`Queued ${result.runs.length} AI review(s).`)
+            } else {
+                toast.info(result.message || 'There are no AI reviews to queue for this submission.')
+            }
+        } catch (error) {
+            handleError(error as Error)
+            toast.error('Failed to queue the AI review(s).')
+        } finally {
+            setQueueingRuns(false)
+        }
+    }, [mutate, props.submission.id])
+
+    /**
+     * Admin only action rendered next to the run result:
+     * - a workflow with no run at all can be queued manually
+     * - an existing (finished) run can be re-run
+     */
+    const buildRowAction = useCallback((row: AiReviewerRow): ReactNode => {
+        if (!isAdmin || row.run?.id === '-1') {
+            return undefined
+        }
+
+        if (!row.run) {
+            // The run was never queued for this workflow
+            return props.submission.virusScan === true && (
+                <Tooltip content='Queue this AI review'>
+                    <IconOutline.PlayIcon
+                        className={classNames('icon-lg', styles.reRunIcon)}
+                        onClick={queueingRuns ? undefined : handleQueueMissingRuns}
+                    />
+                </Tooltip>
+            )
+        }
+
+        const runId = row.run.id
+        if (!runId || row.status === 'pending') {
+            return undefined
+        }
+
+        return (
+            <Tooltip content='Re-run the workflow'>
+                <IconOutline.RefreshIcon
+                    className={classNames('icon-lg', styles.reRunIcon)}
+                    onClick={function onClick() { handleRerun(runId) }}
+                />
+            </Tooltip>
+        )
+    }, [handleQueueMissingRuns, handleRerun, isAdmin, props.submission.virusScan, queueingRuns])
 
     const failedGatingReviewers = useMemo(
         () => reviewerRows
@@ -548,20 +611,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
                                 <AiWorkflowRunStatus
                                     run={row.run}
                                     status={row.status}
-                                    action={
-                                        row.run?.id
-                                        && row.run?.id !== '-1'
-                                        && isAdmin
-                                        && row.status !== 'pending'
-                                        && (
-                                            <Tooltip content='Re-run the workflow'>
-                                                <IconOutline.RefreshIcon
-                                                    className={classNames('icon-lg', styles.reRunIcon)}
-                                                    onClick={function onClick() { handleRerun(row.run!.id) }}
-                                                />
-                                            </Tooltip>
-                                        )
-                                    }
+                                    action={buildRowAction(row)}
                                 />
                             </div>
                         </div>
@@ -682,20 +732,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
                                 <AiWorkflowRunStatus
                                     status={row.status}
                                     run={row.run}
-                                    action={
-                                        row.run?.id
-                                        && row.run?.id !== '-1'
-                                        && isAdmin
-                                        && row.status !== 'pending'
-                                        && (
-                                            <Tooltip content='Re-run the workflow'>
-                                                <IconOutline.RefreshIcon
-                                                    className={classNames('icon-lg', styles.reRunIcon)}
-                                                    onClick={function onClick() { handleRerun(row.run!.id) }}
-                                                />
-                                            </Tooltip>
-                                        )
-                                    }
+                                    action={buildRowAction(row)}
                                 />
                             </td>
                             <td>

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiReviewsTable.tsx
@@ -394,7 +394,7 @@ const AiReviewsTable: FC<AiReviewsTableProps> = props => {
         if (!row.run) {
             // The run was never queued for this workflow
             return props.submission.virusScan === true && (
-                <Tooltip content='Queue this AI review'>
+                <Tooltip content='Queue missing AI reviews'>
                     <IconOutline.PlayIcon
                         className={classNames('icon-lg', styles.reRunIcon)}
                         onClick={queueingRuns ? undefined : handleQueueMissingRuns}

--- a/src/apps/review/src/lib/components/AiReviewsTable/AiWorkflowRunStatus.tsx
+++ b/src/apps/review/src/lib/components/AiReviewsTable/AiWorkflowRunStatus.tsx
@@ -108,6 +108,8 @@ export const AiWorkflowRunStatus: FC<AiWorkflowRunStatusProps> = props => {
                     action={props.action}
                 />
             )}
+            {/* No status to render, but the caller still has an action to offer (e.g. queue a missing run) */}
+            {!displayStatus && props.action}
         </>
     )
 }

--- a/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
+++ b/src/apps/review/src/lib/hooks/useFetchAiWorkflowRuns.ts
@@ -15,6 +15,7 @@ export enum AiWorkflowRunStatusEnum {
     IN_PROGRESS = 'IN_PROGRESS',
     CANCELLED = 'CANCELLED',
     FAILURE = 'FAILURE',
+    TIMEOUT = 'TIMEOUT',
     COMPLETED = 'COMPLETED',
     SUCCESS = 'SUCCESS',
 }
@@ -118,6 +119,17 @@ interface RetriggerAiWorkflowRunRequest {
     workflowRunId: string
 }
 
+interface QueueAiWorkflowRunsRequest {
+    submissionId: string
+    ignoreAiPhaseState?: boolean
+}
+
+export interface QueueAiWorkflowRunsResponse {
+    queued: boolean
+    runs: AiWorkflowRun[]
+    message: string
+}
+
 export const aiRunInProgress = (aiRun: Pick<AiWorkflowRun, 'status'>): boolean => [
     AiWorkflowRunStatusEnum.INIT,
     AiWorkflowRunStatusEnum.QUEUED,
@@ -128,6 +140,7 @@ export const aiRunInProgress = (aiRun: Pick<AiWorkflowRun, 'status'>): boolean =
 export const aiRunFailed = (aiRun: Pick<AiWorkflowRun, 'status'>): boolean => [
     AiWorkflowRunStatusEnum.FAILURE,
     AiWorkflowRunStatusEnum.CANCELLED,
+    AiWorkflowRunStatusEnum.TIMEOUT,
 ].includes(aiRun.status)
 
 export function useFetchAiWorkflowsRuns(
@@ -288,5 +301,20 @@ export const retriggerAiWorkflowRun = async (workflowRunId: string): Promise<AiW
     xhrPostAsync<RetriggerAiWorkflowRunRequest, AiWorkflowRun>(
         `${TC_API_BASE_URL}/workflows/runs/retrigger`,
         { workflowRunId },
+    )
+)
+
+/**
+ * Manually queues the AI workflow runs configured for a submission.
+ * Used to recover submissions whose runs were never queued because the
+ * virus scan / AI phase opened event was missed.
+ */
+export const queueAiWorkflowRuns = async (
+    submissionId: string,
+    ignoreAiPhaseState?: boolean,
+): Promise<QueueAiWorkflowRunsResponse> => (
+    xhrPostAsync<QueueAiWorkflowRunsRequest, QueueAiWorkflowRunsResponse>(
+        `${TC_API_BASE_URL}/workflows/runs/queue`,
+        { ignoreAiPhaseState, submissionId },
     )
 )


### PR DESCRIPTION
…russcan

<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-5206


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request adds the ability for admins to manually queue missing AI workflow runs for a submission in the `AiReviewsTable` component, improving recovery from missed events and enhancing workflow management. It also introduces better action rendering for AI review rows and updates workflow run status handling.

**New admin controls for AI workflow runs:**
- Added a "Queue missing AI reviews" action for admins, allowing them to manually queue AI workflow runs that were never started due to missed events (e.g., virus scan/AI phase triggers). This includes UI feedback for success, info, and error cases. (`AiReviewsTable.tsx`, `useFetchAiWorkflowRuns.ts`) [[1]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840R23-R24) [[2]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840R336) [[3]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840R361-R420) [[4]](diffhunk://#diff-7905bccab218f33a8726466483e54a6e3855be51f50b16d37b12c634f30d65daR122-R132) [[5]](diffhunk://#diff-7905bccab218f33a8726466483e54a6e3855be51f50b16d37b12c634f30d65daR306-R320)

**UI improvements and refactoring:**
- Refactored action rendering for each AI review row into a dedicated `buildRowAction` function, consolidating logic for both queueing missing runs and re-running existing ones. Action buttons are now consistently rendered via this function. (`AiReviewsTable.tsx`) [[1]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840R361-R420) [[2]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840L551-R614) [[3]](diffhunk://#diff-757bf85b34e2d6dc3d710ef85ab66ba320ab8d265c9040fe6d6b699cecf4b840L685-R735)
- Updated `AiWorkflowRunStatus` to render actions even when there is no status to display, ensuring the queue action appears in all necessary cases. (`AiWorkflowRunStatus.tsx`)

**Workflow status enhancements:**
- Added a new `TIMEOUT` status to `AiWorkflowRunStatusEnum` and included it in the list of statuses considered as failed. (`useFetchAiWorkflowRuns.ts`) [[1]](diffhunk://#diff-7905bccab218f33a8726466483e54a6e3855be51f50b16d37b12c634f30d65daR18) [[2]](diffhunk://#diff-7905bccab218f33a8726466483e54a6e3855be51f50b16d37b12c634f30d65daR143)

These changes improve the robustness and usability of the AI review workflow management, especially for admin users.