### PR TITLE
fix(PM-6095): handle Report an Issue attachment upload failures

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -367,6 +367,11 @@ S3 bucket. Because support-api-v6 accepts only `challengeId` and Markdown
 category, body, and any uploaded links into that description without inventing
 unsupported request fields.
 
+Attachment gateway, network, and timeout failures display a readable error and
+preserve the report fields. A failed attachment blocks sending until the member
+removes it; the member can then drop or select it again to retry, or send the
+report without it. Successful uploads remain attached throughout this recovery.
+
 The challenge rail parses case-insensitive `fileTypes`, `allowStockArt`,
 `submissionLimit`, `environment`, and `codeRepo` metadata, shows safe Challenge
 API discussions and attachments, and fails closed for unsafe or retired-host

--- a/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.spec.tsx
@@ -208,6 +208,53 @@ describe('ReportIssueModal', () => {
             .not.toHaveBeenCalled()
     })
 
+    it('keeps a failed dropped file visible and requires its removal before sending', async () => {
+        const message = 'Attachment uploads are temporarily unavailable. Please try again.'
+        mockedUploadAttachment.mockRejectedValueOnce(new Error(message))
+        render(<ReportIssueModal onClose={jest.fn()} open />)
+        fireEvent.change(screen.getByPlaceholderText('Enter the subject of your issue'), {
+            target: { value: 'Submission timeout' },
+        })
+        fireEvent.change(screen.getByRole('combobox', { name: /Category/ }), {
+            target: { value: 'Submission' },
+        })
+        fireEvent.change(screen.getByPlaceholderText('Explain your issue'), {
+            target: { value: 'The submission failed.' },
+        })
+        const file = new File(['screenshot'], 'Screenshot.png', { type: 'image/png' })
+        fireEvent.drop(screen.getByRole('button', { name: /Drop your file/ }), {
+            dataTransfer: { files: [file] },
+        })
+
+        expect(await screen.findByRole('alert'))
+            .toHaveTextContent(message)
+        expect(mockedUploadAttachment)
+            .toHaveBeenCalledWith(file)
+        expect(screen.getByPlaceholderText('Explain your issue'))
+            .toHaveValue('The submission failed.')
+        expect(screen.getByRole('button', { name: 'Send report' }))
+            .toBeDisabled()
+        expect(mockedCreateSupportTicket)
+            .not.toHaveBeenCalled()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Remove Screenshot.png' }))
+        expect(screen.queryByRole('alert'))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Send report' }))
+            .toBeEnabled()
+
+        fireEvent.drop(screen.getByRole('button', { name: /Drop your file/ }), {
+            dataTransfer: { files: [file] },
+        })
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Send report' }))
+            .toBeEnabled())
+        fireEvent.click(screen.getByRole('button', { name: 'Send report' }))
+        await waitFor(() => expect(mockedCreateSupportTicket)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                description: expect.stringContaining('[Screenshot.png](https://files.example/Screenshot.png)'),
+            })))
+    })
+
     it('builds stable Markdown for multiple uploaded attachments', () => {
         expect(buildReportIssueDescription(' Subject ', ' Other ', ' Details ', [{
             filename: '[log].txt',

--- a/src/apps/opportunities/src/components/ReportIssueModal.tsx
+++ b/src/apps/opportunities/src/components/ReportIssueModal.tsx
@@ -95,7 +95,8 @@ export function buildReportIssueDescription(
  * Renders both authored Report an Issue states while adapting their richer
  * fields to support-api-v6's challenge-id plus Markdown-description contract.
  * Attachments are optional and upload through the authenticated Support API
- * before submission.
+ * before submission. Failed attachments must be removed before submission so
+ * files the member intended to include are never silently omitted.
  *
  * @param props optional challenge context and modal state.
  * @returns subject, category, description, attachment, and success states.
@@ -113,6 +114,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
     const attachmentId = useRef(0)
     const fileInput = useRef<HTMLInputElement>(null)
     const uploading = attachments.some(attachment => attachment.status === 'uploading')
+    const uploadFailed = attachments.some(attachment => attachment.status === 'error')
     const uploaded = attachments
         .filter((attachment): attachment is IssueAttachment & { result: SupportAttachmentUploadResult } => (
             attachment.status === 'uploaded' && !!attachment.result
@@ -121,6 +123,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
         && !!category
         && !!description.trim()
         && !uploading
+        && !uploadFailed
         && !busy
 
     /**
@@ -224,7 +227,8 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
     }
 
     /**
-     * Removes one uploaded, pending, or failed attachment from the report.
+     * Removes one uploaded, pending, or failed attachment from the report and
+     * clears the form error so the member can retry or submit without the file.
      *
      * @param id local attachment identifier.
      * @returns void.
@@ -232,6 +236,7 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
      */
     const removeAttachment = (id: number): void => {
         setAttachments(current => current.filter(attachment => attachment.id !== id))
+        setError(undefined)
     }
 
     /**
@@ -439,6 +444,9 @@ export const ReportIssueModal: FC<ReportIssueModalProps> = props => {
                         </div>
                     )}
                     {error && <p className={styles.error} role='alert'>{error}</p>}
+                    {uploadFailed && (
+                        <p>Remove the failed file to try again or send your report without it.</p>
+                    )}
                 </div>
             )}
         </BaseModal>

--- a/src/apps/support/README.md
+++ b/src/apps/support/README.md
@@ -33,7 +33,10 @@ one `file` field as authenticated multipart form data to
 `POST /v6/support/attachments`; support-api-v6 then uses the standard hosted
 upload flow and returns the canonical HTTPS URL inserted into Markdown. The
 browser never connects directly to the configured storage bucket. Both the UI
-and API enforce a 2 MiB limit. The Support editor and API share the exact
+and API enforce a 2 MiB limit. Upload requests have a 30-second client timeout;
+gateway errors (502/503/504), network failures, and timeouts show a readable
+temporary-unavailability message without displaying the gateway HTML. The client
+does not automatically retry uploads. The Support editor and API share the exact
 extension/MIME allowlist: `.7z`, `.bmp`, `.csv`, `.doc`, `.docx`, `.gif`, `.gz`,
 `.jpeg`, `.jpg`, `.json`, `.log`, `.pdf`, `.png`, `.ppt`, `.pptx`, `.rar`,
 `.tar`, `.tgz`, `.tif`, `.tiff`, `.txt`, `.webp`, `.xls`, `.xlsx`, `.xml`, and

--- a/src/apps/support/src/lib/services/support-attachment.service.spec.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.spec.ts
@@ -46,6 +46,7 @@ describe('Support attachment service', () => {
                         'Content-Type': 'multipart/form-data',
                     },
                     onUploadProgress: expect.any(Function),
+                    timeout: 30_000,
                 }),
             )
         const formData = mockedPost.mock.calls[0][1] as FormData
@@ -72,6 +73,37 @@ describe('Support attachment service', () => {
 
         expect(onProgress.mock.calls)
             .toEqual([[13], [100]])
+    })
+
+    it.each([502, 503, 504])('normalizes HTTP %s, including HTML gateway responses', async status => {
+        mockedPost.mockRejectedValue({
+            isAxiosError: true,
+            message: 'Request failed',
+            response: { data: '<html><h1>Bad Gateway</h1></html>', status },
+        })
+
+        await expect(uploadSupportAttachment(new File(['notes'], 'notes.txt', { type: 'text/plain' })))
+            .rejects.toThrow('Attachment uploads are temporarily unavailable. Please try again.')
+        expect(mockedPost)
+            .toHaveBeenCalledTimes(1)
+    })
+
+    it.each(['ERR_NETWORK', 'ECONNABORTED', 'ETIMEDOUT'])('normalizes %s failures', async code => {
+        mockedPost.mockRejectedValue({ code, isAxiosError: true })
+
+        await expect(uploadSupportAttachment(new File(['notes'], 'notes.txt', { type: 'text/plain' })))
+            .rejects.toThrow('Attachment uploads are temporarily unavailable. Please try again.')
+    })
+
+    it('preserves API validation failures', async () => {
+        const error = Object.assign(new Error('The file name is invalid.'), {
+            isAxiosError: true,
+            response: { status: 400 },
+        })
+        mockedPost.mockRejectedValue(error)
+
+        await expect(uploadSupportAttachment(new File(['notes'], 'notes.txt', { type: 'text/plain' })))
+            .rejects.toBe(error)
     })
 
     it('exports the API extension and MIME allowlist for upload controls', () => {

--- a/src/apps/support/src/lib/services/support-attachment.service.ts
+++ b/src/apps/support/src/lib/services/support-attachment.service.ts
@@ -1,4 +1,6 @@
 /** Authenticated attachment uploader for support-api-v6. */
+import { isAxiosError } from 'axios'
+
 import { xhrPostAsync } from '~/libs/core'
 
 import { SUPPORT_API_BASE } from './support.service'
@@ -72,7 +74,9 @@ export interface SupportAttachmentUploadResult {
  * @returns canonical hosted-file metadata for Markdown insertion.
  * @throws Error when no file is supplied, the file is empty, larger than 2 MiB,
  * does not match the Support API extension/MIME allowlist, or support-api-v6
- * rejects or cannot complete the upload.
+ * rejects or cannot complete the upload. Gateway, network, and timeout failures
+ * use a readable temporary-unavailability message. Requests time out after 30
+ * seconds, allowing the API's 20-second provider deadline to respond first.
  */
 export async function uploadSupportAttachment(
     file: File,
@@ -123,6 +127,17 @@ export async function uploadSupportAttachment(
                         : 0
                 options.onProgress(Math.max(0, Math.min(100, Math.round(ratio * 100))))
             },
+            timeout: 30_000,
         },
     )
+        .catch((error: unknown) => {
+            if (isAxiosError(error) && (
+                [502, 503, 504].includes(error.response?.status ?? 0)
+                || ['ERR_NETWORK', 'ECONNABORTED', 'ETIMEDOUT'].includes(error.code ?? '')
+            )) {
+                throw new Error('Attachment uploads are temporarily unavailable. Please try again.')
+            }
+
+            throw error
+        })
 }


### PR DESCRIPTION
When Report an Issue attachment uploads fail with a gateway response, the dialog currently shows a generic request error and can submit the report while silently omitting the failed file.

Give the shared Support attachment client a 30-second timeout and a readable message for gateway, network, and timeout failures. Preserve the report fields and block submission while a failed attachment remains. Members can remove the file and add it again to retry, or send the report without it.

Companion API fix: https://github.com/topcoder-platform/support-api-v6/pull/15

Validation:
- `yarn lint` passed.
- `yarn run build` passed with source-map and CSS ordering warnings in unchanged dependencies/styles.
- Focused Support attachment, ReportIssueModal, and SupportMarkdownEditor suites: 20 tests passed, including dropped-file failure, preserved text, removal, retry, and successful Markdown attachment submission.

Live verification limitation: the dev Filestack app reports HTTP 429 because of a free-plan limit or unpaid invoice. An account owner must resolve that restriction before successful live uploads can be verified.
