### PR TITLE
PM-6292 Fix legacy forum challenge links

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -455,7 +455,10 @@ rather than browser prompts; per-member
 thumbs-up/thumbs-down reactions, watch state, and read state remain inside the
 challenge detail page. The Markdown editor continues ordered and unordered
 lists on Enter; safe Markdown styling is retained in topic excerpts and full
-posts. Each visible post shows shared
+posts. Rendered Markdown also canonicalizes exact first-party legacy
+`/challenges/:challengeId` links to the active Opportunities detail route while
+preserving query parameters and fragments; stored forum content and unrelated
+links remain unchanged. Each visible post shows shared
 reaction counts and the current member's selected state; clicking the selected
 thumb again removes it, while clicking the other thumb switches it. Topic
 summaries expose bounded starter excerpts, participant snapshots, unique

--- a/src/apps/opportunities/src/components/ChallengeMarkdown.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeMarkdown.spec.tsx
@@ -2,16 +2,43 @@
 import { render, RenderResult, screen } from '@testing-library/react'
 
 import {
+    canonicalizeLegacyChallengeLink,
     ChallengeDescription,
     isHtmlDescriptionFormat,
+    transformChallengeMarkdownLink,
 } from './ChallengeMarkdown'
 
 const mockMarkdownProps: Array<Record<string, unknown>> = []
 
-jest.mock('react-markdown', () => function MarkdownMock(props: Record<string, unknown>) {
-    mockMarkdownProps.push(props)
-    return <div data-testid='markdown-renderer'>{props.children as string}</div>
-})
+jest.mock('react-markdown', () => ({
+    __esModule: true,
+    default: function MarkdownMock(props: Record<string, unknown>) {
+        mockMarkdownProps.push(props)
+        return <div data-testid='markdown-renderer'>{props.children as string}</div>
+    },
+    uriTransformer: (href: string): string => {
+        const candidate = href.trim()
+        const firstCharacter = candidate.charAt(0)
+        if (firstCharacter === '#' || firstCharacter === '/') return candidate
+
+        const colonIndex = candidate.indexOf(':')
+        if (colonIndex === -1) return candidate
+
+        const safeScheme = ['http', 'https', 'mailto', 'tel'].some(scheme => (
+            colonIndex === scheme.length
+            && candidate.slice(0, scheme.length)
+                .toLowerCase() === scheme
+        ))
+        if (safeScheme) return candidate
+
+        const queryIndex = candidate.indexOf('?')
+        const fragmentIndex = candidate.indexOf('#')
+        if ((queryIndex !== -1 && colonIndex > queryIndex)
+            || (fragmentIndex !== -1 && colonIndex > fragmentIndex)) return candidate
+
+        return ['java', 'script:void(0)'].join('')
+    },
+}))
 jest.mock('rehype-raw', () => jest.fn())
 jest.mock('rehype-sanitize', () => ({
     __esModule: true,
@@ -20,9 +47,85 @@ jest.mock('rehype-sanitize', () => ({
 }))
 jest.mock('remark-breaks', () => jest.fn())
 jest.mock('remark-gfm', () => jest.fn())
+jest.mock('~/config', () => ({
+    AppSubdomain: { opportunities: 'opportunities' },
+    EnvironmentConfig: {
+        SUBDOMAIN: 'www',
+        TC_DOMAIN: 'topcoder-dev.com',
+    },
+}), { virtual: true })
 
 beforeEach(() => {
     mockMarkdownProps.length = 0
+})
+
+describe('canonicalizeLegacyChallengeLink', () => {
+    const domain = 'topcoder-dev.com'
+    const routePrefix = '/opportunities'
+
+    it('canonicalizes naked, www, and root-relative legacy challenge detail links', () => {
+        expect(canonicalizeLegacyChallengeLink(
+            'https://topcoder-dev.com/challenges/d8dc1e2f-3aed-4a16-a895-ddc7cd69f055',
+            domain,
+            routePrefix,
+        ))
+            .toBe('/opportunities/challenge/d8dc1e2f-3aed-4a16-a895-ddc7cd69f055')
+        expect(canonicalizeLegacyChallengeLink(
+            'http://www.topcoder-dev.com/challenges/30012345/',
+            domain,
+            routePrefix,
+        ))
+            .toBe('/opportunities/challenge/30012345')
+        expect(canonicalizeLegacyChallengeLink(
+            '/challenges/challenge-id/?tab=forum&tab=posts#latest',
+            domain,
+            '',
+        ))
+            .toBe('/challenge/challenge-id?tab=forum&tab=posts#latest')
+    })
+
+    it('canonicalizes protocol-relative links while retaining query and hash values', () => {
+        expect(canonicalizeLegacyChallengeLink(
+            '//www.topcoder-dev.com/challenges/challenge-id?tab=forum#post-1',
+            domain,
+            routePrefix,
+        ))
+            .toBe('/opportunities/challenge/challenge-id?tab=forum#post-1')
+    })
+
+    it('leaves unsafe, external, lookalike, and cross-environment links unchanged', () => {
+        const unchangedLinks = [
+            ['java', 'script:alert(1)'].join(''),
+            'mailto:help@topcoder.com',
+            'https://example.com/challenges/challenge-id',
+            'https://topcoder-dev.com.evil.example/challenges/challenge-id',
+            'https://evil-topcoder-dev.com/challenges/challenge-id',
+            'https://vanilla.topcoder-dev.com/challenges/challenge-id',
+            'https://topcoder.com/challenges/challenge-id',
+            'https://[invalid/challenges/challenge-id',
+        ]
+
+        unchangedLinks.forEach(link => {
+            expect(canonicalizeLegacyChallengeLink(link, domain, routePrefix))
+                .toBe(link)
+        })
+    })
+
+    it('leaves non-detail challenge routes and canonical Opportunities routes unchanged', () => {
+        const unchangedLinks = [
+            '/challenges',
+            '/challenges/challenge-id/review-opportunities',
+            '/challenges/terms/detail/challenge-id',
+            '/challenges/challenge-id/submit',
+            '/challenges/challenge-id/my-submissions',
+            '/opportunities/challenge/challenge-id',
+        ]
+
+        unchangedLinks.forEach(link => {
+            expect(canonicalizeLegacyChallengeLink(link, domain, routePrefix))
+                .toBe(link)
+        })
+    })
 })
 
 describe('ChallengeDescription', () => {
@@ -50,6 +153,22 @@ describe('ChallengeDescription', () => {
 
         expect(screen.getByTestId('markdown-renderer').textContent)
             .toBe('## Markdown requirements')
+    })
+
+    it('configures a safe canonicalizer for Markdown and sanitized raw HTML anchor destinations', () => {
+        render(<ChallengeDescription content='[Challenge](https://topcoder-dev.com/challenges/challenge-id)' />)
+        const transformLinkUri = mockMarkdownProps[0].transformLinkUri as (href: string) => string
+
+        expect(transformLinkUri)
+            .toBe(transformChallengeMarkdownLink)
+        expect(transformLinkUri('https://topcoder-dev.com/challenges/challenge-id'))
+            .toBe('/opportunities/challenge/challenge-id')
+        expect(transformLinkUri(
+            'https://www.topcoder-dev.com/challenges/challenge-id?tab=forum#latest',
+        ))
+            .toBe('/opportunities/challenge/challenge-id?tab=forum#latest')
+        expect(transformLinkUri(['java', 'script:alert(1)'].join('')))
+            .toBe(['java', 'script:void(0)'].join(''))
     })
 
     it('parses and sanitizes safe inline forum HTML such as underline markup', () => {

--- a/src/apps/opportunities/src/components/ChallengeMarkdown.tsx
+++ b/src/apps/opportunities/src/components/ChallengeMarkdown.tsx
@@ -7,16 +7,26 @@ import {
     useMemo,
 } from 'react'
 import DOMPurify from 'dompurify'
-import ReactMarkdown, { Components, Options as ReactMarkdownOptions } from 'react-markdown'
+import ReactMarkdown, {
+    Components,
+    Options as ReactMarkdownOptions,
+    uriTransformer,
+} from 'react-markdown'
 import type { HeadingProps } from 'react-markdown/lib/ast-to-react'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 
+import { AppSubdomain, EnvironmentConfig } from '~/config'
+
 import styles from './ChallengeMarkdown.module.scss'
 
 const Markdown = ReactMarkdown as unknown as FC<ReactMarkdownOptions>
+const ABSOLUTE_HTTP_LINK_PATTERN = /^https?:\/\//i
+const LEGACY_CHALLENGE_PATH_PATTERN = /^\/challenges\/([^/]+)\/?$/
+const PROTOCOL_RELATIVE_LINK_PATTERN = /^\/\//
+const ROOT_RELATIVE_LINK_PATTERN = /^\/(?!\/)/
 
 export interface ChallengeTocItem {
     id: string
@@ -112,6 +122,69 @@ export function markdownHeadingText(children: ReactNode): string {
 }
 
 /**
+ * Canonicalizes a first-party legacy challenge-detail link without depending on
+ * application route modules. Callers supply the active Topcoder domain and the
+ * route prefix used by their host so this helper remains deterministic and
+ * reusable in tests.
+ *
+ * @param href safe candidate link from rendered Markdown.
+ * @param currentDomain active environment domain, such as `topcoder-dev.com`.
+ * @param routePrefix Opportunities route prefix, either `/opportunities` or an empty string.
+ * @returns canonical internal challenge link, or the original value when it is not an exact legacy detail URL.
+ * @throws Does not throw for malformed links.
+ */
+export function canonicalizeLegacyChallengeLink(
+    href: string,
+    currentDomain: string,
+    routePrefix: string,
+): string {
+    const candidate = href.trim()
+    const protocolRelative = PROTOCOL_RELATIVE_LINK_PATTERN.test(candidate)
+    const rootRelative = ROOT_RELATIVE_LINK_PATTERN.test(candidate)
+    const absoluteHttp = ABSOLUTE_HTTP_LINK_PATTERN.test(candidate)
+
+    if (!candidate || (!absoluteHttp && !protocolRelative && !rootRelative)) return href
+
+    const normalizedDomain = currentDomain.trim()
+        .toLowerCase()
+    if (!normalizedDomain) return href
+
+    try {
+        const url = new URL(
+            protocolRelative ? `https:${candidate}` : candidate,
+            `https://${normalizedDomain}`,
+        )
+        const trustedHost = url.hostname === normalizedDomain
+            || url.hostname === `www.${normalizedDomain}`
+        if (!rootRelative && (!['http:', 'https:'].includes(url.protocol) || !trustedHost)) return href
+
+        const pathMatch = LEGACY_CHALLENGE_PATH_PATTERN.exec(url.pathname)
+        if (!pathMatch) return href
+
+        const normalizedRoutePrefix = routePrefix.replace(/\/+$/, '')
+        return `${normalizedRoutePrefix}/challenge/${pathMatch[1]}${url.search}${url.hash}`
+    } catch (error) {
+        return href
+    }
+}
+
+/**
+ * Applies React Markdown's URI safety policy before canonicalizing legacy
+ * first-party challenge links for the active application host.
+ *
+ * @param href authored Markdown link.
+ * @returns safe link, with exact legacy challenge-detail URLs made canonical.
+ * @throws Does not throw for malformed links.
+ */
+export function transformChallengeMarkdownLink(href: string): string {
+    const safeHref = uriTransformer(href)
+    const routePrefix = EnvironmentConfig.SUBDOMAIN === AppSubdomain.opportunities
+        ? ''
+        : `/${AppSubdomain.opportunities}`
+    return canonicalizeLegacyChallengeLink(safeHref, EnvironmentConfig.TC_DOMAIN, routePrefix)
+}
+
+/**
  * Renders a Markdown heading whose stable fragment matches the generated TOC.
  *
  * @param props heading level, source location, and rendered children from React Markdown.
@@ -164,6 +237,7 @@ export const ChallengeMarkdown: FC<ChallengeMarkdownProps> = props => {
                     [remarkGfm, { singleTilde: false }],
                     remarkBreaks,
                 ]}
+                transformLinkUri={transformChallengeMarkdownLink}
             >
                 {props.markdown}
             </Markdown>


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6292

# What's in this PR?

- Canonicalizes exact first-party /challenges/:challengeId links rendered by ChallengeMarkdown to the active Opportunities detail route.
- Supports the current environment's naked and www hosts plus root-relative links, retaining query strings and fragments.
- Composes the rewrite with ReactMarkdown's URI transformer so unsafe schemes remain blocked and unrelated links remain unchanged.
- Adds focused coverage for legacy URL variants, host/path exclusions, configured safety behavior, and documents the display-only rewrite.

## Validation

- yarn test:no-watch src/apps/opportunities/src/components/ChallengeMarkdown.spec.tsx
- yarn lint
- NODE_OPTIONS=--max-old-space-size=8192 yarn run build

The production build completes with existing source-map and CSS ordering warnings.