### PR TITLE
PM-6267: Keep mobile review header decoration clear of content

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -200,6 +200,9 @@ header reads the persisted review-opportunity `createdAt` value as “Posted” 
 uses the start-date label only as a compatibility fallback for an older Review
 API response. Its date, open-position, and review-period metrics use the
 authored outline glyphs, while the Thrive card reuses the authored book asset.
+At widths up to 760px, the decorative header rings sit at the bottom right by
+the compensation card, keeping the title, skills, and review metrics clear as
+the content wraps. Desktop ring positioning is unchanged.
 The two Thrive actions open the published Topcoder Review Process and Topcoder
 Challenges Explained articles rather than an unfiltered search page.
 

--- a/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.module.scss
@@ -881,6 +881,12 @@
 }
 
 @media (max-width: 760px) {
+    .rings {
+        bottom: -200px;
+        right: -168px;
+        top: auto;
+    }
+
     .breadcrumbsShell,
     .headerInner {
         padding-inline: 24px;


### PR DESCRIPTION
## What was broken

The decorative rings crossed the title, skills, and review metrics on the mobile Review Opportunity Details header (PM-6267).

## Root cause

The absolutely positioned rings kept their desktop top offset as the header content wrapped on small screens.

## What was changed

- Move the rings to the bottom right, beside the compensation card, at the existing 760px breakpoint.
- Preserve styling above that breakpoint and document the responsive behavior.
- Files: `src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.module.scss` and `src/apps/opportunities/README.md`.

## Any added/updated tests

No permanent test files changed: the existing Jest setup mocks SCSS, so browser layout checks cover this CSS-only fix.

- A temporary Playwright regression harness rendered the actual review page with compiled before/after styles in 32 scenarios: widths 320, 375, 430, 520, 760, 761, 1280, and 1440px; short/long titles; single/split payments. All passed. It reproduced the original overlap, verified that the rings clear mobile titles, skills, and metadata, and confirmed identical wider-screen geometry. Mobile screenshots were visually checked against the ticket references.
- `yarn lint`: passed.
- `yarn run build`: passed with warnings.
- `CI=true yarn test:no-watch --runInBand --runTestsByPath src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.spec.tsx src/apps/opportunities/src/utils/review-opportunity.utils.spec.ts`: passed, 2 suites and 10 tests.
- `CI=true yarn test:no-watch --runInBand`: 299 passing suites, 24 failing suites; 1710 passing tests, 26 failing tests. A second run on unmodified `dev` at `208a52810` produced identical failing suites, failure titles, and totals. The full suite is not green because of these existing failures.
- Ran `nvm use` before Node/Yarn commands, plus `git fetch origin` and `git diff --check`.
