### PR TITLE
PM-6288 Restore grid card divider spacing

### DIFF
--- a/src/apps/opportunities/src/components/OpportunityListCard.module.scss
+++ b/src/apps/opportunities/src/components/OpportunityListCard.module.scss
@@ -707,7 +707,6 @@
 
 .competitionCard.gridCard {
     .competitionMain {
-        gap: 0;
         min-height: 0;
     }
 

--- a/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
+++ b/src/apps/opportunities/src/components/OpportunityListCard.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
+import { readFileSync } from 'fs'
 import {
     fireEvent,
     render,
@@ -17,6 +18,8 @@ import {
 } from '../models'
 
 import { OpportunityListCard } from './OpportunityListCard'
+
+const opportunityListCardStyles = readFileSync(`${__dirname}/OpportunityListCard.module.scss`, 'utf8')
 
 jest.mock('~/libs/ui', () => {
     const Icon = (): JSX.Element => <svg />
@@ -217,6 +220,18 @@ describe('OpportunityListCard competition presentation', () => {
             .toHaveLength(2)
         expect(screen.getByText('Submissions:'))
             .toBeInTheDocument()
+    })
+
+    it('preserves the Figma spacing between grid skills and the divider', () => {
+        const competitionMainRules = Array.from(
+            opportunityListCardStyles.matchAll(/(?:^|\n)\s*\.competitionMain\s*\{([^}]*)\}/g),
+            match => match[1],
+        )
+
+        expect(competitionMainRules)
+            .toEqual(expect.arrayContaining([expect.stringContaining('gap: 15px;')]))
+        expect(competitionMainRules.some(rule => /\bgap:\s*0;/.test(rule)))
+            .toBe(false)
     })
 
     it('deep-links every active competition metric without nesting card links', () => {


### PR DESCRIPTION
## Summary

- restore the Figma-authored 15px spacing between competition grid skill chips and the divider
- remove the grid-only zero-gap override so cards inherit the shared competition spacing
- add a stylesheet regression test that protects the shared gap from another grid reset

## Validation

- `yarn test --watchAll=false --runInBand src/apps/opportunities/src/components/OpportunityListCard.spec.tsx` (32/32 passed)
- `yarn lint`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn run build`
- `git diff --check`

Jira: https://topcoder.atlassian.net/browse/PM-6288
