### PR TITLE
PM-6291 Restore My Submissions downloads

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -400,7 +400,13 @@ and active challenges retain the ongoing-review guidance.
 
 Registered members submit without leaving challenge details. My Submissions
 also exposes the environment-specific Review App handoff before and after an
-upload. Work Manager's case-insensitive `submission_type=url` challenge
+upload. File-backed rows expose the authorized download action for every
+challenge track, while authored external-URL rows omit that file action. The
+browser requests a short-lived URL from
+`GET /v6/submissions/:submissionId/download-url` instead of using submission
+list URLs; Review API remains authoritative for access and signs only clean
+storage, so pending DMZ and quarantined files cannot be downloaded. Work
+Manager's case-insensitive `submission_type=url` challenge
 metadata selects the URL experience; every other value, including missing or
 malformed metadata, retains the standard ZIP experience. URL submissions
 require a confirmed absolute HTTP(S) link and send that link directly to

--- a/src/apps/opportunities/src/models/opportunity.models.ts
+++ b/src/apps/opportunities/src/models/opportunity.models.ts
@@ -374,6 +374,8 @@ export interface ChallengeSubmission {
     finalScore?: number | string | null
     id: string
     initialScore?: number | string | null
+    /** Review API discriminator; false when the submission is an authored external URL. */
+    isFileSubmission?: boolean
     isLatest?: boolean
     memberHandle?: string
     memberId?: string

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -23,6 +23,7 @@ import { ChallengeDetailsPage } from './ChallengeDetailsPage'
 const mockUseSWR = jest.fn()
 const mockAgreeToTerms = jest.fn()
 const mockDeleteSubmission = jest.fn()
+const mockGetSubmissionDownloadUrl = jest.fn()
 const mockChallengeMutate = jest.fn()
 const mockChallengeForumRender = jest.fn()
 const mockMySubmissionCountMutate = jest.fn()
@@ -225,7 +226,7 @@ jest.mock('../services', () => ({
     getChallengeProjectResults: jest.fn(),
     getChallengeRegistration: jest.fn(),
     getChallengeReviewSummations: jest.fn(),
-    getChallengeSubmissionDownloadUrl: jest.fn(),
+    getChallengeSubmissionDownloadUrl: (...args: unknown[]) => mockGetSubmissionDownloadUrl(...args),
     getChallengeSubmissionPreviews: jest.fn(),
     getChallengeSubmissions: jest.fn(),
     getChallengeSubmitters: jest.fn(),
@@ -435,6 +436,9 @@ describe('ChallengeDetailsPage member flows', () => {
         mockRegister.mockResolvedValue({ id: 'new-resource-id', memberId: 123 })
         mockAgreeToTerms.mockResolvedValue(undefined)
         mockDeleteSubmission.mockResolvedValue(undefined)
+        mockGetSubmissionDownloadUrl.mockResolvedValue(
+            'https://clean-storage.example/submission-1.zip',
+        )
         mockChallengeMutate.mockImplementation(async update => (
             typeof update === 'function' ? update(mockChallenge) : update
         ))
@@ -1122,16 +1126,19 @@ describe('ChallengeDetailsPage member flows', () => {
             .not.toBeInTheDocument()
     })
 
-    it('renders the Development My Submissions fields and authored actions', () => {
+    it('renders and downloads the Development My Submissions fields and authored actions', async () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }
         mockSubmissions = [{
             createdAt: '2026-06-03T09:30:00.000Z',
             id: 'submission-1',
+            isFileSubmission: true,
             status: 'ACTIVE',
             type: 'CONTEST_SUBMISSION',
         }]
         mockChallenge = { ...mockChallenge, status: 'ACTIVE' }
+        const anchorClick = jest.spyOn(HTMLAnchorElement.prototype, 'click')
+            .mockImplementation(() => undefined)
 
         renderPage()
         fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
@@ -1155,8 +1162,17 @@ describe('ChallengeDetailsPage member flows', () => {
         expect(screen.getByText('submission-1')
             .closest('a'))
             .toBeNull()
-        expect(screen.queryByRole('button', { name: 'Download submission submission-1' }))
-            .not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Download submission submission-1' }))
+        await waitFor(() => expect(mockGetSubmissionDownloadUrl)
+            .toHaveBeenCalledWith('submission-1'))
+        await waitFor(() => expect(anchorClick)
+            .toHaveBeenCalledTimes(1))
+        expect(anchorClick.mock.instances[0])
+            .toMatchObject({
+                href: 'https://clean-storage.example/submission-1.zip',
+                rel: 'noreferrer',
+                target: '_blank',
+            })
         expect(screen.getByRole('button', { name: 'View history for submission submission-1' }))
             .toBeInTheDocument()
         const submissionRequest = mockUseSWR.mock.calls.find(([key]) => (
@@ -1166,6 +1182,31 @@ describe('ChallengeDetailsPage member flows', () => {
         ))
         expect(submissionRequest?.[2])
             .toMatchObject({ refreshInterval: 30000, shouldRetryOnError: false })
+    })
+
+    it('does not offer a clean-storage download for an external URL submission', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockChallenge = {
+            ...mockChallenge,
+            metadata: [{ name: 'submission_type', value: 'url' }],
+        }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'url-submission',
+            isFileSubmission: false,
+            status: 'ACTIVE',
+            type: 'CONTEST_SUBMISSION',
+            url: 'https://deliverables.example.com/member/result',
+        }]
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.queryByRole('button', { name: 'Download submission url-submission' }))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'Open submission url-submission in Review App' }))
+            .toBeInTheDocument()
     })
 
     it('displays a completed AI workflow score in active My Submissions', () => {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -1542,7 +1542,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                         ) : undefined}
                                         <td data-mobile-label='Actions'>
                                             <div className={styles.submissionActions}>
-                                                {(isDesign || isQa || isMarathonMatch) && (
+                                                {submission.isFileSubmission !== false && (
                                                     <button
                                                         aria-label={`Download submission ${submission.id}`}
                                                         disabled={downloadingSubmissionId === submission.id}


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6291

# What’s in this PR?
- Restores the Download action for file-backed Development submissions instead of limiting it by challenge track.
- Uses Review API’s `isFileSubmission` discriminator so external-URL submissions do not receive a broken clean-storage action.
- Verifies the signed download URL click flow and URL-submission regression, and documents the clean-storage contract.

## Validation
- `yarn test:no-watch src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx --runInBand` (52 passed)
- `yarn lint`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn run build`
- `git diff --check`