### PR TITLE
PM-6264: Handle empty Gig Work candidate searches

### DIFF
--- a/src/apps/gigs/README.md
+++ b/src/apps/gigs/README.md
@@ -30,8 +30,10 @@ use the refreshed platform token. Applications preserve the existing multipart
 resume may be reused; otherwise PDF/DOCX up to **8,000,000 bytes** is required to
 match the server's multer limit. No success state appears without an explicit
 `success: true` response. HTTP errors and Recruit error envelopes returned with
-HTTP 200 both reject. Candidate lookup failures block prefill/submission and
-expose a retry instead of being interpreted as new candidates.
+HTTP 200 both reject. Candidate searches return an existing profile from the
+`data` envelope. A bare `[]` or `{ data: [] }` means no existing candidate and
+opens the application form with the member's Topcoder profile. Candidate lookup
+failures still block prefill/submission and expose a retry.
 
 Candidate Terms and the Equal Employment Opportunity Policy load on demand
 from the existing Payload compatibility endpoint using the original modal IDs.
@@ -60,12 +62,14 @@ yarn build
 yarn test:no-watch --runInBand --watch=false --runTestsByPath \
   src/apps/gigs/src/gigs.utils.spec.ts \
   src/apps/gigs/src/gigs.service.spec.ts \
-  src/apps/gigs/src/components/GigApplicationForm.spec.tsx
+  src/apps/gigs/src/components/GigApplicationForm.spec.tsx \
+  src/apps/gigs/src/pages/GigApplyPage.spec.tsx
 ```
 
 The tests cover discovery rules, salary fallbacks, required fields, consent and
 availability, upload limits, legacy payload mapping, HTTP-200 error envelopes,
-expired authentication, prefill, submission retry and already-placed candidates.
+expired authentication, empty candidate search responses, candidate lookup retry,
+prefill, submission retry and already-placed candidates.
 Also verify the listing, detail and anonymous apply route against real Recruit
 reads in a browser at desktop and mobile widths. Authenticated submission tests
 use mocks so verification does not create real candidates or send recruiter

--- a/src/apps/gigs/src/gigs.service.spec.ts
+++ b/src/apps/gigs/src/gigs.service.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable sort-keys */
+/* eslint-disable sort-keys, unicorn/no-null */
 import { tokenGetAsync } from '~/libs/core'
 
 import { applyToGig, getCandidate, getGig, getGigs } from './gigs.service'
@@ -54,6 +54,22 @@ describe('Recruit API integration', () => {
         fetchMock.mockResolvedValue(response({ error: true }, 503))
         await expect(getCandidate('member@example.com')).rejects.toThrow()
     })
+    it('accepts Recruit\'s bare empty array for a member without a candidate profile', async () => {
+        fetchMock.mockResolvedValue(response([]))
+        await expect(getCandidate('member@example.com')).resolves.toBeUndefined()
+    })
+    it('returns the existing candidate from a populated search envelope', async () => {
+        const candidate = { slug: 'existing-candidate', salary_expectation: 500, skill: 'Java' }
+        fetchMock.mockResolvedValue(response({ data: [candidate] }))
+        await expect(getCandidate('member@example.com')).resolves.toEqual(candidate)
+    })
+    it.each([{}, { data: 'unexpected' }, { data: null }, [{ slug: 'unexpected' }]])(
+        'rejects malformed candidate search responses: %j',
+        async data => {
+            fetchMock.mockResolvedValue(response(data))
+            await expect(getCandidate('member@example.com')).rejects.toMatchObject({ status: 502 })
+        },
+    )
     it('uses a refreshed token for multipart submission without a manual content-type boundary', async () => {
         const body = new FormData()
         fetchMock.mockResolvedValue(response({ success: true }))

--- a/src/apps/gigs/src/gigs.service.ts
+++ b/src/apps/gigs/src/gigs.service.ts
@@ -60,12 +60,17 @@ export async function getGig(slug: string): Promise<Gig> {
     return recruitRequest<Gig>(`${RECRUIT_URL}/jobs/${encodeURIComponent(slug)}`)
 }
 
-/** Looks up the signed-in member's existing candidate profile; no match returns undefined, failures reject. */
+/**
+ * Looks up the signed-in member's candidate by email for application prefill.
+ * Returns the first candidate, or undefined for Recruit's bare empty array or empty data envelope.
+ * Rejects with RecruitError on authentication, API or malformed-response failures; network errors propagate.
+ */
 export async function getCandidate(email: string): Promise<Candidate | undefined> {
     const result = await recruitRequest<{ data: Candidate[] }>(
         `${RECRUIT_URL}/candidates/search?email=${encodeURIComponent(email)}`,
         true,
     )
+    if (Array.isArray(result) && result.length === 0) return undefined
     if (!Array.isArray(result.data)) throw new RecruitError('We could not load your Gig Work profile.', 502)
     return result.data[0]
 }

--- a/src/apps/gigs/src/pages/GigApplyPage.spec.tsx
+++ b/src/apps/gigs/src/pages/GigApplyPage.spec.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable sort-keys, react/jsx-no-bind, import/no-extraneous-dependencies, ordered-imports/ordered-imports */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { SWRConfig } from 'swr'
+
+import { profileContext, tokenGetAsync, UserProfile } from '~/libs/core'
+
+import GigApplyPage from './GigApplyPage'
+
+jest.mock('react-router-dom', () => {
+    const util = jest.requireActual('util')
+    global.TextEncoder = util.TextEncoder
+    return jest.requireActual('react-router-dom')
+})
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        COMMUNITY_APP_URL: 'https://www.topcoder-dev.com',
+        USER_PROFILE_URL: 'https://profiles.topcoder-dev.com',
+        URLS: { ACCOUNT_SETTINGS: '/settings' },
+    },
+}), { virtual: true })
+jest.mock('~/libs/core', () => ({
+    profileContext: jest.requireActual('react')
+        .createContext({}),
+    tokenGetAsync: jest.fn(),
+}), { virtual: true })
+jest.mock('~/libs/shared', () => ({ autoCompleteSkills: jest.fn()
+    .mockResolvedValue([]) }), { virtual: true })
+jest.mock('~/libs/ui', () => ({
+    Button: (props: any) => (
+        <button
+            type={props.type === 'submit' ? 'submit' : 'button'}
+            disabled={props.disabled}
+            onClick={props.onClick}
+        >
+            {props.children}
+        </button>
+    ),
+    BaseModal: (props: any) => (props.open ? <div role='dialog'>{props.children}</div> : undefined),
+    LoadingSpinner: () => <span>Loading</span>,
+    PageTitle: () => undefined,
+}), { virtual: true })
+
+const profile = {
+    userId: 123,
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+    handle: 'jane',
+    homeCountryCode: 'AUS',
+} as UserProfile
+const job = {
+    name: 'Java engineer',
+    slug: 'example-gig',
+    job_status: { id: 1 },
+    enable_job_application_form: 1,
+}
+const originalFetch = global.fetch
+const fetchMock = jest.fn()
+
+/**
+ * Renders the apply route for a signed-in member using the real service and an isolated SWR cache.
+ * Takes no parameters and returns nothing; used by the candidate-loading regressions.
+ * React rendering errors propagate to the test.
+ */
+function renderApplyPage(): void {
+    render(
+        <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+            <profileContext.Provider value={{ profile, initialized: true } as any}>
+                <MemoryRouter initialEntries={['/gigs/example-gig/apply']}>
+                    <Routes>
+                        <Route path='/gigs/:slug/apply' element={<GigApplyPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </profileContext.Provider>
+        </SWRConfig>,
+    )
+}
+
+beforeEach(() => {
+    global.fetch = fetchMock
+    fetchMock.mockReset();
+    (tokenGetAsync as jest.Mock).mockResolvedValue({ token: 'member-token' })
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => job })
+})
+afterAll(() => {
+    global.fetch = originalFetch
+})
+
+describe('Gig application candidate loading', () => {
+    it('opens the application form when Recruit returns its bare empty no-match array', async () => {
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+        renderApplyPage()
+
+        expect(await screen.findByRole('button', { name: 'Apply to this job' }))
+            .toBeTruthy()
+        expect((screen.getByLabelText('First name *') as HTMLInputElement).value)
+            .toBe('Jane')
+        expect(screen.queryByText('Unable to load your Gig Work profile'))
+            .toBeNull()
+        expect(fetchMock)
+            .toHaveBeenCalledWith(
+                'https://www.topcoder-dev.com/api/recruit/candidates/search?email=jane%40example.com',
+                expect.objectContaining({ headers: { Authorization: 'Bearer member-token' } }),
+            )
+    })
+    it('prefills the application form from an existing candidate search envelope', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ data: [{ salary_expectation: 500 }] }),
+        })
+        renderApplyPage()
+
+        const pay = await screen.findByLabelText('Weekly pay expectation (USD) *') as HTMLInputElement
+        expect(pay.value)
+            .toBe('500')
+        expect(screen.getByText('Review your Gig Work profile and update anything that has changed.'))
+            .toBeTruthy()
+    })
+    it('blocks a failed lookup and opens the form after a successful no-match retry', async () => {
+        fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({ error: true }) })
+        renderApplyPage()
+
+        expect(await screen.findByText('Unable to load your Gig Work profile'))
+            .toBeTruthy()
+        expect(screen.queryByRole('button', { name: 'Apply to this job' }))
+            .toBeNull()
+        fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+        fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+        expect(await screen.findByRole('button', { name: 'Apply to this job' }))
+            .toBeTruthy()
+        expect(screen.queryByText('Unable to load your Gig Work profile'))
+            .toBeNull()
+    })
+})


### PR DESCRIPTION
## What was broken

Clicking "Apply to this job" blocked members without an existing Recruit candidate profile with "Unable to load your Gig Work profile".

## Root cause

The development Recruit endpoint returns a bare `[]` when no candidate matches. Platform-ui only accepted `{ data: [...] }`, so it rejected this valid response. The legacy community app already handles the bare empty array as a new candidate.

## What was changed

- Accept a bare empty array as no existing candidate, allowing the application form to open with the member's Topcoder profile.
- Preserve existing candidate prefill, authentication, malformed-response rejection and retry on genuine lookup failures.
- Update the Gigs service documentation and README.

## Any added/updated tests

- Add nine service/page regression cases for empty searches, existing candidate prefill, malformed responses and lookup failure/retry. The regressions reproduced the reported error before the fix.
- `nvm use` followed by `yarn lint`: passed.
- `yarn run build`: passed with existing warnings.
- `yarn test:no-watch --runInBand --watch=false --runTestsByPath src/apps/gigs/src/gigs.utils.spec.ts src/apps/gigs/src/gigs.service.spec.ts src/apps/gigs/src/components/GigApplicationForm.spec.tsx src/apps/gigs/src/pages/GigApplyPage.spec.tsx`: all 4 suites / 24 tests passed.
- `yarn test:no-watch --runInBand --watch=false`: 300 suites passed, 24 failed; 1,719 tests passed, 26 failed. An unchanged `dev` checkout at `208a52810` has the exact same 24 failing suites and 26 failing tests (299 suites / 1,710 tests passed). No new failures.
- Chromium checks of the production build: details-to-apply navigation opens the new-candidate form; desktop/mobile screenshots inspected; lookup failures block submission and retry restores the form. All browser network responses were intercepted; no real applications were submitted.
