### PR TITLE
fix(PM-6295): require explicit challenge term agreements

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -313,7 +313,15 @@ resolves that same role and sends `memberId` plus
 filters, global sorting, counts, and pagination. The terms modal similarly
 filters Challenge API references to the
 Submitter role and loads complete v5 Terms API records before an electronic
-agreement. Registration content stays unmounted until that request resolves
+agreement. Outstanding terms are presented one at a time and each electronic
+agreement is persisted before the next appears; the Submitter resource is not
+created until the final prerequisite succeeds. Ambiguous agreement failures are
+reconciled once against authenticated outstanding terms before a retry is shown.
+Member identity scopes the
+agreement cache, and numeric legacy references are followed through their
+canonical authenticated Terms API detail before eligibility is decided.
+Registration content stays
+unmounted until that request resolves
 and unmounts immediately on close, so unresolved fallback terms cannot flash
 during the modal transition. Passive “Review challenge terms” mode never
 registers or agrees on a member's behalf. Terms API HTML retains its semantic

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
@@ -98,6 +98,13 @@
     }
 }
 
+.progress {
+    color: #6f7787;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+}
+
 .modalAction {
     border-radius: 4px !important;
     font-family: 'Nunito Sans', sans-serif !important;

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies, ordered-imports/ordered-imports */
 import '@testing-library/jest-dom'
-import { PropsWithChildren } from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+    PropsWithChildren,
+    ReactNode,
+} from 'react'
+import {
+    act,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+} from '@testing-library/react'
 
 import { ChallengeTerm } from '../models'
 
@@ -16,14 +25,23 @@ interface MockSWRResponse {
 
 let mockSWRResponse: MockSWRResponse
 const mockBaseModal = jest.fn()
+const mockAgreeToTerms = jest.fn()
+const mockGetSubmitterTermsDetails = jest.fn()
+const mockMutateTermsCache = jest.fn()
+const mockUseSWR = jest.fn()
 
 jest.mock('swr', () => ({
     __esModule: true,
-    default: (): MockSWRResponse => mockSWRResponse,
+    default: (...args: unknown[]): MockSWRResponse => {
+        mockUseSWR(...args)
+        return mockSWRResponse
+    },
+    useSWRConfig: (): { mutate: jest.Mock } => ({ mutate: mockMutateTermsCache }),
 }))
 
 jest.mock('../services', () => ({
-    getChallengeSubmitterTermsDetails: jest.fn(),
+    agreeToChallengeTerms: (...args: unknown[]) => mockAgreeToTerms(...args),
+    getChallengeSubmitterTermsDetails: (...args: unknown[]) => mockGetSubmitterTermsDetails(...args),
     getChallengeTermDocuSignUrl: jest.fn(),
     getChallengeTermsDetails: jest.fn(),
 }))
@@ -34,19 +52,45 @@ jest.mock('~/libs/cms', () => ({
 
 jest.mock('~/libs/ui', () => ({
     BaseModal: (props: PropsWithChildren<{
+        buttons?: ReactNode
+        onClose: () => void
         open: boolean
         title: string
     }>): JSX.Element => {
         mockBaseModal(props)
-        return <>{props.open && <div aria-label={props.title} role='dialog'>{props.children}</div>}</>
+        return (
+            <>
+                {props.open && (
+                    <div aria-label={props.title} role='dialog'>
+                        <button aria-label='Close modal' onClick={props.onClose} type='button' />
+                        {props.children}
+                        {props.buttons}
+                    </div>
+                )}
+            </>
+        )
     },
-    Button: (props: { label: string }): JSX.Element => <button type='button'>{props.label}</button>,
+    Button: (props: {
+        disabled?: boolean
+        label: string
+        onClick?: () => void
+    }): JSX.Element => (
+        <button disabled={props.disabled} onClick={props.onClick} type='button'>{props.label}</button>
+    ),
     LoadingSpinner: (): JSX.Element => <span>Loading</span>,
 }), { virtual: true })
 
 describe('ChallengeTermsModal', () => {
     beforeEach(() => {
         mockBaseModal.mockClear()
+        mockAgreeToTerms.mockReset()
+        mockAgreeToTerms.mockResolvedValue(undefined)
+        mockGetSubmitterTermsDetails.mockReset()
+        mockMutateTermsCache.mockReset()
+        mockMutateTermsCache.mockImplementation(async (_key, update) => (typeof update === 'function'
+            ? update(mockSWRResponse.data)
+            : update))
+        mockUseSWR.mockClear()
         mockSWRResponse = {
             data: undefined,
             error: undefined,
@@ -58,8 +102,8 @@ describe('ChallengeTermsModal', () => {
     it('does not flash unresolved terms before showing the compact registration reminder', () => {
         const props = {
             mode: 'register' as const,
-            onAccept: jest.fn(),
             onClose: jest.fn(),
+            onComplete: jest.fn(),
             open: true,
             terms: [{ id: 'standard-terms', title: 'Challenge Terms' }],
         }
@@ -88,8 +132,8 @@ describe('ChallengeTermsModal', () => {
         render(
             <ChallengeTermsModal
                 mode='register'
-                onAccept={jest.fn()}
                 onClose={jest.fn()}
+                onComplete={jest.fn()}
                 open
                 terms={[{ id: 'standard-terms', title: 'Challenge Terms' }]}
             />,
@@ -109,8 +153,8 @@ describe('ChallengeTermsModal', () => {
         }
         const props = {
             mode: 'register' as const,
-            onAccept: jest.fn(),
             onClose: jest.fn(),
+            onComplete: jest.fn(),
             terms: [{ id: 'standard-terms', title: 'Challenge Terms' }],
         }
         const view = render(<ChallengeTermsModal {...props} open />)
@@ -137,8 +181,8 @@ describe('ChallengeTermsModal', () => {
         render(
             <ChallengeTermsModal
                 mode='register'
-                onAccept={jest.fn()}
                 onClose={jest.fn()}
+                onComplete={jest.fn()}
                 open
                 terms={[{ id: 'current-terms', title: 'Challenge Terms' }]}
             />,
@@ -146,6 +190,464 @@ describe('ChallengeTermsModal', () => {
 
         expect(screen.queryByRole('dialog'))
             .not.toBeInTheDocument()
+    })
+
+    it('persists Standard Terms and NDA separately before completing registration', async () => {
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: '<p>NDA body</p>',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const onComplete = jest.fn()
+            .mockResolvedValue(undefined)
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms, nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[standardTerms, nda]}
+            />,
+        )
+
+        expect(screen.getByRole('dialog', { name: 'Standard Terms 2026' }))
+            .toBeInTheDocument()
+        expect(screen.getByText('Agreement 1 of 2'))
+            .toBeInTheDocument()
+        expect(screen.getByText('Standard terms body'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('NDA body'))
+            .not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+
+        await waitFor(() => expect(mockAgreeToTerms)
+            .toHaveBeenNthCalledWith(1, [standardTerms]))
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+        expect(await screen.findByRole('dialog', {
+            name: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }))
+            .toBeInTheDocument()
+        expect(screen.getByText('Agreement 2 of 2'))
+            .toBeInTheDocument()
+        expect(screen.getByText('NDA body'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Standard terms body'))
+            .not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+
+        await waitFor(() => expect(onComplete)
+            .toHaveBeenCalledTimes(1))
+        expect(mockAgreeToTerms)
+            .toHaveBeenNthCalledWith(2, [nda])
+        expect(mockAgreeToTerms.mock.invocationCallOrder[1])
+            .toBeLessThan(onComplete.mock.invocationCallOrder[0])
+    })
+
+    it('stays on the active term and does not register when agreement fails', async () => {
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: '<p>NDA body</p>',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const onComplete = jest.fn()
+        mockAgreeToTerms.mockRejectedValueOnce(new Error('Terms API unavailable'))
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms, nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[standardTerms, nda]}
+            />,
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+
+        expect(await screen.findByRole('alert'))
+            .toHaveTextContent('Terms API unavailable')
+        expect(screen.getByRole('dialog', { name: 'Standard Terms 2026' }))
+            .toBeInTheDocument()
+        expect(screen.queryByText('NDA body'))
+            .not.toBeInTheDocument()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('advances when authoritative refresh confirms an ambiguous agreement succeeded', async () => {
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: '<p>NDA body</p>',
+            title: 'NDA',
+        }
+        mockAgreeToTerms.mockRejectedValueOnce(new Error('Response lost after save'))
+        mockGetSubmitterTermsDetails.mockResolvedValueOnce([nda])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms, nda],
+            isValidating: false,
+        }
+        const onComplete = jest.fn()
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[standardTerms, nda]}
+            />,
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+
+        expect(await screen.findByRole('dialog', { name: 'NDA' }))
+            .toBeInTheDocument()
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledWith([standardTerms, nda])
+        expect(mockMutateTermsCache)
+            .toHaveBeenNthCalledWith(
+                1,
+                ['opportunities:challenge-terms', 'register', 'anonymous', 'standard-terms:|nda:'],
+                [nda],
+                { revalidate: false },
+            )
+        expect(mockMutateTermsCache)
+            .toHaveBeenNthCalledWith(
+                2,
+                ['opportunities:challenge-terms', 'register', 'anonymous', 'standard-terms:|nda:'],
+                expect.any(Function),
+                { revalidate: false },
+            )
+        expect(screen.queryByRole('alert'))
+            .not.toBeInTheDocument()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('keeps final cache removal authoritative without registering when closed and reopened', async () => {
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: '<p>NDA body</p>',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms, nda],
+            isValidating: false,
+            mutate: jest.fn(),
+        }
+        mockMutateTermsCache.mockImplementation(async (_key, update) => {
+            const current = mockSWRResponse.data
+            const data = typeof update === 'function' ? update(current) : update
+            mockSWRResponse = { ...mockSWRResponse, data }
+            return data
+        })
+        const props = {
+            mode: 'register' as const,
+            onClose: jest.fn(),
+            onComplete: jest.fn(),
+            terms: [standardTerms, nda],
+        }
+        const view = render(<ChallengeTermsModal {...props} open />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        await waitFor(() => expect(screen.getByRole('dialog', {
+            name: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }))
+            .toBeInTheDocument())
+        let resolveAgreement: (() => void) | undefined
+        mockAgreeToTerms.mockReturnValueOnce(new Promise<void>(resolve => {
+            resolveAgreement = resolve
+        }))
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Close modal' }))
+        expect(props.onClose)
+            .toHaveBeenCalledTimes(1)
+        view.rerender(<ChallengeTermsModal {...props} open={false} />)
+        expect(props.onComplete)
+            .not.toHaveBeenCalled()
+        view.rerender(<ChallengeTermsModal {...props} open />)
+        expect(screen.getByRole('dialog', {
+            name: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }))
+            .toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Agreeing…' }))
+            .toBeDisabled()
+        await act(async () => resolveAgreement?.())
+        await waitFor(() => expect(mockMutateTermsCache)
+            .toHaveBeenCalledTimes(2))
+
+        expect(props.onComplete)
+            .not.toHaveBeenCalled()
+        expect(await screen.findByRole('dialog', { name: 'Important Reminder' }))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Standard terms body'))
+            .not.toBeInTheDocument()
+        expect(screen.queryByText('NDA body'))
+            .not.toBeInTheDocument()
+    })
+
+    it('evicts only the captured registration cache after switching mode and member', async () => {
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            roleId: 'submitter-role',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const passiveTerm: ChallengeTerm = {
+            id: 'nda',
+            roleId: 'viewer-role',
+            text: '<p>Passive NDA body</p>',
+            title: 'NDA reference',
+        }
+        const registrationKey = [
+            'opportunities:challenge-terms',
+            'register',
+            '123',
+            'standard-terms:submitter-role',
+        ]
+        const passiveKey = [
+            'opportunities:challenge-terms',
+            'view',
+            '456',
+            'nda:viewer-role',
+        ]
+        const cachedTerms = new Map<string, ChallengeTerm[]>([
+            [JSON.stringify(registrationKey), [standardTerms]],
+            [JSON.stringify(passiveKey), [passiveTerm]],
+        ])
+        mockMutateTermsCache.mockImplementation(async (key, update) => {
+            const serializedKey = JSON.stringify(key)
+            const current = cachedTerms.get(serializedKey)
+            const data = typeof update === 'function' ? update(current) : update
+            cachedTerms.set(serializedKey, data)
+            return data
+        })
+        let resolveAgreement: (() => void) | undefined
+        mockAgreeToTerms.mockReturnValueOnce(new Promise<void>(resolve => {
+            resolveAgreement = resolve
+        }))
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms],
+            isValidating: false,
+        }
+        const onComplete = jest.fn()
+        const view = render(
+            <ChallengeTermsModal
+                memberId='123'
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[standardTerms]}
+            />,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Close modal' }))
+        mockSWRResponse = { ...mockSWRResponse, data: [passiveTerm] }
+        view.rerender(
+            <ChallengeTermsModal
+                memberId='456'
+                mode='view'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[passiveTerm]}
+            />,
+        )
+        await act(async () => resolveAgreement?.())
+
+        await waitFor(() => expect(mockMutateTermsCache)
+            .toHaveBeenCalledWith(registrationKey, expect.any(Function), { revalidate: false }))
+        expect(mockMutateTermsCache.mock.calls.some(call => JSON.stringify(call[0]) === JSON.stringify(passiveKey)))
+            .toBe(false)
+        expect(cachedTerms.get(JSON.stringify(registrationKey)))
+            .toEqual([])
+        expect(cachedTerms.get(JSON.stringify(passiveKey)))
+            .toEqual([passiveTerm])
+        expect(screen.getByText('Passive NDA body'))
+            .toBeInTheDocument()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('does not skip the next term when the SWR pending list shrinks', async () => {
+        const terms: ChallengeTerm[] = [
+            {
+                agreeabilityType: 'Electronically-agreeable',
+                id: 'standard-terms',
+                text: '<p>Standard body</p>',
+                title: 'Standard Terms',
+            },
+            {
+                agreeabilityType: 'Electronically-agreeable',
+                id: 'nda',
+                text: '<p>NDA body</p>',
+                title: 'NDA',
+            },
+            {
+                agreeabilityType: 'Electronically-agreeable',
+                id: 'challenge-rules',
+                text: '<p>Rules body</p>',
+                title: 'Challenge Rules',
+            },
+        ]
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: terms,
+            isValidating: false,
+        }
+        const props = {
+            mode: 'register' as const,
+            onClose: jest.fn(),
+            onComplete: jest.fn(),
+            open: true,
+            terms,
+        }
+        const view = render(<ChallengeTermsModal {...props} />)
+        const firstScrollContainer = screen.getByText('Standard body')
+            .closest('article')?.parentElement
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        await waitFor(() => expect(screen.getByRole('dialog', { name: 'NDA' }))
+            .toBeInTheDocument())
+        const secondScrollContainer = screen.getByText('NDA body')
+            .closest('article')?.parentElement
+        expect(secondScrollContainer)
+            .not.toBe(firstScrollContainer)
+        mockSWRResponse = { ...mockSWRResponse, data: terms.slice(1) }
+        view.rerender(<ChallengeTermsModal {...props} />)
+
+        expect(screen.getByRole('dialog', { name: 'NDA' }))
+            .toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        await waitFor(() => expect(screen.getByRole('dialog', { name: 'Challenge Rules' }))
+            .toBeInTheDocument())
+        expect(mockAgreeToTerms)
+            .toHaveBeenNthCalledWith(2, [terms[1]])
+        expect(props.onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('scopes registration details by member and Submitter role', () => {
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [],
+            isValidating: false,
+        }
+        const props = {
+            mode: 'register' as const,
+            onClose: jest.fn(),
+            onComplete: jest.fn(),
+            open: true,
+            terms: [{ id: 'standard-terms', roleId: 'submitter-role-a' }],
+        }
+        const view = render(<ChallengeTermsModal {...props} memberId='123' />)
+
+        expect(mockUseSWR.mock.calls.at(-1)?.[0])
+            .toEqual([
+                'opportunities:challenge-terms',
+                'register',
+                '123',
+                'standard-terms:submitter-role-a',
+            ])
+
+        view.rerender(
+            <ChallengeTermsModal
+                {...props}
+                memberId='456'
+                terms={[{ id: 'standard-terms', roleId: 'submitter-role-b' }]}
+            />,
+        )
+
+        expect(mockUseSWR.mock.calls.at(-1)?.[0])
+            .toEqual([
+                'opportunities:challenge-terms',
+                'register',
+                '456',
+                'standard-terms:submitter-role-b',
+            ])
+    })
+
+    it('fails closed on the active external agreement', () => {
+        const externalNda: ChallengeTerm = {
+            agreeabilityType: 'DocuSign-template',
+            docusignTemplateId: 'nda-template',
+            id: 'nda',
+            text: '<p>NDA body</p>',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const onComplete = jest.fn()
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [externalNda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[externalNda]}
+            />,
+        )
+
+        expect(screen.getByRole('button', { name: 'I agree' }))
+            .toBeDisabled()
+        expect(screen.getByRole('button', { name: 'Complete with DocuSign' }))
+            .toBeInTheDocument()
+        expect(screen.getByRole('alert'))
+            .toHaveTextContent('Complete this external agreement before registering.')
+        expect(mockAgreeToTerms)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
     })
 
     it('still opens a retryable dialog when accepted-term hydration fails', () => {
@@ -158,8 +660,8 @@ describe('ChallengeTermsModal', () => {
         render(
             <ChallengeTermsModal
                 mode='register'
-                onAccept={jest.fn()}
                 onClose={jest.fn()}
+                onComplete={jest.fn()}
                 open
                 terms={[{ id: 'standard-terms', title: 'Challenge Terms' }]}
             />,
@@ -200,8 +702,8 @@ describe('ChallengeTermsModal', () => {
         render(
             <ChallengeTermsModal
                 mode='view'
-                onAccept={jest.fn()}
                 onClose={jest.fn()}
+                onComplete={jest.fn()}
                 open
                 terms={[{ id: 'standard-terms', title: 'Standard Terms 2026' }]}
             />,

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -3,10 +3,15 @@ import {
     FC,
     useEffect,
     useMemo,
+    useRef,
     useState,
 } from 'react'
+import type { FullConfiguration } from 'swr/dist/types'
 import DOMPurify from 'dompurify'
-import useSWR, { SWRResponse } from 'swr'
+import useSWR, {
+    SWRResponse,
+    useSWRConfig,
+} from 'swr'
 
 import { getSafeCmsLink } from '~/libs/cms'
 import {
@@ -18,6 +23,7 @@ import {
 
 import { ChallengeTerm } from '../models'
 import {
+    agreeToChallengeTerms,
     getChallengeSubmitterTermsDetails,
     getChallengeTermDocuSignUrl,
     getChallengeTermsDetails,
@@ -29,9 +35,10 @@ export type ChallengeTermsMode = 'register' | 'view'
 
 interface ChallengeTermsModalProps {
     busy?: boolean
+    memberId?: number | string
     mode: ChallengeTermsMode
-    onAccept: (terms: ChallengeTerm[]) => void
     onClose: () => void
+    onComplete: () => Promise<void> | void
     open: boolean
     terms: ChallengeTerm[]
 }
@@ -54,7 +61,8 @@ export function requiresExternalAgreement(term: ChallengeTerm): boolean {
 /**
  * Renders full Terms API content for either passive review or challenge
  * registration. View mode never exposes an agreement or registration action;
- * registration mode requires acknowledgement and blocks external agreements.
+ * registration mode persists one explicit agreement at a time and does not
+ * complete registration until the final outstanding term has been accepted.
  *
  * @param props term references, modal mode, submit state, and callbacks.
  * @returns Figma-aligned terms dialog with retryable detail loading.
@@ -62,14 +70,28 @@ export function requiresExternalAgreement(term: ChallengeTerm): boolean {
  */
 export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const [accepted, setAccepted] = useState(false)
+    const [completedTermIds, setCompletedTermIds] = useState<string[]>([])
+    const [agreementBusy, setAgreementBusy] = useState(false)
+    const [agreementError, setAgreementError] = useState('')
     const [externalBusy, setExternalBusy] = useState(false)
     const [externalError, setExternalError] = useState('')
+    const agreementRequestRef = useRef(0)
+    const activeAgreementRequestRef = useRef<number>()
+    const interactionRef = useRef(0)
+    const { mutate: mutateTermsCache }: FullConfiguration = useSWRConfig()
+    const memberScope = props.memberId === undefined ? 'anonymous' : String(props.memberId)
     const termKey = useMemo(
-        () => props.terms.map(term => term.id ?? term.url ?? term.title ?? 'term')
+        () => props.terms.map(term => `${term.id ?? term.url ?? term.title ?? 'term'}:${term.roleId ?? ''}`)
             .join('|'),
         [props.terms],
     )
     const shouldLoad = props.open && props.terms.some(term => !!term.id)
+    const termsCacheKey = shouldLoad ? [
+        'opportunities:challenge-terms',
+        props.mode,
+        memberScope,
+        termKey,
+    ] : undefined
     /**
      * Loads the terms appropriate to the active modal mode.
      *
@@ -82,13 +104,22 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         ? getChallengeSubmitterTermsDetails(props.terms)
         : getChallengeTermsDetails(props.terms))
     const response: SWRResponse<ChallengeTerm[], Error> = useSWR(
-        shouldLoad ? ['opportunities:challenge-terms', props.mode, termKey] : undefined,
+        termsCacheKey,
         loadTerms,
         { revalidateOnFocus: false },
     )
     const terms = response.data ?? (shouldLoad ? [] : props.terms)
-    const externalAgreement = terms.some(requiresExternalAgreement)
     const registrationMode = props.mode === 'register'
+    const pendingTerms = registrationMode
+        ? terms.filter(term => !term.id || !completedTermIds.includes(term.id))
+        : []
+    const activeTerm = pendingTerms[0]
+    const displayedTerms = registrationMode
+        ? activeTerm ? [activeTerm] : []
+        : terms
+    const activePosition = completedTermIds.length
+    const agreementTotal = completedTermIds.length + pendingTerms.length
+    const activeExternalAgreement = !!activeTerm && requiresExternalAgreement(activeTerm)
     const compactRegistration = registrationMode
         && !response.error
         && !response.isValidating
@@ -97,14 +128,18 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         && shouldLoad
         && !response.error
         && (response.isValidating || response.data === undefined)
-    const fullTitle = terms[0]?.title || props.terms[0]?.title || 'Challenge Terms'
+    const fullTitle = activeTerm?.title || terms[0]?.title || props.terms[0]?.title || 'Challenge Terms'
 
     useEffect(() => {
+        interactionRef.current += 1
         if (props.open) {
             setAccepted(false)
+            setCompletedTermIds([])
+            setAgreementError('')
+            setExternalBusy(false)
             setExternalError('')
         }
-    }, [props.open, props.mode])
+    }, [props.open, props.mode, memberScope, termKey])
 
     /**
      * Sanitizes Terms API HTML while removing document-authored inline CSS.
@@ -121,47 +156,142 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         FORBID_ATTR: ['style'],
     }))
 
-    /** Submits the exact resolved term records displayed to the member. */
-    const accept = (): void => props.onAccept(terms)
+    /**
+     * Persists the active electronic agreement before advancing to the next
+     * Submitter term. Registration begins only after the final agreement has
+     * succeeded, matching the legacy challenge prerequisite flow. An ambiguous
+     * POST failure is reconciled once against authenticated outstanding terms.
+     *
+     * @returns promise settled after agreement, advancement, or registration completion.
+     * @throws Does not throw; Terms API failures remain visible on the active term.
+     */
+    const acceptActiveTerm = async (): Promise<void> => {
+        if (!activeTerm || activeExternalAgreement || activeAgreementRequestRef.current !== undefined) return
+        const termId = activeTerm.id
+        if (!termId || !termsCacheKey) {
+            setAgreementError('We couldn\u2019t record this agreement because it is missing an identifier.')
+            return
+        }
+
+        const interaction = interactionRef.current
+        const agreementRequest = agreementRequestRef.current + 1
+        agreementRequestRef.current = agreementRequest
+        activeAgreementRequestRef.current = agreementRequest
+        const finalTerm = pendingTerms.length === 1
+        setAgreementBusy(true)
+        setAgreementError('')
+        try {
+            try {
+                await agreeToChallengeTerms([activeTerm])
+            } catch (agreementFailure) {
+                if (interaction !== interactionRef.current) return
+                let refreshedTerms: ChallengeTerm[] | undefined
+                try {
+                    refreshedTerms = await getChallengeSubmitterTermsDetails(props.terms)
+                } catch {
+                    throw agreementFailure
+                }
+
+                if (interaction !== interactionRef.current) return
+                await mutateTermsCache(termsCacheKey, refreshedTerms, { revalidate: false })
+                if (!refreshedTerms || refreshedTerms.some(term => term.id === termId)) {
+                    throw agreementFailure
+                }
+            }
+
+            await mutateTermsCache(
+                termsCacheKey,
+                (currentTerms: ChallengeTerm[] | undefined) => (currentTerms ?? terms)
+                    .filter(term => term.id !== termId),
+                { revalidate: false },
+            )
+            if (interaction !== interactionRef.current) return
+            if (!finalTerm) {
+                setCompletedTermIds(current => [...current, termId])
+            } else {
+                await props.onComplete()
+            }
+        } catch (error) {
+            if (interaction !== interactionRef.current) return
+            setAgreementError(error instanceof Error && error.message.trim()
+                ? error.message
+                : 'We couldn\u2019t record your agreement. Please try again.')
+        } finally {
+            if (activeAgreementRequestRef.current === agreementRequest) {
+                activeAgreementRequestRef.current = undefined
+                setAgreementBusy(false)
+            }
+        }
+    }
+
+    /** Registers directly only when no outstanding Submitter terms remain. */
+    const accept = (): void => {
+        if (compactRegistration) {
+            props.onComplete()
+            return
+        }
+
+        acceptActiveTerm()
+    }
+
+    /**
+     * Invalidates pending agreement callbacks before asking the owner to close
+     * the dialog, preventing a just-finished request from registering after cancellation.
+     *
+     * @returns void after invalidating the active interaction and closing.
+     * @throws Does not throw.
+     */
+    const close = (): void => {
+        interactionRef.current += 1
+        props.onClose()
+    }
 
     /** Opens the Terms API's authenticated DocuSign recipient flow. */
     const startDocuSign = async (term: ChallengeTerm): Promise<void> => {
-        if (!term.docusignTemplateId) return
+        if (!term.docusignTemplateId || externalBusy) return
+        const interaction = interactionRef.current
         setExternalBusy(true)
         setExternalError('')
         try {
             const url = await getChallengeTermDocuSignUrl(term.docusignTemplateId, window.location.href)
+            if (interaction !== interactionRef.current) return
             window.location.assign(url)
         } catch (error) {
+            if (interaction !== interactionRef.current) return
             setExternalError(error instanceof Error
                 ? error.message
                 : 'The external agreement could not be opened.')
-            setExternalBusy(false)
+        } finally {
+            if (interaction === interactionRef.current) setExternalBusy(false)
         }
     }
 
     const buttons = registrationMode ? (
         <>
             <Button
-                disabled={props.busy}
+                disabled={props.busy || agreementBusy || externalBusy}
                 className={styles.modalAction}
                 customRadius
                 label={compactRegistration ? 'Cancel' : 'I disagree'}
                 noCaps
-                onClick={props.onClose}
+                onClick={close}
                 secondary
                 size='lg'
             />
             <Button
                 disabled={(compactRegistration && !accepted)
                     || props.busy
+                    || agreementBusy
+                    || externalBusy
                     || response.isValidating
                     || !!response.error
-                    || externalAgreement}
+                    || (!compactRegistration && (!activeTerm || activeExternalAgreement))}
                 className={styles.modalAction}
                 customRadius
-                label={props.busy ? 'Registering…' : compactRegistration ? 'Register' : 'I agree'}
-                loading={props.busy}
+                label={props.busy
+                    ? 'Registering…'
+                    : agreementBusy ? 'Agreeing…' : compactRegistration ? 'Register' : 'I agree'}
+                loading={props.busy || agreementBusy}
                 noCaps
                 onClick={accept}
                 primary
@@ -175,7 +305,7 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
             disabled={props.busy}
             label='Close'
             noCaps
-            onClick={props.onClose}
+            onClick={close}
             primary
             size='lg'
         />
@@ -193,7 +323,7 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
             classNames={{
                 modal: compactRegistration ? styles.compactModal : styles.termsModal,
             }}
-            onClose={props.onClose}
+            onClose={close}
             open
             size={compactRegistration ? 'md' : 'body'}
             spacer={false}
@@ -219,6 +349,11 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                             : 'These terms govern participation in this competition.'}
                     </p>
                 )}
+                {registrationMode && activeTerm && agreementTotal > 1 && (
+                    <p aria-live='polite' className={styles.progress}>
+                        {`Agreement ${activePosition + 1} of ${agreementTotal}`}
+                    </p>
+                )}
                 {!compactRegistration && response.isValidating && !response.data && (
                     <div className={styles.loading} role='status'>
                         <LoadingSpinner />
@@ -234,14 +369,17 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                 {!compactRegistration && !response.error && !response.isValidating && terms.length === 0 && (
                     <p>No additional challenge-specific terms are listed.</p>
                 )}
-                {!compactRegistration && terms.length > 0 && (
-                    <div className={styles.terms}>
-                        {terms.map((term: ChallengeTerm, index: number) => (
+                {!compactRegistration && displayedTerms.length > 0 && (
+                    <div
+                        className={styles.terms}
+                        key={registrationMode ? activeTerm?.id : 'view'}
+                    >
+                        {displayedTerms.map((term: ChallengeTerm, index: number) => (
                             <article
                                 className={styles.term}
                                 key={term.id ?? term.url ?? term.title ?? `term-${index}`}
                             >
-                                {(terms.length > 1 || index > 0) && (
+                                {!registrationMode && (terms.length > 1 || index > 0) && (
                                     <h3>{term.title || `Challenge term ${index + 1}`}</h3>
                                 )}
                                 {term.text && (
@@ -268,10 +406,13 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                         ))}
                     </div>
                 )}
-                {!compactRegistration && registrationMode && externalAgreement && (
+                {!compactRegistration && registrationMode && activeExternalAgreement && (
                     <div className={styles.error} role='alert'>
-                        Complete each external agreement before registering.
+                        Complete this external agreement before registering.
                     </div>
+                )}
+                {!compactRegistration && agreementError && (
+                    <div className={styles.error} role='alert'>{agreementError}</div>
                 )}
                 {!compactRegistration && externalError && (
                     <div className={styles.error} role='alert'>{externalError}</div>

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -21,7 +21,6 @@ import { toast } from 'react-toastify'
 import { ChallengeDetailsPage } from './ChallengeDetailsPage'
 
 const mockUseSWR = jest.fn()
-const mockAgreeToTerms = jest.fn()
 const mockDeleteSubmission = jest.fn()
 const mockGetSubmissionDownloadUrl = jest.fn()
 const mockChallengeMutate = jest.fn()
@@ -172,13 +171,13 @@ jest.mock('../components', () => ({
         )
     },
     ChallengeTermsModal: (props: {
-        onAccept: () => Promise<void>
         onClose: () => void
+        onComplete: () => Promise<void>
         open: boolean
     }): JSX.Element => (
         props.open ? (
             <div aria-label='Challenge terms' role='dialog'>
-                <button onClick={props.onAccept} type='button'>Accept terms</button>
+                <button onClick={props.onComplete} type='button'>Complete terms</button>
                 <button onClick={props.onClose} type='button'>Close terms</button>
             </div>
         ) : <></>
@@ -219,7 +218,6 @@ jest.mock('../components/challenge-card.utils', () => ({
 }))
 
 jest.mock('../services', () => ({
-    agreeToChallengeTerms: (...args: unknown[]) => mockAgreeToTerms(...args),
     deleteChallengeSubmission: (...args: unknown[]) => mockDeleteSubmission(...args),
     getChallengeAiReviewConfig: jest.fn(),
     getChallengeOpportunity: jest.fn(),
@@ -434,7 +432,6 @@ describe('ChallengeDetailsPage member flows', () => {
         }
         mockUnregister.mockResolvedValue(undefined)
         mockRegister.mockResolvedValue({ id: 'new-resource-id', memberId: 123 })
-        mockAgreeToTerms.mockResolvedValue(undefined)
         mockDeleteSubmission.mockResolvedValue(undefined)
         mockGetSubmissionDownloadUrl.mockResolvedValue(
             'https://clean-storage.example/submission-1.zip',
@@ -675,7 +672,7 @@ describe('ChallengeDetailsPage member flows', () => {
 
     it('closes challenge terms immediately while registration is pending', () => {
         mockProfile = { handle: 'coder', userId: 123 }
-        mockAgreeToTerms.mockReturnValue(new Promise<void>(() => {
+        mockRegister.mockReturnValue(new Promise<void>(() => {
             // Keep the request pending so the modal state can be asserted independently.
         }))
 
@@ -684,7 +681,7 @@ describe('ChallengeDetailsPage member flows', () => {
         expect(screen.getByRole('dialog', { name: 'Challenge terms' }))
             .toBeInTheDocument()
 
-        fireEvent.click(screen.getByRole('button', { name: 'Accept terms' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Complete terms' }))
 
         expect(screen.queryByRole('dialog', { name: 'Challenge terms' }))
             .not.toBeInTheDocument()
@@ -695,15 +692,15 @@ describe('ChallengeDetailsPage member flows', () => {
 
         renderPage()
         fireEvent.click(screen.getByRole('button', { name: 'Register' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Accept terms' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Complete terms' }))
 
         await waitFor(() => expect(mockRegister)
             .toHaveBeenCalledWith('challenge-id', 'coder'))
-        expect(mockRegistrationMutate)
+        await waitFor(() => expect(mockRegistrationMutate)
             .toHaveBeenCalledWith(
                 { id: 'new-resource-id', memberId: 123 },
                 { revalidate: false },
-            )
+            ))
         const countUpdate = mockChallengeMutate.mock.calls[0][0] as (
             challenge: Record<string, unknown>
         ) => Record<string, unknown>

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.spec.tsx
@@ -61,7 +61,6 @@ jest.mock('../components/challenge-card.utils', () => ({
 }))
 
 jest.mock('../services', () => ({
-    agreeToChallengeTerms: jest.fn(),
     getChallengeAiReviewConfig: jest.fn(),
     getChallengeOpportunity: jest.fn(),
     getChallengeProjectResults: jest.fn(),
@@ -79,6 +78,7 @@ jest.mock('../utils', () => ({
     challengeForumUrl: (): undefined => undefined,
     formatMarathonScore: (): string => '—',
     isMarathonMatchChallenge: (): boolean => false,
+    isTaskChallenge: (): boolean => false,
     marathonDashboardIsEnabled: (): boolean => false,
     marathonSubmissionScores: (): Record<string, never> => ({}),
     memberProfileUrl: (handle: string): string => `https://profiles.topcoder-dev.com/${handle}`,

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -62,7 +62,6 @@ import {
     OpportunityPage,
 } from '../models'
 import {
-    agreeToChallengeTerms,
     deleteChallengeSubmission,
     getChallengeAiReviewConfig,
     getChallengeForumTopics,
@@ -581,18 +580,16 @@ export const ChallengeDetailsPage: FC = () => {
     }
 
     /**
-     * Closes registration terms, records agreement, and creates the Submitter resource.
+     * Closes the completed prerequisite flow and creates the Submitter resource.
      *
-     * @param terms challenge terms accepted by the member.
      * @returns promise settled after registration caches and user feedback are updated.
-     * @throws Does not throw; agreement and registration errors are shown as toasts.
+     * @throws Does not throw; registration errors are shown as toasts.
      */
-    const completeRegistration = async (terms: ChallengeTerm[]): Promise<void> => {
+    const completeRegistration = async (): Promise<void> => {
         if (!challenge || !profile) return
         setTermsOpen(false)
         setRegistrationBusy(true)
         try {
-            await agreeToChallengeTerms(terms)
             const createdRegistration = await registerForChallenge(challenge.id, profile.handle)
             recordAnalyticsEvent('challenge_registered', {
                 challenge_id: challenge.id,
@@ -794,9 +791,10 @@ export const ChallengeDetailsPage: FC = () => {
             </div>
             <ChallengeTermsModal
                 busy={registrationBusy}
+                memberId={memberId}
                 mode={termsMode}
-                onAccept={completeRegistration}
                 onClose={() => setTermsOpen(false)}
+                onComplete={completeRegistration}
                 open={termsOpen}
                 terms={visibleTerms}
             />

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '~/libs/core'
 import { init } from 'filestack-js'
 import {
+    agreeToChallengeTerms,
     buildOpportunityPageUrl,
     createChallengeSubmission,
     createChallengeUrlSubmission,
@@ -1860,18 +1861,42 @@ describe('opportunities service normalization', () => {
 
     it('resolves legacy challenge term references from v5 details', async () => {
         const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
-        get.mockResolvedValueOnce({
-            result: [{ agreeabilityType: 'Electronically-agreeable', id: 'term-uuid', text: '<p>Rules</p>' }],
-        })
+        get
+            .mockResolvedValueOnce({
+                result: [{ agreeabilityType: 'Electronically-agreeable', id: 'term-uuid', title: 'Rules' }],
+            })
+            .mockResolvedValueOnce({
+                agreed: true,
+                id: 'term-uuid',
+                text: '<p>Rules</p>',
+            })
 
         await expect(getChallengeTermDetails({ agreed: false, id: '123456', title: 'Rules' }))
             .resolves.toEqual({
                 agreeabilityType: 'Electronically-agreeable',
-                agreed: false,
+                agreed: true,
                 id: 'term-uuid',
                 text: '<p>Rules</p>',
                 title: 'Rules',
             })
+        expect(get)
+            .toHaveBeenNthCalledWith(1, 'https://api.example/v5/terms?legacyId=123456')
+        expect(get)
+            .toHaveBeenNthCalledWith(2, 'https://api.example/v5/terms/term-uuid')
+    })
+
+    it('persists separate electronic agreement requests in caller order', async () => {
+        const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
+        post.mockClear()
+        post.mockResolvedValue(undefined)
+
+        await agreeToChallengeTerms([{ id: 'standard-terms' }])
+        await agreeToChallengeTerms([{ id: 'nda' }])
+
+        expect(post)
+            .toHaveBeenNthCalledWith(1, 'https://api.example/v5/terms/standard-terms/agree', {})
+        expect(post)
+            .toHaveBeenNthCalledWith(2, 'https://api.example/v5/terms/nda/agree', {})
     })
 
     it('loads only outstanding terms assigned to the canonical Submitter resource role', async () => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -2155,8 +2155,10 @@ interface DocuSignViewResponse {
  * Loads the complete title, agreement type, URL, and body for one challenge
  * term reference from the v5 Terms API.
  *
- * Numeric legacy IDs use the legacyId search route; UUIDs use the canonical
- * detail route. Reference fields are retained when the detail omits them.
+ * Numeric legacy IDs first use the legacyId search route to resolve their UUID,
+ * then use the canonical authenticated detail route so user-specific agreement
+ * state and the complete body are present. Reference fields are retained when
+ * either API response omits them.
  *
  * @param term lightweight challenge term reference.
  * @returns complete term details, or the original reference when it has no ID.
@@ -2171,7 +2173,11 @@ export async function getChallengeTermDetails(term: ChallengeTerm): Promise<Chal
         )
         const match = response.result?.[0]
         if (!match) throw new Error(`Challenge term ${term.id} was not found.`)
-        details = match
+        if (!match.id) throw new Error(`Challenge term ${term.id} has no canonical identifier.`)
+        const canonicalDetails = await xhrGetAsync<ChallengeTerm>(
+            `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(match.id)}`,
+        )
+        details = { ...match, ...canonicalDetails }
     } else {
         details = await xhrGetAsync<ChallengeTerm>(
             `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(term.id)}`,


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6295

# What's in this PR?
- Presents outstanding Submitter terms one at a time during challenge registration.
- Persists each explicit electronic agreement before advancing and creates the Submitter resource only after the final prerequisite.
- Keeps passive review and the zero-outstanding Important Reminder flow unchanged.
- Scopes agreement caches by member and role, safely handles close/reopen and mode/member switches, and reconciles ambiguous agreement responses.
- Hydrates numeric legacy term references through their canonical authenticated detail endpoint so already accepted terms are not prompted again.

## Validation
- Focused Jest suites: 4 passed, 125 tests passed.
- Full yarn lint passed.
- NODE_OPTIONS=--max-old-space-size=8192 yarn run build passed.
- git diff --check passed.

The production build reports the repository's existing source-map, CSS ordering, and bundle-size warnings.

## API impact
No API repository change is required. The Challenge, Terms, and Resource APIs already expose and enforce the required role-scoped agreement data; this change corrects the client workflow.