### PR TITLE
PM-6289 Support URL challenge submissions

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -400,21 +400,28 @@ and active challenges retain the ongoing-review guidance.
 
 Registered members submit without leaving challenge details. My Submissions
 also exposes the environment-specific Review App handoff before and after an
-upload. The flow accepts one `.zip` archive up to 500MB, requires the authored
-declaration, and reports live upload progress. The browser uploads to
-Filestack's S3 endpoint using the environment's canonical submissions DMZ
-bucket, then sends the resulting storage URL to `POST /v6/submissions`. The
-active phase selects `CONTEST_SUBMISSION`,
+upload. Work Manager's case-insensitive `submission_type=url` challenge
+metadata selects the URL experience; every other value, including missing or
+malformed metadata, retains the standard ZIP experience. URL submissions
+require a confirmed absolute HTTP(S) link and send that link directly to
+`POST /v6/submissions` without invoking Filestack. ZIP submissions accept one
+`.zip` archive up to 500MB and report live upload progress. The browser uploads
+the archive to Filestack's S3 endpoint using the environment's canonical
+submissions DMZ bucket, then sends the resulting storage URL to the same Review
+API endpoint. Both modes require the authored declaration and revalidate the
+member's registration before submission. The active phase selects `CONTEST_SUBMISSION`,
 `CHECKPOINT_SUBMISSION`, or `STUDIO_FINAL_FIX_SUBMISSION`; Review API remains
 authoritative for registration, phase, winner, submission-limit, and file
 validation. Design shows the four expected inner deliverables, while
 Development, Marathon Match, and Quality Assurance direct members to their
-Requirements content. Successful uploads expose the created submission ID and
-refresh challenge and member submission counts without leaving the confirmation
-state. The declaration opens the public Topcoder Terms of Use in a new tab.
-While an upload is active, the detail tabs and every form action that would
-unmount the upload are disabled. The explicit upload-cancel control remains
-available, aborts its request, and then unlocks normal navigation.
+Requirements content in ZIP mode; URL mode replaces file-specific guidance
+with link accessibility reminders. Successful submissions expose the created
+submission ID and refresh challenge and member submission counts without
+leaving the confirmation state. The declaration opens the public Topcoder
+Terms of Use in a new tab. While either request is active, the detail tabs and
+every form action that would unmount the submission are disabled. The explicit
+cancel control remains available, aborts its request, clears the selected file
+or URL, and then unlocks normal navigation.
 Marathon Match attempts fall back to Review submission, virus-scan, and scoring
 lifecycle fields when test metadata is absent, preserving truthful Failed, In
 progress, and completed states. Virus-scan and quarantine failures are reported

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.module.scss
@@ -175,7 +175,8 @@
     min-width: 0;
 }
 
-.fileUploader {
+.fileUploader,
+.urlSubmission {
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -191,6 +192,14 @@
         }
     }
 
+    > small {
+        color: #6f6f6f;
+        font-size: 12px;
+        line-height: 16px;
+    }
+}
+
+.fileUploader {
     > input {
         height: 1px;
         opacity: 0;
@@ -198,11 +207,66 @@
         position: absolute;
         width: 1px;
     }
+}
 
-    > small {
-        color: #6f6f6f;
-        font-size: 12px;
-        line-height: 16px;
+.urlInputRow {
+    align-items: stretch;
+    display: flex;
+    gap: 8px;
+
+    > input {
+        border: 1px solid #a8a8a8;
+        border-radius: 4px;
+        box-sizing: border-box;
+        color: #161616;
+        flex: 1;
+        font: inherit;
+        font-size: 14px;
+        height: 40px;
+        line-height: 20px;
+        min-width: 0;
+        padding: 9px 12px;
+
+        &::placeholder {
+            color: #6f6f6f;
+        }
+
+        &:focus {
+            border-color: #007d79;
+            box-shadow: 0 0 0 1px #007d79;
+            outline: none;
+        }
+
+        &[aria-invalid='true'] {
+            border-color: #c1294f;
+        }
+
+        &:disabled {
+            background: #f4f4f4;
+            cursor: not-allowed;
+        }
+    }
+}
+
+.setUrlButton {
+    align-items: center;
+    background: #007d79;
+    border: 1px solid #007d79;
+    border-radius: 4px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 700;
+    justify-content: center;
+    line-height: 20px;
+    padding: 9px 20px;
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: .65;
     }
 }
 
@@ -302,6 +366,11 @@
 .fileCopy {
     display: flex;
     flex-direction: column;
+    min-width: 0;
+
+    strong {
+        overflow-wrap: anywhere;
+    }
 
     span {
         color: #6f6f6f;
@@ -536,5 +605,9 @@
     .submissionId {
         align-items: center;
         flex-wrap: wrap;
+    }
+
+    .urlInputRow {
+        flex-direction: column;
     }
 }

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
@@ -10,18 +10,25 @@ import {
 } from '@testing-library/react'
 
 import { ChallengeOpportunity, ChallengeSubmission } from '../models'
-import { createChallengeSubmission } from '../services'
+import {
+    createChallengeSubmission,
+    createChallengeUrlSubmission,
+} from '../services'
 
 import {
     ChallengeSubmissionUpload,
     challengeSubmissionType,
     validateChallengeSubmissionFile,
+    validateChallengeSubmissionUrl,
 } from './ChallengeSubmissionUpload'
 
 const mockRecordAnalyticsEvent = jest.fn()
 
 jest.mock('~/config', () => ({
     EnvironmentConfig: { URLS: { TERMS_OF_USE: 'https://www.example.com/terms' } },
+}), { virtual: true })
+jest.mock('~/libs/cms', () => ({
+    getSafeCmsLink: jest.fn(),
 }), { virtual: true })
 jest.mock('~/libs/core', () => ({
     recordAnalyticsEvent: (...args: unknown[]) => mockRecordAnalyticsEvent(...args),
@@ -39,9 +46,12 @@ jest.mock('react-toastify', () => ({
 }))
 jest.mock('../services', () => ({
     createChallengeSubmission: jest.fn(),
+    createChallengeUrlSubmission: jest.fn(),
 }))
 
 const mockedCreateSubmission = createChallengeSubmission as jest.MockedFunction<typeof createChallengeSubmission>
+const mockedCreateUrlSubmission
+    = createChallengeUrlSubmission as jest.MockedFunction<typeof createChallengeUrlSubmission>
 
 /** Creates the minimum challenge data needed by the upload workflow. */
 function challengeFixture(overrides: Partial<ChallengeOpportunity> = {}): ChallengeOpportunity {
@@ -132,6 +142,169 @@ describe('ChallengeSubmissionUpload', () => {
         Object.defineProperty(oversized, 'size', { value: (500 * 1024 * 1024) + 1 })
         expect(validateChallengeSubmissionFile(oversized))
             .toBe('The ZIP file must be 500MB or smaller.')
+    })
+
+    it('accepts only trimmed absolute HTTP or HTTPS submission URLs', () => {
+        expect(validateChallengeSubmissionUrl(''))
+            .toBe('Enter the URL to your submission.')
+        expect(validateChallengeSubmissionUrl('deliverables.example.com/result'))
+            .toBe('Enter a valid submission URL.')
+        expect(validateChallengeSubmissionUrl('ftp://deliverables.example.com/result'))
+            .toBe('Enter a URL beginning with http:// or https://.')
+        expect(validateChallengeSubmissionUrl('  https://deliverables.example.com/result  '))
+            .toBeUndefined()
+    })
+
+    it('renders metadata-selected URL guidance without the ZIP picker', () => {
+        renderUpload(challengeFixture({
+            metadata: [{ name: ' SUBMISSION_TYPE ', value: ' URL ' }],
+        }))
+
+        expect(screen.getByText('Submit the URL to your solution as described in the requirements.'))
+            .toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Required Link' }))
+            .toBeInTheDocument()
+        expect(screen.getByLabelText(/Submission URL/))
+            .toHaveAttribute('type', 'url')
+        expect(screen.getByRole('button', { name: 'Set URL' }))
+            .toBeInTheDocument()
+        expect(screen.queryByLabelText(/Upload File/))
+            .not.toBeInTheDocument()
+        expect(screen.queryByText('Drop your file(s) here or'))
+            .not.toBeInTheDocument()
+        expect(screen.getByText('Link directly to your challenge deliverable'))
+            .toBeInTheDocument()
+    })
+
+    it('validates and reconfirms an edited URL before enabling its declaration', () => {
+        renderUpload(challengeFixture({
+            metadata: [{ name: 'submission_type', value: 'url' }],
+        }))
+        const urlInput = screen.getByLabelText(/Submission URL/)
+        const agreement = screen.getByRole('checkbox', { name: 'I understand and agree' })
+
+        fireEvent.change(urlInput, { target: { value: 'ftp://files.example.com/result' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        expect(screen.getByRole('alert'))
+            .toHaveTextContent('Enter a URL beginning with http:// or https://.')
+        expect(urlInput)
+            .toHaveAttribute('aria-invalid', 'true')
+        expect(agreement)
+            .toBeDisabled()
+
+        fireEvent.change(urlInput, { target: { value: '  https://files.example.com/result  ' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        expect(screen.getByText('Ready to submit'))
+            .toBeInTheDocument()
+        expect(screen.getByText('https://files.example.com/result'))
+            .toBeInTheDocument()
+        expect(urlInput)
+            .toHaveValue('https://files.example.com/result')
+        expect(agreement)
+            .not.toBeDisabled()
+
+        fireEvent.click(agreement)
+        fireEvent.change(urlInput, { target: { value: 'https://files.example.com/revised' } })
+        expect(screen.queryByText('Ready to submit'))
+            .not.toBeInTheDocument()
+        expect(agreement)
+            .toBeDisabled()
+        expect(agreement)
+            .not.toBeChecked()
+    })
+
+    it('posts a confirmed URL directly and resets URL state for another solution', async () => {
+        mockedCreateUrlSubmission.mockResolvedValue({ id: 'url-submission-id' })
+        renderUpload(challengeFixture({
+            currentPhaseNames: ['Submission'],
+            metadata: [{ name: 'submission_type', value: 'url' }],
+            phases: [{ isOpen: true, name: 'Submission' }],
+        }))
+
+        fireEvent.change(screen.getByLabelText(/Submission URL/), {
+            target: { value: '  https://files.example.com/result  ' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => expect(mockedCreateUrlSubmission)
+            .toHaveBeenCalledWith(
+                'challenge-id',
+                '123',
+                'CONTEST_SUBMISSION',
+                'https://files.example.com/result',
+                expect.any(AbortSignal),
+            ))
+        expect(mockedCreateSubmission)
+            .not.toHaveBeenCalled()
+        expect(await screen.findByText('url-submission-id'))
+            .toBeInTheDocument()
+        expect(mockRecordAnalyticsEvent)
+            .toHaveBeenCalledWith('challenge_submitted', {
+                challenge_id: 'challenge-id',
+                challenge_track: 'design',
+                member_id: '123',
+                submission_type: 'CONTEST_SUBMISSION',
+            }, true)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Submit another solution' }))
+        expect(screen.getByLabelText(/Submission URL/))
+            .toHaveValue('')
+        expect(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+            .toBeDisabled()
+    })
+
+    it('revalidates registration before creating a URL submission', async () => {
+        const validateRegistration = jest.fn()
+            .mockResolvedValue(false)
+        renderUpload(
+            challengeFixture({ metadata: [{ name: 'submission_type', value: 'url' }] }),
+            validateRegistration,
+        )
+
+        fireEvent.change(screen.getByLabelText(/Submission URL/), {
+            target: { value: 'https://files.example.com/result' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' }))
+            .not.toBeDisabled())
+        expect(validateRegistration)
+            .toHaveBeenCalledTimes(1)
+        expect(mockedCreateUrlSubmission)
+            .not.toHaveBeenCalled()
+    })
+
+    it('cancels a pending URL submission and unlocks parent navigation', async () => {
+        const onUploadingChange = jest.fn()
+        mockedCreateUrlSubmission.mockImplementation((...args) => new Promise((_resolve, reject) => {
+            args[4]?.addEventListener('abort', () => reject(new DOMException('Cancelled', 'AbortError')))
+        }))
+        renderUpload(
+            challengeFixture({ metadata: [{ name: 'submission_type', value: 'url' }] }),
+            async () => true,
+            onUploadingChange,
+        )
+
+        fireEvent.change(screen.getByLabelText(/Submission URL/), {
+            target: { value: 'https://files.example.com/result' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => expect(onUploadingChange)
+            .toHaveBeenLastCalledWith(true))
+        expect(screen.getByRole('button', { name: 'Back to My Submissions' }))
+            .toBeDisabled()
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel submission' }))
+        await waitFor(() => expect(onUploadingChange)
+            .toHaveBeenLastCalledWith(false))
+        expect(screen.getByLabelText(/Submission URL/))
+            .toHaveValue('')
     })
 
     it('derives final-fix, checkpoint, and contest Review API types', () => {

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.spec.tsx
@@ -255,6 +255,28 @@ describe('ChallengeSubmissionUpload', () => {
             .toBeDisabled()
     })
 
+    it('keeps a confirmed URL semantically valid when submission fails', async () => {
+        mockedCreateUrlSubmission.mockRejectedValue(new Error('Review API unavailable.'))
+        renderUpload(challengeFixture({
+            metadata: [{ name: 'submission_type', value: 'url' }],
+        }))
+
+        const urlInput = screen.getByLabelText(/Submission URL/)
+        fireEvent.change(urlInput, {
+            target: { value: 'https://files.example.com/result' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+        fireEvent.click(screen.getByRole('checkbox', { name: 'I understand and agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        expect(await screen.findByRole('alert'))
+            .toHaveTextContent('Review API unavailable.')
+        expect(urlInput)
+            .toHaveAttribute('aria-invalid', 'false')
+        expect(urlInput)
+            .toHaveAttribute('aria-describedby', 'challenge-submission-url-help challenge-submission-url-error')
+    })
+
     it('revalidates registration before creating a URL submission', async () => {
         const validateRegistration = jest.fn()
             .mockResolvedValue(false)

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
@@ -532,7 +532,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                                             aria-describedby={error
                                                 ? 'challenge-submission-url-help challenge-submission-url-error'
                                                 : 'challenge-submission-url-help'}
-                                            aria-invalid={!!error}
+                                            aria-invalid={!!error && !submissionUrl}
                                             autoComplete='url'
                                             disabled={uploading}
                                             id='challenge-submission-url'

--- a/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
+++ b/src/apps/opportunities/src/components/ChallengeSubmissionUpload.tsx
@@ -19,7 +19,11 @@ import {
     ChallengeSubmission,
     ChallengeSubmissionType,
 } from '../models'
-import { createChallengeSubmission } from '../services'
+import {
+    createChallengeSubmission,
+    createChallengeUrlSubmission,
+} from '../services'
+import { challengeSubmissionMode } from '../utils/challenge-detail.utils'
 
 import { challengeCatalogKey } from './challenge-card.utils'
 import styles from './ChallengeSubmissionUpload.module.scss'
@@ -76,6 +80,30 @@ export function validateChallengeSubmissionFile(file: File): string | undefined 
 }
 
 /**
+ * Validates a member-authored challenge deliverable URL.
+ *
+ * @param value URL entered in the submission form.
+ * @returns member-facing validation failure, or undefined for an absolute HTTP(S) URL.
+ * @throws Does not throw; malformed URLs are returned as validation failures.
+ */
+export function validateChallengeSubmissionUrl(value: string): string | undefined {
+    const normalizedValue = value.trim()
+    if (!normalizedValue) return 'Enter the URL to your submission.'
+
+    try {
+        const url = new URL(normalizedValue)
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return 'Enter a URL beginning with http:// or https://.'
+        }
+
+        if (!url.hostname) return 'Enter a valid submission URL.'
+        return undefined
+    } catch {
+        return 'Enter a valid submission URL.'
+    }
+}
+
+/**
  * Formats the compact whole-megabyte size displayed beside an uploaded archive.
  *
  * @param bytes file size in bytes.
@@ -101,6 +129,8 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
     const [error, setError] = useState<string | undefined>()
     const [file, setFile] = useState<File | undefined>()
     const [progress, setProgress] = useState(0)
+    const [submissionUrl, setSubmissionUrl] = useState<string | undefined>()
+    const [urlInput, setUrlInput] = useState('')
     const [submissionId, setSubmissionId] = useState<string | undefined>()
     const [uploading, setUploading] = useState(false)
     const abortController = useRef<AbortController | undefined>()
@@ -109,6 +139,9 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
     const typeKey = challengeCatalogKey(props.challenge.type)
     const designChallenge = trackKey === 'design'
     const pluralUpload = trackKey === 'qualityassurance' || typeKey === 'marathonmatch'
+    const submissionMode = challengeSubmissionMode(props.challenge)
+    const urlMode = submissionMode === 'url'
+    const selectionReady = urlMode ? !!submissionUrl : !!file
 
     useEffect(() => () => {
         abortController.current?.abort()
@@ -128,12 +161,12 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
     }
 
     /**
-     * Clears a selected file and cancels its active multipart request when present.
+     * Clears the selected file or URL and cancels its active request when present.
      *
      * @returns void after restoring the empty uploader state.
      * @throws Does not throw.
      */
-    const clearFile = (): void => {
+    const clearSelection = (): void => {
         abortController.current?.abort()
         abortController.current = undefined
         if (input.current) input.current.value = ''
@@ -141,6 +174,8 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
         setError(undefined)
         setFile(undefined)
         setProgress(0)
+        setSubmissionUrl(undefined)
+        setUrlInput('')
         setUploadActive(false)
     }
 
@@ -181,6 +216,35 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
     }
 
     /**
+     * Updates the URL draft and invalidates any previously confirmed link.
+     *
+     * @param event text-input change event.
+     * @returns void after returning the URL mode to its editable state.
+     * @throws Does not throw.
+     */
+    const changeUrl = (event: ChangeEvent<HTMLInputElement>): void => {
+        setUrlInput(event.target.value)
+        setSubmissionUrl(undefined)
+        setAgreementAccepted(false)
+        setError(undefined)
+    }
+
+    /**
+     * Validates and confirms the URL that will be sent to Review API.
+     *
+     * @returns void after accepting the trimmed URL or showing an inline error.
+     * @throws Does not throw.
+     */
+    const confirmUrl = (): void => {
+        const normalizedUrl = urlInput.trim()
+        const validationError = validateChallengeSubmissionUrl(normalizedUrl)
+        setError(validationError)
+        setAgreementAccepted(false)
+        if (!validationError) setUrlInput(normalizedUrl)
+        setSubmissionUrl(validationError ? undefined : normalizedUrl)
+    }
+
+    /**
      * Enables the browser's file-drop behavior over the styled drop zone.
      *
      * @param event drop-zone drag-over event.
@@ -213,7 +277,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
      * @throws Does not throw; request failures restore the ready state with an error message.
      */
     const submit = async (): Promise<void> => {
-        if (!file || !agreementAccepted || uploading) return
+        if (!selectionReady || !agreementAccepted || uploading) return
         const controller = new AbortController()
         abortController.current = controller
         setError(undefined)
@@ -222,19 +286,28 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
         try {
             const registrationIsCurrent = await props.onValidateRegistration()
             if (!registrationIsCurrent || controller.signal.aborted) return
-            const submission = await createChallengeSubmission(
-                props.challenge.id,
-                props.memberId,
-                challengeSubmissionType(props.challenge),
-                file,
-                setProgress,
-                controller.signal,
-            )
+            const submissionType = challengeSubmissionType(props.challenge)
+            const submission = urlMode
+                ? await createChallengeUrlSubmission(
+                    props.challenge.id,
+                    props.memberId,
+                    submissionType,
+                    submissionUrl as string,
+                    controller.signal,
+                )
+                : await createChallengeSubmission(
+                    props.challenge.id,
+                    props.memberId,
+                    submissionType,
+                    file as File,
+                    setProgress,
+                    controller.signal,
+                )
             recordAnalyticsEvent('challenge_submitted', {
                 challenge_id: props.challenge.id,
                 challenge_track: trackKey,
                 member_id: props.memberId,
-                submission_type: challengeSubmissionType(props.challenge),
+                submission_type: submissionType,
             }, true)
             setProgress(100)
             setSubmissionId(submission.id)
@@ -277,7 +350,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
      * @throws Does not throw.
      */
     const submitAnother = (): void => {
-        clearFile()
+        clearSelection()
         setSubmissionId(undefined)
     }
 
@@ -295,16 +368,25 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                     </button>
                     <h2>Submit your solution</h2>
                 </div>
-                <p>Upload your solution files as described in the requirements.</p>
+                <p>
+                    {urlMode
+                        ? 'Submit the URL to your solution as described in the requirements.'
+                        : 'Upload your solution files as described in the requirements.'}
+                </p>
             </header>
             <div className={styles.columns}>
                 <aside className={styles.leftPanel}>
                     <section className={styles.infoCard}>
                         <h3>
                             <IconOutline.DocumentAddIcon aria-hidden='true' />
-                            Required Files
+                            {urlMode ? 'Required Link' : 'Required Files'}
                         </h3>
-                        {designChallenge ? (
+                        {urlMode ? (
+                            <p>
+                                Provide a direct link to the solution requested in the Requirements tab and keep it
+                                accessible throughout review.
+                            </p>
+                        ) : designChallenge ? (
                             <ul className={styles.requiredFiles}>
                                 <li>
                                     <FileTypeIcon extension='ZIP' />
@@ -345,22 +427,45 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                             Submission tips
                         </h3>
                         <ul className={styles.tips}>
-                            <li>
-                                <IconOutline.SunIcon aria-hidden='true' />
-                                Upload a single ZIP file only
-                            </li>
-                            <li>
-                                <IconOutline.SunIcon aria-hidden='true' />
-                                Do not password protect the files
-                            </li>
-                            <li>
-                                <IconOutline.SunIcon aria-hidden='true' />
-                                Include all files as per guidelines
-                            </li>
-                            <li>
-                                <IconOutline.SunIcon aria-hidden='true' />
-                                Keep your handle out of your files and file names
-                            </li>
+                            {urlMode ? (
+                                <>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Link directly to your challenge deliverable
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Use a link that challenge reviewers can access
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Keep access available throughout review
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Follow all challenge submission guidelines
+                                    </li>
+                                </>
+                            ) : (
+                                <>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Upload a single ZIP file only
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Do not password protect the files
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Include all files as per guidelines
+                                    </li>
+                                    <li>
+                                        <IconOutline.SunIcon aria-hidden='true' />
+                                        Keep your handle out of your files and file names
+                                    </li>
+                                </>
+                            )}
                         </ul>
                     </section>
                     <section className={styles.infoCard}>
@@ -416,36 +521,76 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                         </div>
                     ) : (
                         <>
-                            <div className={styles.fileUploader}>
-                                <label htmlFor='challenge-submission-file'>
-                                    {pluralUpload ? 'Upload File(s)' : 'Upload File'}
-                                    <span>*</span>
-                                </label>
-                                <input
-                                    accept='.zip,application/zip,application/x-zip-compressed'
-                                    disabled={uploading}
-                                    id='challenge-submission-file'
-                                    onChange={changeFile}
-                                    ref={input}
-                                    type='file'
-                                />
-                                <button
-                                    className={classNames(styles.dropZone, { [styles.dragActive]: dragActive })}
-                                    disabled={uploading}
-                                    onClick={browse}
-                                    onDragEnter={() => setDragActive(true)}
-                                    onDragLeave={() => setDragActive(false)}
-                                    onDragOver={dragOver}
-                                    onDrop={dropFile}
-                                    type='button'
-                                >
-                                    <IconOutline.UploadIcon aria-hidden='true' />
-                                    <span>Drop your file(s) here or</span>
-                                    <strong>Browse</strong>
-                                </button>
-                                <small>Format file must be .zip | Max file size 500MB</small>
-                                {error && <p className={styles.error} role='alert'>{error}</p>}
-                            </div>
+                            {urlMode ? (
+                                <div className={styles.urlSubmission}>
+                                    <label htmlFor='challenge-submission-url'>
+                                        Submission URL
+                                        <span>*</span>
+                                    </label>
+                                    <div className={styles.urlInputRow}>
+                                        <input
+                                            aria-describedby={error
+                                                ? 'challenge-submission-url-help challenge-submission-url-error'
+                                                : 'challenge-submission-url-help'}
+                                            aria-invalid={!!error}
+                                            autoComplete='url'
+                                            disabled={uploading}
+                                            id='challenge-submission-url'
+                                            onChange={changeUrl}
+                                            placeholder='https://example.com/your-solution'
+                                            type='url'
+                                            value={urlInput}
+                                        />
+                                        <button
+                                            className={styles.setUrlButton}
+                                            disabled={uploading}
+                                            onClick={confirmUrl}
+                                            type='button'
+                                        >
+                                            Set URL
+                                        </button>
+                                    </div>
+                                    <small id='challenge-submission-url-help'>
+                                        Enter an absolute URL beginning with http:// or https://.
+                                    </small>
+                                    {error && (
+                                        <p className={styles.error} id='challenge-submission-url-error' role='alert'>
+                                            {error}
+                                        </p>
+                                    )}
+                                </div>
+                            ) : (
+                                <div className={styles.fileUploader}>
+                                    <label htmlFor='challenge-submission-file'>
+                                        {pluralUpload ? 'Upload File(s)' : 'Upload File'}
+                                        <span>*</span>
+                                    </label>
+                                    <input
+                                        accept='.zip,application/zip,application/x-zip-compressed'
+                                        disabled={uploading}
+                                        id='challenge-submission-file'
+                                        onChange={changeFile}
+                                        ref={input}
+                                        type='file'
+                                    />
+                                    <button
+                                        className={classNames(styles.dropZone, { [styles.dragActive]: dragActive })}
+                                        disabled={uploading}
+                                        onClick={browse}
+                                        onDragEnter={() => setDragActive(true)}
+                                        onDragLeave={() => setDragActive(false)}
+                                        onDragOver={dragOver}
+                                        onDrop={dropFile}
+                                        type='button'
+                                    >
+                                        <IconOutline.UploadIcon aria-hidden='true' />
+                                        <span>Drop your file(s) here or</span>
+                                        <strong>Browse</strong>
+                                    </button>
+                                    <small>Format file must be .zip | Max file size 500MB</small>
+                                    {error && <p className={styles.error} role='alert'>{error}</p>}
+                                </div>
+                            )}
                             {file && (
                                 <div className={styles.uploadedFile}>
                                     <strong aria-live='polite'>{uploading ? 'Uploading' : 'Ready to upload'}</strong>
@@ -462,7 +607,7 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                                         </div>
                                         <button
                                             aria-label={uploading ? 'Cancel upload' : 'Remove selected file'}
-                                            onClick={clearFile}
+                                            onClick={clearSelection}
                                             type='button'
                                         >
                                             {uploading
@@ -486,10 +631,35 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                                     </div>
                                 </div>
                             )}
+                            {submissionUrl && (
+                                <div className={styles.uploadedFile}>
+                                    <strong aria-live='polite'>
+                                        {uploading ? 'Submitting URL' : 'Ready to submit'}
+                                    </strong>
+                                    <div className={styles.fileRow}>
+                                        <IconOutline.LinkIcon aria-hidden='true' />
+                                        <div className={styles.fileCopy}>
+                                            <strong>{submissionUrl}</strong>
+                                            <span>Submission URL</span>
+                                        </div>
+                                        <button
+                                            aria-label={uploading ? 'Cancel submission' : 'Clear submission URL'}
+                                            onClick={clearSelection}
+                                            type='button'
+                                        >
+                                            {uploading
+                                                ? <IconOutline.XIcon aria-hidden='true' />
+                                                : <IconOutline.TrashIcon aria-hidden='true' />}
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
                             <div className={styles.declaration}>
                                 <h3>Declaration</h3>
                                 <p>
-                                    Submitting your files means you hereby agree to the
+                                    {urlMode
+                                        ? 'Submitting your link means you hereby agree to the'
+                                        : 'Submitting your files means you hereby agree to the'}
                                     {' '}
                                     <a
                                         className={styles.inlineButton}
@@ -500,15 +670,18 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                                         Topcoder Terms of Use
                                     </a>
                                     {' '}
-                                    and to the extent your uploaded file wins a Topcoder competition, you hereby assign,
-                                    grant and transfer and agree to assign, grant and transfer to Topcoder all right and
-                                    title in and to the Winning Submission (as further described in the terms of use).
+                                    {urlMode
+                                        ? 'and to the extent your linked solution wins a Topcoder competition, '
+                                        : 'and to the extent your uploaded file wins a Topcoder competition, '}
+                                    you hereby assign, grant and transfer and agree to assign, grant and transfer to
+                                    Topcoder all right and title in and to the Winning Submission (as further described
+                                    in the terms of use).
                                 </p>
                             </div>
                             <label className={styles.agreement}>
                                 <input
                                     checked={agreementAccepted}
-                                    disabled={!file || uploading}
+                                    disabled={!selectionReady || uploading}
                                     onChange={event => setAgreementAccepted(event.target.checked)}
                                     type='checkbox'
                                 />
@@ -528,12 +701,14 @@ export const ChallengeSubmissionUpload: FC<ChallengeSubmissionUploadProps> = pro
                                     className={styles.primaryButton}
                                     data-analytics-id='challenge-submit-confirm'
                                     data-analytics-placement='challenge-submission'
-                                    disabled={!file || !agreementAccepted || uploading}
+                                    disabled={!selectionReady || !agreementAccepted || uploading}
                                     onClick={submit}
                                     type='button'
                                 >
-                                    <IconOutline.UploadIcon aria-hidden='true' />
-                                    {uploading ? 'Uploading…' : 'Submit'}
+                                    {urlMode
+                                        ? <IconOutline.LinkIcon aria-hidden='true' />
+                                        : <IconOutline.UploadIcon aria-hidden='true' />}
+                                    {uploading ? (urlMode ? 'Submitting…' : 'Uploading…') : 'Submit'}
                                 </button>
                             </div>
                         </>

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -11,6 +11,7 @@ import { init } from 'filestack-js'
 import {
     buildOpportunityPageUrl,
     createChallengeSubmission,
+    createChallengeUrlSubmission,
     deleteChallengeSubmission,
     downloadChallengeSubmissionArtifact,
     getChallengeAiReviewConfig,
@@ -1319,6 +1320,55 @@ describe('opportunities service normalization', () => {
             .toHaveBeenNthCalledWith(1, 50)
         expect(progress)
             .toHaveBeenLastCalledWith(100)
+    })
+
+    it('creates a URL submission directly without initializing Filestack', async () => {
+        const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
+        const initMock = init as jest.MockedFunction<typeof init>
+        const controller = new AbortController()
+        initMock.mockClear()
+        post.mockResolvedValueOnce({ id: 'url-submission-id' } as never)
+
+        await expect(createChallengeUrlSubmission(
+            'challenge-id',
+            '123',
+            'CONTEST_SUBMISSION',
+            '  https://deliverables.example.com/member/result  ',
+            controller.signal,
+        ))
+            .resolves.toEqual({ id: 'url-submission-id' })
+
+        expect(post)
+            .toHaveBeenCalledWith(
+                'https://api.example/v6/submissions',
+                {
+                    challengeId: 'challenge-id',
+                    memberId: '123',
+                    type: 'CONTEST_SUBMISSION',
+                    url: 'https://deliverables.example.com/member/result',
+                },
+                { signal: controller.signal },
+            )
+        expect(initMock)
+            .not.toHaveBeenCalled()
+    })
+
+    it('does not create an already-cancelled URL submission', async () => {
+        const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
+        const controller = new AbortController()
+        post.mockClear()
+        controller.abort()
+
+        await expect(createChallengeUrlSubmission(
+            'challenge-id',
+            '123',
+            'CONTEST_SUBMISSION',
+            'https://deliverables.example.com/member/result',
+            controller.signal,
+        ))
+            .rejects.toMatchObject({ name: 'AbortError' })
+        expect(post)
+            .not.toHaveBeenCalled()
     })
 
     it('requests only the latest submission per member for the main table', async () => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -157,6 +157,46 @@ export async function createChallengeSubmission(
 }
 
 /**
+ * Creates a challenge submission whose deliverable is an authored external URL.
+ *
+ * URL submissions bypass Filestack and storage because Review API persists the
+ * member-provided link as a non-file submission. Registration and open-phase
+ * authorization remain owned by Review API.
+ *
+ * @param challengeId Challenge API UUID receiving the submission.
+ * @param memberId authenticated submitter's numeric member identifier serialized as text.
+ * @param type Review API submission category derived from the active challenge phase.
+ * @param url validated absolute HTTP(S) URL supplied by the member.
+ * @param signal optional abort signal used by the form's cancel action.
+ * @returns the newly created Review API submission.
+ * @throws request, authorization, registration, phase, validation, or abort errors.
+ */
+export async function createChallengeUrlSubmission(
+    challengeId: string,
+    memberId: string,
+    type: ChallengeSubmissionType,
+    url: string,
+    signal?: AbortSignal,
+): Promise<ChallengeSubmission> {
+    if (signal?.aborted) throw new DOMException('Submission cancelled.', 'AbortError')
+    return xhrPostAsync<{
+        challengeId: string
+        memberId: string
+        type: ChallengeSubmissionType
+        url: string
+    }, ChallengeSubmission>(
+        `${V6_URL}/submissions`,
+        {
+            challengeId,
+            memberId,
+            type,
+            url: url.trim(),
+        },
+        { signal },
+    )
+}
+
+/**
  * Converts a value into a finite non-negative number.
  *
  * @param value API value that may be numeric or a serialized number.

--- a/src/apps/opportunities/src/utils/challenge-detail.utils.spec.ts
+++ b/src/apps/opportunities/src/utils/challenge-detail.utils.spec.ts
@@ -6,6 +6,7 @@ import {
     challengeReviewAppUrl,
     challengeScorecardUrl,
     challengeSidebarLinks,
+    challengeSubmissionMode,
     challengeSubmissionLimit,
     memberProfileUrl,
 } from './challenge-detail.utils'
@@ -98,6 +99,32 @@ describe('challenge detail utilities', () => {
             .toBe(false)
         expect(challengeAllowsStockArt({ ...challenge, metadata: [] }))
             .toBe(false)
+    })
+
+    it('enables URL submissions only for the exact normalized metadata value', () => {
+        expect(challengeSubmissionMode({
+            id: 'url-challenge',
+            metadata: [{ name: ' SUBMISSION_TYPE ', value: ' URL ' }],
+            name: 'URL challenge',
+        }))
+            .toBe('url')
+        expect(challengeSubmissionMode({
+            id: 'zip-challenge',
+            metadata: [{ name: 'submission_type', value: 'zip' }],
+            name: 'ZIP challenge',
+        }))
+            .toBe('zip')
+        expect(challengeSubmissionMode({
+            id: 'unsupported-challenge',
+            metadata: [{ name: 'submission_type', value: 'external-url' }],
+            name: 'Unsupported challenge',
+        }))
+            .toBe('zip')
+        expect(challengeSubmissionMode({
+            id: 'default-challenge',
+            name: 'Default challenge',
+        }))
+            .toBe('zip')
     })
 
     it('returns only safe authored challenge and attachment links', () => {

--- a/src/apps/opportunities/src/utils/challenge-detail.utils.ts
+++ b/src/apps/opportunities/src/utils/challenge-detail.utils.ts
@@ -11,6 +11,9 @@ export interface ChallengeSidebarLink {
     url: string
 }
 
+/** Submission experiences selected by Work Manager challenge metadata. */
+export type ChallengeSubmissionMode = 'url' | 'zip'
+
 /**
  * Builds the canonical Review App challenge-detail destination.
  *
@@ -62,6 +65,25 @@ export function challengeMetadataValue(
         .toLowerCase()
     return metadata?.find(item => item.name.trim()
         .toLowerCase() === normalizedName)?.value
+}
+
+/**
+ * Resolves whether a challenge accepts a URL or the standard ZIP archive.
+ *
+ * Work Manager persists this choice as `submission_type` metadata. URL mode
+ * is deliberately opt-in: missing, malformed, and unsupported values retain
+ * the established ZIP flow.
+ *
+ * @param challenge raw Challenge API detail response.
+ * @returns `url` only for an exact case-insensitive metadata value; otherwise `zip`.
+ * @throws Does not throw.
+ */
+export function challengeSubmissionMode(challenge: ChallengeOpportunity): ChallengeSubmissionMode {
+    const value = challengeMetadataValue(challenge.metadata, 'submission_type')
+    return typeof value === 'string' && value.trim()
+        .toLowerCase() === 'url'
+        ? 'url'
+        : 'zip'
 }
 
 /**


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6289

# What’s in this PR?

- Resolves URL mode only when challenge metadata contains submission_type=url, case-insensitively; all other cases retain ZIP submission.
- Adds the labeled URL input, Set URL confirmation, accessible HTTP(S) validation, URL-specific guidance, declaration gating, cancellation, and reset/success behavior.
- Posts URL submissions directly to Review API without initializing Filestack, while leaving the existing ZIP upload path unchanged.
- Documents the submission-mode contract and adds component, utility, and service coverage.

## Validation

- Focused Jest suites: 3 passed, 82 tests passed.
- yarn lint: passed.
- NODE_OPTIONS=--max-old-space-size=8192 yarn run build: passed.
- git diff --check: passed.

## Notes

The production build continues to report the repository’s existing source-map, CSS-order, baseline lint, and bundle-size warnings; it completes successfully. Review API already accepts external submission URLs at POST /v6/submissions, so this change requires no API repository update.