### PR TITLE
PM-6282 - review context edit

### DIFF
--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextEditor.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextEditor.tsx
@@ -23,6 +23,7 @@ interface ReviewContextEditorProps {
     reviewContext: ChallengeReviewContext
     onContextSaved: () => Promise<unknown>
     isLocked?: boolean
+    lockMessage?: string
 }
 
 interface RequirementValidationErrors {
@@ -386,7 +387,8 @@ const ReviewContextEditor: FC<ReviewContextEditorProps> = props => {
         <div className={styles.wrap}>
             {props.isLocked && (
                 <div className={styles.infoBanner}>
-                    Review context is locked because this challenge already has submissions.
+                    {props.lockMessage
+                        || 'Review context is locked because this challenge already has submissions.'}
                 </div>
             )}
             <div className={styles.toolbar}>

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextTab.spec.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextTab.spec.tsx
@@ -99,7 +99,7 @@ describe('ReviewContextTab', () => {
             <ReviewContextTab
                 challengeId='challenge-1'
                 challengeDescription={'A'.repeat(120)}
-                hasSubmissions
+                lockReason='HAS_SUBMISSIONS'
             />,
         )
 

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextTab.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewContextTab/ReviewContextTab.tsx
@@ -14,6 +14,8 @@ import { ChallengeStatus } from '~/apps/admin/src/lib/models'
 import { ConfirmationModal } from '~/apps/work/src/lib/components'
 import { IconButton } from '~/libs/ui/lib/components/button/icon-button'
 
+import { ReviewContextLockReason } from '../reviewers-field.utils'
+
 import ReviewContextEditor from './ReviewContextEditor'
 import styles from './ReviewContextTab.module.scss'
 
@@ -21,7 +23,7 @@ interface ReviewContextTabProps {
     challengeId?: string
     challengeDescription?: string
     challengeStatus?: ChallengeStatus
-    hasSubmissions?: boolean
+    lockReason?: ReviewContextLockReason
     onRequirementCountChange?: (count: number | undefined) => void
 }
 
@@ -43,7 +45,10 @@ const ReviewContextTab: FC<ReviewContextTabProps> = props => {
     const hasContext = !!context?.id
     const hasLoadedContext = !isLoading
     const requirementCount = context?.context?.requirements?.length
-    const isLocked = props.hasSubmissions === true
+    const isLocked = !!props.lockReason
+    const lockMessage = props.lockReason === 'HAS_SUBMISSIONS'
+        ? 'Review context is locked because instant review is enabled and this challenge already has submissions.'
+        : 'Review context is locked because the submission phase has ended.'
 
     useEffect(() => {
         props.onRequirementCountChange?.(requirementCount)
@@ -189,7 +194,7 @@ const ReviewContextTab: FC<ReviewContextTabProps> = props => {
                     <p><strong>{descriptionText}</strong></p>
                     {isLocked ? (
                         <div className={styles.errorText}>
-                            Review context is locked because this challenge already has submissions.
+                            {lockMessage}
                         </div>
                     ) : (
                         <>
@@ -231,7 +236,7 @@ const ReviewContextTab: FC<ReviewContextTabProps> = props => {
                         </p>
                         <IconButton
                             icon={IconSolid.RefreshIcon}
-                            disabled={isSaving || blockGenerate}
+                            disabled={isSaving || blockGenerate || isLocked}
                             label='Regenerate'
                             onClick={function (): void {
                                 setShowRegenerateConfirm(true)
@@ -244,7 +249,8 @@ const ReviewContextTab: FC<ReviewContextTabProps> = props => {
                         challengeId={props.challengeId ?? ''}
                         reviewContext={context}
                         onContextSaved={refetchContext}
-                        isLocked={props.hasSubmissions === true}
+                        isLocked={isLocked}
+                        lockMessage={lockMessage}
                     />
                     {showRegenerateConfirm && (
                         <ConfirmationModal

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewersField.tsx
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/ReviewersField.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../../../lib/models'
 
 import {
+    getReviewContextLockReason,
     isAiReviewer,
     syncAiConfigReviewers,
 } from './reviewers-field.utils'
@@ -69,6 +70,7 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
      * requirement follows the selection instead of the last saved value.
      */
     const [selectedAiReviewMode, setSelectedAiReviewMode] = useState<AiReviewMode | undefined>()
+    const [aiInstantReview, setAiInstantReview] = useState<boolean>(false)
     const [hasLoadedAiConfig, setHasLoadedAiConfig] = useState<boolean>(false)
     const [reviewContextRequirementCount, setReviewContextRequirementCount] = useState<number | undefined>(undefined)
     const humanTabRef = useRef<HTMLDivElement>(null)
@@ -133,6 +135,8 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
                 if (!mounted) {
                     return
                 }
+
+                setAiInstantReview(config?.instantReview === true)
 
                 if (config?.mode) {
                     setAiReviewMode(config.mode)
@@ -202,6 +206,14 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
         () => Number(numOfSubmissions || 0) > 0,
         [numOfSubmissions],
     )
+    const reviewContextLockReason = useMemo(
+        () => getReviewContextLockReason({
+            hasSubmissions,
+            instantReview: aiInstantReview,
+            phases,
+        }),
+        [aiInstantReview, hasSubmissions, phases],
+    )
     const handleTabChange = useCallback((tab: ReviewTab): void => {
         setActiveTab(tab)
     }, [])
@@ -266,6 +278,7 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
     const handleAiConfigPersisted = useCallback(
         (config: AiReviewConfig): void => {
             setAiReviewMode(config.mode)
+            setAiInstantReview(config.instantReview === true)
             const currentReviewers = formContext.getValues('reviewers') as Reviewer[] | undefined
             let nextReviewers = syncAiConfigReviewers({
                 phases,
@@ -291,6 +304,7 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
     )
     const handleAiConfigRemoved = useCallback(async (): Promise<void> => {
         setAiReviewMode(undefined)
+        setAiInstantReview(false)
         const currentReviewers = formContext.getValues('reviewers') as Reviewer[] | undefined
         const nextReviewers = (currentReviewers || []).filter(reviewer => !isAiReviewer(reviewer))
 
@@ -495,7 +509,7 @@ export const ReviewersField: FC<ReviewersFieldProps> = (props: ReviewersFieldPro
                                     challengeId={challengeId}
                                     challengeDescription={formContext.getValues('description')}
                                     challengeStatus={challengeStatus}
-                                    hasSubmissions={hasSubmissions}
+                                    lockReason={reviewContextLockReason}
                                     onRequirementCountChange={setReviewContextRequirementCount}
                                 />
                             </div>

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewers-field.utils.spec.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewers-field.utils.spec.ts
@@ -1,6 +1,7 @@
 import {
     aiReviewConfigHasChanges,
     getAiReviewerPhaseId,
+    getReviewContextLockReason,
     normalizeTrackForAiTemplates,
     syncAiConfigReviewers,
     validateAiReviewConfiguration,
@@ -199,5 +200,72 @@ describe('reviewers-field utils ai reviewer syncing', () => {
             },
         ]))
             .toBe('screening-phase-id')
+    })
+})
+
+describe('reviewers-field utils review context locking', () => {
+    const openSubmissionPhase = {
+        isOpen: true,
+        name: 'Submission',
+        scheduledEndDate: new Date(Date.now() + 86400000)
+            .toISOString(),
+    }
+    const closedSubmissionPhase = {
+        actualEndDate: new Date(Date.now() - 86400000)
+            .toISOString(),
+        isOpen: false,
+        name: 'Submission',
+    }
+
+    it('locks on the first submission when instant review is on', () => {
+        expect(getReviewContextLockReason({
+            hasSubmissions: true,
+            instantReview: true,
+            phases: [openSubmissionPhase],
+        }))
+            .toBe('HAS_SUBMISSIONS')
+    })
+
+    it('stays editable without submissions when instant review is on', () => {
+        expect(getReviewContextLockReason({
+            hasSubmissions: false,
+            instantReview: true,
+            phases: [openSubmissionPhase],
+        }))
+            .toBeUndefined()
+    })
+
+    it('stays editable with submissions while the submission phase is open', () => {
+        expect(getReviewContextLockReason({
+            hasSubmissions: true,
+            instantReview: false,
+            phases: [openSubmissionPhase],
+        }))
+            .toBeUndefined()
+    })
+
+    it('locks once the submission phase ends when instant review is off', () => {
+        expect(getReviewContextLockReason({
+            hasSubmissions: true,
+            instantReview: false,
+            phases: [closedSubmissionPhase],
+        }))
+            .toBe('SUBMISSION_PHASE_ENDED')
+    })
+
+    it('ignores submission phases that have not started yet', () => {
+        expect(getReviewContextLockReason({
+            hasSubmissions: false,
+            instantReview: false,
+            phases: [
+                {
+                    isOpen: false,
+                    name: 'Submission',
+                    scheduledEndDate: new Date(Date.now() + 86400000)
+                        .toISOString(),
+                },
+            ],
+        }))
+            .toBeUndefined()
     })
 })

--- a/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewers-field.utils.ts
+++ b/src/apps/work/src/pages/challenges/ChallengeEditorPage/components/ReviewersField/reviewers-field.utils.ts
@@ -287,3 +287,59 @@ export function syncAiConfigReviewers(
         ...nextAiReviewers,
     ]
 }
+
+/**
+ * Determines whether the challenge submission phase is over.
+ */
+export function isSubmissionPhaseClosed(phases: ChallengePhase[] | undefined): boolean {
+    const submissionPhase = (Array.isArray(phases) ? phases : [])
+        .find(phase => normalizeReviewerText(phase.name)
+            .toLowerCase() === 'submission')
+
+    if (!submissionPhase) {
+        return false
+    }
+
+    if (submissionPhase.isOpen === true) {
+        return false
+    }
+
+    const endDate = submissionPhase.actualEndDate || submissionPhase.scheduledEndDate
+
+    if (!endDate) {
+        return false
+    }
+
+    const endTime = new Date(endDate)
+        .getTime()
+
+    return Number.isFinite(endTime) && endTime <= Date.now()
+}
+
+export type ReviewContextLockReason = 'HAS_SUBMISSIONS' | 'SUBMISSION_PHASE_ENDED'
+
+interface ReviewContextLockParams {
+    hasSubmissions?: boolean
+    instantReview?: boolean
+    phases?: ChallengePhase[]
+}
+
+/**
+ * Review context requirements stay editable while they can still influence a review.
+ * With instant review on, the first submission is reviewed right away, so the
+ * requirements lock as soon as a submission exists. Otherwise they only lock once
+ * the submission phase is over.
+ */
+export function getReviewContextLockReason(
+    params: ReviewContextLockParams,
+): ReviewContextLockReason | undefined {
+    if (params.instantReview === true) {
+        return params.hasSubmissions === true
+            ? 'HAS_SUBMISSIONS'
+            : undefined
+    }
+
+    return isSubmissionPhaseClosed(params.phases)
+        ? 'SUBMISSION_PHASE_ENDED'
+        : undefined
+}


### PR DESCRIPTION
<!--
  NOTE: you can leave these comments as they are,
  no need to delete them as they won't appear in the final PR description
-->
<!-- Please make sure to link the JIRA ticket related to this PR, if any -->
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6282


<!-- Please add a brief description of what this PR accomplishes -->
<!-- SEE [Pull Requests](../README.md#pull-requests) for more details about opening a PR -->
# What's in this PR?
This pull request improves how and when the review context editor is locked in the challenge editor, making the locking logic more accurate and user-friendly. The main change is that the editor now distinguishes between different reasons for locking (such as instant review being enabled or the submission phase ending), and displays appropriate messages to the user. The logic is centralized and tested, and the UI is updated to reflect these changes.

Key changes:

**Locking Logic Improvements**
- Introduced a new utility function `getReviewContextLockReason` in `reviewers-field.utils.ts` to determine if and why the review context should be locked, considering both instant review mode and the state of the submission phase.
- Added `ReviewContextLockReason` type to clearly represent lock reasons (`'HAS_SUBMISSIONS'` or `'SUBMISSION_PHASE_ENDED'`).

**UI and Prop Updates**
- Updated `ReviewContextTab` and `ReviewContextEditor` components to accept a `lockReason` and `lockMessage` prop, and to display context-specific lock messages based on the reason. The regenerate button is now disabled when locked. [[1]](diffhunk://#diff-cc9e886995a38dfc6e515cc9c90a797e2b1d3258d2bc0966a307a9348c49431dR17-R26) [[2]](diffhunk://#diff-cc9e886995a38dfc6e515cc9c90a797e2b1d3258d2bc0966a307a9348c49431dL46-R51) [[3]](diffhunk://#diff-cc9e886995a38dfc6e515cc9c90a797e2b1d3258d2bc0966a307a9348c49431dL192-R197) [[4]](diffhunk://#diff-cc9e886995a38dfc6e515cc9c90a797e2b1d3258d2bc0966a307a9348c49431dL234-R239) [[5]](diffhunk://#diff-cc9e886995a38dfc6e515cc9c90a797e2b1d3258d2bc0966a307a9348c49431dL247-R253) [[6]](diffhunk://#diff-e95e7b3da50bc2a45c53eb5ffaf2b2a731e69ca5090e0e009811906a5223e97bR26) [[7]](diffhunk://#diff-e95e7b3da50bc2a45c53eb5ffaf2b2a731e69ca5090e0e009811906a5223e97bL389-R391)
- Changed how the lock state is passed from `ReviewersField` to `ReviewContextTab`, using the new lock reason instead of a simple boolean.

**State and Behavior Synchronization**
- Tracked `instantReview` mode in component state, ensuring that lock logic updates correctly when AI review settings change or are removed. [[1]](diffhunk://#diff-f362345494309e6010457f8b8db7fd5207d8a0ea19dd6fe31630613adc1c93daR73) [[2]](diffhunk://#diff-f362345494309e6010457f8b8db7fd5207d8a0ea19dd6fe31630613adc1c93daR139-R140) [[3]](diffhunk://#diff-f362345494309e6010457f8b8db7fd5207d8a0ea19dd6fe31630613adc1c93daR281) [[4]](diffhunk://#diff-f362345494309e6010457f8b8db7fd5207d8a0ea19dd6fe31630613adc1c93daR307)
- Used `useMemo` to compute the lock reason reactively based on challenge state.

**Testing**
- Added comprehensive unit tests for `getReviewContextLockReason` to cover all relevant scenarios for locking and unlocking the review context.

These changes ensure that the review context editor is only locked when it should be, and that users receive clear feedback about why editing is disabled.