### PR TITLE
PM-6297 Keep registration first for concurrent phases

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -174,7 +174,10 @@ The expanded challenge timeline follows chronological phase order between the
 synthetic Launch and Winners boundaries. Launch uses the challenge start, each
 authored phase displays its actual (then scheduled fallback) start and end on
 separate rows, and Winners uses the top-level challenge end. Only responses
-without a valid challenge end fall back to the latest valid phase end.
+without a valid challenge end fall back to the latest valid phase end. When
+Registration and another phase share the same valid start, Registration is
+shown first so overlapping Checkpoint Submission schedules match the authored
+challenge flow rather than being ordered by their different end dates.
 
 Open phase flags, `currentPhase`, and `currentPhaseNames` can mark overlapping
 phases current. Ended phases and boundaries render complete, future milestones

--- a/src/apps/opportunities/src/components/ChallengeDetailHeader.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeDetailHeader.spec.tsx
@@ -571,6 +571,46 @@ describe('ChallengeDetailHeader actions and presentation', () => {
             .toEqual(['Launch', 'Registration', 'Checkpoint Submission', 'Submission', 'Winners'])
     })
 
+    it('places Registration before a concurrent Checkpoint Submission phase', () => {
+        const sharedStart = '2026-09-10T07:40:29.840Z'
+        render(
+            <MemoryRouter>
+                <ChallengeDetailHeader
+                    busy={false}
+                    challenge={challengeFixture({
+                        endDate: '2026-09-28T15:34:09.020Z',
+                        phases: [
+                            {
+                                actualStartDate: sharedStart,
+                                id: 'checkpoint-submission',
+                                name: 'Checkpoint Submission',
+                                scheduledEndDate: '2026-09-13T07:34:09.020Z',
+                            },
+                            {
+                                actualStartDate: sharedStart,
+                                id: 'registration',
+                                name: 'Registration',
+                                scheduledEndDate: '2026-09-16T07:34:09.020Z',
+                            },
+                        ],
+                        startDate: sharedStart,
+                    })}
+                    isRegistered
+                    onRegister={jest.fn()}
+                    onSubmit={jest.fn()}
+                    onUnregister={jest.fn()}
+                />
+            </MemoryRouter>,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show full timeline' }))
+        const itemLabels = within(screen.getByRole('region', { name: 'Challenge timeline' }))
+            .getAllByRole('listitem')
+            .map(item => item.querySelector('strong')?.textContent)
+        expect(itemLabels)
+            .toEqual(['Launch', 'Registration', 'Checkpoint Submission', 'Winners'])
+    })
+
     it('omits an ended Task review and keeps Registration before Submission', () => {
         const { container }: RenderResult = render(
             <MemoryRouter>

--- a/src/apps/opportunities/src/components/ChallengeDetailHeader.tsx
+++ b/src/apps/opportunities/src/components/ChallengeDetailHeader.tsx
@@ -298,6 +298,7 @@ function challengeTimelineEnd(challenge: ChallengeOpportunity): string | undefin
 
 /**
  * Builds the Figma timeline sequence from Challenge API boundaries and phases.
+ * Authored phases stay chronological, with Registration first when valid starts match.
  *
  * @param challenge Challenge API detail response.
  * @param selected API-authoritative current phase.
@@ -322,21 +323,26 @@ function challengeTimelineItems(
     const phases = authoredPhases
         .map((item, index) => ({ index, item }))
         .sort((left: IndexedChallengePhase, right: IndexedChallengePhase) => {
+            const leftKey = challengeCatalogKey(left.item.name)
+            const rightKey = challengeCatalogKey(right.item.name)
+            const leftIsRegistration = leftKey.includes('registration')
+            const rightIsRegistration = rightKey.includes('registration')
             if (taskChallenge) {
-                const leftKey = challengeCatalogKey(left.item.name)
-                const rightKey = challengeCatalogKey(right.item.name)
-                const leftIsRegistration = leftKey.includes('registration')
-                const rightIsRegistration = rightKey.includes('registration')
                 if (leftIsRegistration !== rightIsRegistration) return leftIsRegistration ? -1 : 1
             }
 
-            const leftStart = timelineTimestamp(
+            const leftStartTimestamp = timelineTimestamp(
                 left.item.actualStartDate ?? left.item.scheduledStartDate,
-            ) ?? Number.MAX_SAFE_INTEGER
-            const rightStart = timelineTimestamp(
+            )
+            const rightStartTimestamp = timelineTimestamp(
                 right.item.actualStartDate ?? right.item.scheduledStartDate,
-            ) ?? Number.MAX_SAFE_INTEGER
+            )
+            const leftStart = leftStartTimestamp ?? Number.MAX_SAFE_INTEGER
+            const rightStart = rightStartTimestamp ?? Number.MAX_SAFE_INTEGER
             if (leftStart !== rightStart) return leftStart - rightStart
+            if (leftStartTimestamp !== undefined && leftIsRegistration !== rightIsRegistration) {
+                return leftIsRegistration ? -1 : 1
+            }
 
             const leftEnd = timelineTimestamp(
                 left.item.actualEndDate ?? left.item.scheduledEndDate,


### PR DESCRIPTION
## Summary
- preserve chronological challenge timeline ordering
- place Registration before phases that share its valid start timestamp
- add regression coverage for the reported two-round Design challenge schedule
- document the timeline tie-break behavior

## Validation
- `yarn test ChallengeDetailHeader.spec.tsx --watchAll=false --runInBand` (27 tests passed)
- `yarn lint`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn run build`
- `git diff --check`

Jira: https://topcoder.atlassian.net/browse/PM-6297