### PR TITLE
Add route-level analytics lookup

### DIFF
--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -51,7 +51,8 @@ only.
 - `bootstrap.sql` creates the read-only Redshift database role and grants only
   the reporting objects required by the handler. Its route event view projects
   only timestamp, pseudonymous join key, session, source group, semantic click,
-  and form lifecycle fields; the Lambda role cannot select the raw event table.
+  challenge join key, and form lifecycle fields; the Lambda role cannot select
+  the raw event table.
 - `collector-host-migration.yaml` creates `events.<domain>` on the existing
   ingestion ALB so `analytics.<domain>` can become the reporting UI host.
 - `tests/test_handler.py` verifies authorization, validation, parameterization,
@@ -122,7 +123,9 @@ route totals, mutually exclusive visitor-source buckets, new/returning counts,
 semantic click locations, form lifecycle totals, abandonment field IDs, and an
 ordered challenge funnel. Bounce is defined as a one-page entrance session,
 average time is focused engagement per page view, and conversion is a unique
-form completer or post-CTA challenge registrant divided by route visitors.
+form completer or a visitor who registers for the exact challenge clicked from
+the route, divided by route visitors. Submission likewise requires the same
+challenge ID and follows that registration.
 Winner attribution is intentionally null until a trusted challenge-results
 event is added upstream.
 

--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -18,8 +18,8 @@ Platform UI
 
 API Gateway validates the configured Auth0 issuer, audience, signature, and
 standard JWT time claims. Lambda then requires `analytics` in a verified
-Topcoder roles claim. The handler accepts only three fixed `GET` routes,
-strict dates, and bounded UTM/surface tokens. SQL is server-owned and uses Data
+Topcoder roles claim. The handler accepts only four fixed `GET` routes,
+strict dates, bounded UTM/surface tokens, and an exact query-free path. SQL is server-owned and uses Data
 API named parameters; callers cannot provide SQL, object names, sort clauses,
 or result limits.
 
@@ -47,9 +47,11 @@ only.
   provisions the JWT authorizer, Lambda, least-privilege query role, scheduled
   default-report prewarm, and logs.
   The former dedicated API remains during the cutover observation window.
-- `src/handler.py` validates and shapes filter, campaign, and general reports.
+- `src/handler.py` validates and shapes filter, campaign, general, and exact-route reports.
 - `bootstrap.sql` creates the read-only Redshift database role and grants only
-  the reporting objects required by the handler.
+  the reporting objects required by the handler. Its route event view projects
+  only timestamp, pseudonymous join key, session, source group, semantic click,
+  and form lifecycle fields; the Lambda role cannot select the raw event table.
 - `collector-host-migration.yaml` creates `events.<domain>` on the existing
   ingestion ALB so `analytics.<domain>` can become the reporting UI host.
 - `tests/test_handler.py` verifies authorization, validation, parameterization,
@@ -112,7 +114,17 @@ valid token with analytics    -> 200 aggregate JSON, or 202 until the query comp
 The canonical development endpoint is
 `https://api.topcoder-dev.com/v1/analytics`. Preserve existing shared-stage
 route settings when adding 5 requests/second, burst 10, detailed metrics for
-the three `GET` routes and the public `OPTIONS /v1/analytics/{proxy+}` route.
+the four `GET` routes and the public `OPTIONS /v1/analytics/{proxy+}` route.
+
+`GET /v1/analytics/route` requires `path=/...` and supports the same inclusive
+date range and optional surface as General Analytics. It returns only aggregate
+route totals, mutually exclusive visitor-source buckets, new/returning counts,
+semantic click locations, form lifecycle totals, abandonment field IDs, and an
+ordered challenge funnel. Bounce is defined as a one-page entrance session,
+average time is focused engagement per page view, and conversion is a unique
+form completer or post-CTA challenge registrant divided by route visitors.
+Winner attribution is intentionally null until a trusted challenge-results
+event is added upstream.
 
 Also verify an invalid date returns `400`, an unsupported route returns `404`,
 an opted-in cold query returns resumable `202` responses instead of `504`,

--- a/infrastructure/analytics-api/bootstrap.sql
+++ b/infrastructure/analytics-api/bootstrap.sql
@@ -47,7 +47,8 @@ SELECT
     NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_host', true), '') AS destination_host,
     NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_path', true), '') AS destination_path,
     NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'form_id', true), '') AS form_id,
-    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'field_id', true), '') AS field_id
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'field_id', true), '') AS field_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'challenge_id', true), '') AS challenge_id
 FROM topcoder_web.event_v2;
 
 GRANT USAGE ON SCHEMA topcoder_web TO ROLE analytics_api_reader;

--- a/infrastructure/analytics-api/bootstrap.sql
+++ b/infrastructure/analytics-api/bootstrap.sql
@@ -4,6 +4,53 @@
 
 CREATE ROLE analytics_api_reader;
 
+-- Expose only the event fields required by the route report. Keeping this
+-- projection separate from event_v2 prevents the Lambda database role from
+-- reading device, location, free-text, or other raw event attributes.
+CREATE OR REPLACE VIEW topcoder_web.route_analytics_events_v1 AS
+SELECT
+    event_timestamp,
+    event_timestamp::date AS event_date,
+    COALESCE(NULLIF(user_id, ''), user_pseudo_id) AS analytics_user_id,
+    event_name,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'surface', true), '') AS surface,
+    COALESCE(
+        NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'page_path', true), ''),
+        NULLIF(page_view_page_url_path, '')
+    ) AS page_path,
+    CASE
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%email%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('email', 'e-mail', 'newsletter')
+            THEN 'email'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%paid%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN (
+              'affiliate', 'cpc', 'cpm', 'cpv', 'display', 'paid', 'paid_search', 'ppc'
+          )
+          OR NULLIF(traffic_source_clid, '') IS NOT NULL
+            THEN 'paid'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%social%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('social', 'social-media', 'social_media')
+            THEN 'social'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%organic%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('organic', 'organic_search', 'seo')
+          OR LOWER(COALESCE(traffic_source_category, '')) = 'search'
+            THEN 'organic'
+        ELSE 'other'
+    END AS source_group,
+    session_id,
+    session_number,
+    page_view_entrances,
+    user_engagement_time_msec,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'placement', true), '') AS placement,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'element_id', true), '') AS element_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'element_type', true), '') AS element_type,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_host', true), '') AS destination_host,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_path', true), '') AS destination_path,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'form_id', true), '') AS form_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'field_id', true), '') AS field_id
+FROM topcoder_web.event_v2;
+
 GRANT USAGE ON SCHEMA topcoder_web TO ROLE analytics_api_reader;
 GRANT SELECT ON topcoder_web.product_analytics_events_v1 TO ROLE analytics_api_reader;
 GRANT SELECT ON topcoder_web.challenge_funnel_daily_v1 TO ROLE analytics_api_reader;
+GRANT SELECT ON topcoder_web.route_analytics_events_v1 TO ROLE analytics_api_reader;

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -443,10 +443,19 @@ route_clicks AS (
     FROM route_events
     WHERE event_name = 'ui_click'
 ),
-challenge_cta_clicks AS (
+challenge_click_candidates AS (
     SELECT
         visitor.analytics_user_id,
-        MIN(click.event_timestamp) AS clicked_at
+        click.event_timestamp,
+        CASE
+            WHEN click.destination_path LIKE '/opportunities/challenge/%'
+                THEN NULLIF(SPLIT_PART(click.destination_path, '/', 4), '')
+            WHEN click.destination_path LIKE '/challenges/%'
+                THEN NULLIF(SPLIT_PART(click.destination_path, '/', 3), '')
+            WHEN click.destination_path LIKE '/earn/challenges/%'
+                THEN NULLIF(SPLIT_PART(click.destination_path, '/', 4), '')
+            ELSE NULL
+        END AS challenge_id
     FROM route_visitors visitor
     JOIN route_clicks click
       ON click.analytics_user_id = visitor.analytics_user_id
@@ -454,29 +463,38 @@ challenge_cta_clicks AS (
     WHERE click.destination_path LIKE '/opportunities/challenge/%'
        OR click.destination_path LIKE '/challenges/%'
        OR click.destination_path LIKE '/earn/challenges/%'
-    GROUP BY visitor.analytics_user_id
+),
+challenge_cta_clicks AS (
+    SELECT analytics_user_id, challenge_id, MIN(event_timestamp) AS clicked_at
+    FROM challenge_click_candidates
+    WHERE challenge_id IS NOT NULL
+    GROUP BY analytics_user_id, challenge_id
 ),
 registrations AS (
     SELECT
         click.analytics_user_id,
+        click.challenge_id,
         MIN(event.event_timestamp) AS registered_at
     FROM challenge_cta_clicks click
     JOIN date_events event
       ON event.analytics_user_id = click.analytics_user_id
      AND event.event_name = 'challenge_registered'
+     AND event.challenge_id = click.challenge_id
      AND event.event_timestamp >= click.clicked_at
-    GROUP BY click.analytics_user_id
+    GROUP BY click.analytics_user_id, click.challenge_id
 ),
 submissions AS (
     SELECT
         registration.analytics_user_id,
+        registration.challenge_id,
         MIN(event.event_timestamp) AS submitted_at
     FROM registrations registration
     JOIN date_events event
       ON event.analytics_user_id = registration.analytics_user_id
      AND event.event_name = 'challenge_submitted'
+     AND event.challenge_id = registration.challenge_id
      AND event.event_timestamp >= registration.registered_at
-    GROUP BY registration.analytics_user_id
+    GROUP BY registration.analytics_user_id, registration.challenge_id
 ),
 route_form_events AS (
     SELECT *
@@ -568,9 +586,9 @@ abandonment_rows AS (
 funnel_row AS (
     SELECT
         (SELECT COUNT(*) FROM route_visitors)::bigint AS page_visitors,
-        (SELECT COUNT(*) FROM challenge_cta_clicks)::bigint AS challenge_cta_clickers,
-        (SELECT COUNT(*) FROM registrations)::bigint AS registrations,
-        (SELECT COUNT(*) FROM submissions)::bigint AS submissions
+        (SELECT COUNT(DISTINCT analytics_user_id) FROM challenge_cta_clicks)::bigint AS challenge_cta_clickers,
+        (SELECT COUNT(DISTINCT analytics_user_id) FROM registrations)::bigint AS registrations,
+        (SELECT COUNT(DISTINCT analytics_user_id) FROM submissions)::bigint AS submissions
 )
 SELECT
     'summary'::varchar AS row_type,

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -364,6 +364,275 @@ ORDER BY row_type, date_value, metric_1 DESC
 """
 
 
+ROUTE_SQL = """
+WITH date_events AS (
+    SELECT *
+    FROM topcoder_web.route_analytics_events_v1
+    WHERE event_timestamp >= CAST(:from_date AS timestamp)
+      AND event_timestamp < DATEADD(day, 1, CAST(:to_date AS timestamp))
+      AND event_name IN (
+          '_page_view',
+          '_user_engagement',
+          'ui_click',
+          'form_viewed',
+          'form_started',
+          'form_completed',
+          'form_abandoned',
+          'challenge_registered',
+          'challenge_submitted'
+      )
+),
+route_events AS (
+    SELECT *
+    FROM date_events
+    WHERE page_path = :path
+      AND (:surface = '*' OR surface = :surface)
+),
+route_page_views AS (
+    SELECT *
+    FROM route_events
+    WHERE event_name = '_page_view'
+),
+ranked_first_views AS (
+    SELECT
+        analytics_user_id,
+        event_timestamp,
+        session_number,
+        source_group,
+        ROW_NUMBER() OVER (
+            PARTITION BY analytics_user_id
+            ORDER BY event_timestamp
+        ) AS view_rank
+    FROM route_page_views
+),
+first_views AS (
+    SELECT analytics_user_id, event_timestamp, session_number, source_group
+    FROM ranked_first_views
+    WHERE view_rank = 1
+),
+route_visitors AS (
+    SELECT analytics_user_id, event_timestamp AS viewed_at
+    FROM first_views
+),
+session_page_counts AS (
+    SELECT analytics_user_id, session_id, COUNT(*)::bigint AS page_views
+    FROM date_events
+    WHERE event_name = '_page_view' AND session_id IS NOT NULL
+    GROUP BY analytics_user_id, session_id
+),
+entry_sessions AS (
+    SELECT DISTINCT analytics_user_id, session_id
+    FROM route_page_views
+    WHERE page_view_entrances IS TRUE AND session_id IS NOT NULL
+),
+bounce_sessions AS (
+    SELECT entry.analytics_user_id, entry.session_id
+    FROM entry_sessions entry
+    JOIN session_page_counts session
+      ON session.analytics_user_id = entry.analytics_user_id
+     AND session.session_id = entry.session_id
+    WHERE session.page_views = 1
+),
+route_engagement AS (
+    SELECT user_engagement_time_msec
+    FROM route_events
+    WHERE event_name = '_user_engagement'
+),
+route_clicks AS (
+    SELECT *
+    FROM route_events
+    WHERE event_name = 'ui_click'
+),
+challenge_cta_clicks AS (
+    SELECT
+        visitor.analytics_user_id,
+        MIN(click.event_timestamp) AS clicked_at
+    FROM route_visitors visitor
+    JOIN route_clicks click
+      ON click.analytics_user_id = visitor.analytics_user_id
+     AND click.event_timestamp >= visitor.viewed_at
+    WHERE click.destination_path LIKE '/opportunities/challenge/%'
+       OR click.destination_path LIKE '/challenges/%'
+       OR click.destination_path LIKE '/earn/challenges/%'
+    GROUP BY visitor.analytics_user_id
+),
+registrations AS (
+    SELECT
+        click.analytics_user_id,
+        MIN(event.event_timestamp) AS registered_at
+    FROM challenge_cta_clicks click
+    JOIN date_events event
+      ON event.analytics_user_id = click.analytics_user_id
+     AND event.event_name = 'challenge_registered'
+     AND event.event_timestamp >= click.clicked_at
+    GROUP BY click.analytics_user_id
+),
+submissions AS (
+    SELECT
+        registration.analytics_user_id,
+        MIN(event.event_timestamp) AS submitted_at
+    FROM registrations registration
+    JOIN date_events event
+      ON event.analytics_user_id = registration.analytics_user_id
+     AND event.event_name = 'challenge_submitted'
+     AND event.event_timestamp >= registration.registered_at
+    GROUP BY registration.analytics_user_id
+),
+route_form_events AS (
+    SELECT *
+    FROM route_events
+    WHERE event_name IN ('form_viewed', 'form_started', 'form_completed', 'form_abandoned')
+      AND form_id IS NOT NULL
+),
+conversion_users AS (
+    SELECT DISTINCT event.analytics_user_id
+    FROM route_form_events event
+    JOIN route_visitors visitor
+      ON visitor.analytics_user_id = event.analytics_user_id
+     AND event.event_timestamp >= visitor.viewed_at
+    WHERE event.event_name = 'form_completed'
+    UNION
+    SELECT analytics_user_id
+    FROM registrations
+),
+summary_row AS (
+    SELECT
+        CAST(MAX(event_date) AS varchar(10)) AS data_through,
+        COUNT(*)::bigint AS page_views,
+        COUNT(DISTINCT analytics_user_id)::bigint AS visitors,
+        (SELECT COUNT(*) FROM route_clicks)::bigint AS clicks,
+        (SELECT COUNT(DISTINCT analytics_user_id) FROM route_clicks)::bigint AS clickers,
+        (SELECT COUNT(*) FROM first_views WHERE session_number = 1)::bigint AS new_visitors,
+        (SELECT COUNT(*) FROM first_views WHERE session_number > 1)::bigint AS returning_visitors,
+        ROUND(
+            COALESCE((SELECT SUM(user_engagement_time_msec) FROM route_engagement), 0)::decimal(20, 2)
+            / NULLIF(COUNT(*), 0)
+            / 1000,
+            2
+        )::double precision AS avg_engagement_seconds,
+        (SELECT COUNT(*) FROM entry_sessions)::bigint AS entrances,
+        (SELECT COUNT(*) FROM bounce_sessions)::bigint AS bounces,
+        (SELECT COUNT(*) FROM conversion_users)::bigint AS conversions,
+        (SELECT COUNT(*) FROM route_form_events WHERE event_name = 'form_started')::bigint AS form_starts,
+        (SELECT COUNT(*) FROM route_form_events WHERE event_name = 'form_completed')::bigint AS form_completions,
+        (SELECT COUNT(*) FROM route_form_events WHERE event_name = 'form_abandoned')::bigint AS form_abandonments
+    FROM route_page_views
+),
+source_rows AS (
+    SELECT source_group, COUNT(*)::bigint AS visitors
+    FROM first_views
+    GROUP BY source_group
+),
+click_rows AS (
+    SELECT
+        placement,
+        element_id,
+        element_type,
+        destination_host,
+        destination_path,
+        COUNT(*)::bigint AS clicks,
+        COUNT(DISTINCT analytics_user_id)::bigint AS clickers
+    FROM route_clicks
+    GROUP BY placement, element_id, element_type, destination_host, destination_path
+    ORDER BY clicks DESC, element_id, destination_path
+    LIMIT 100
+),
+form_rows AS (
+    SELECT
+        form_id,
+        COUNT(CASE WHEN event_name = 'form_viewed' THEN 1 END)::bigint AS form_views,
+        COUNT(DISTINCT CASE WHEN event_name = 'form_viewed' THEN analytics_user_id END)::bigint AS form_viewers,
+        COUNT(CASE WHEN event_name = 'form_started' THEN 1 END)::bigint AS form_starts,
+        COUNT(DISTINCT CASE WHEN event_name = 'form_started' THEN analytics_user_id END)::bigint AS form_starters,
+        COUNT(CASE WHEN event_name = 'form_completed' THEN 1 END)::bigint AS form_completions,
+        COUNT(DISTINCT CASE WHEN event_name = 'form_completed' THEN analytics_user_id END)::bigint AS form_completers,
+        COUNT(CASE WHEN event_name = 'form_abandoned' THEN 1 END)::bigint AS form_abandonments,
+        COUNT(DISTINCT CASE WHEN event_name = 'form_abandoned' THEN analytics_user_id END)::bigint AS form_abandoners
+    FROM route_form_events
+    GROUP BY form_id
+    ORDER BY form_views DESC, form_id
+    LIMIT 50
+),
+abandonment_rows AS (
+    SELECT
+        form_id,
+        COALESCE(field_id, 'Unknown field') AS field_id,
+        COUNT(*)::bigint AS abandonments,
+        COUNT(DISTINCT analytics_user_id)::bigint AS visitors
+    FROM route_form_events
+    WHERE event_name = 'form_abandoned'
+    GROUP BY form_id, COALESCE(field_id, 'Unknown field')
+    ORDER BY abandonments DESC, form_id, field_id
+    LIMIT 100
+),
+funnel_row AS (
+    SELECT
+        (SELECT COUNT(*) FROM route_visitors)::bigint AS page_visitors,
+        (SELECT COUNT(*) FROM challenge_cta_clicks)::bigint AS challenge_cta_clickers,
+        (SELECT COUNT(*) FROM registrations)::bigint AS registrations,
+        (SELECT COUNT(*) FROM submissions)::bigint AS submissions
+)
+SELECT
+    'summary'::varchar AS row_type,
+    NULL::varchar AS dimension_1,
+    NULL::varchar AS dimension_2,
+    NULL::varchar AS dimension_3,
+    NULL::varchar AS dimension_4,
+    NULL::varchar AS dimension_5,
+    data_through::varchar AS dimension_6,
+    page_views::double precision AS metric_1,
+    visitors::double precision AS metric_2,
+    clicks::double precision AS metric_3,
+    clickers::double precision AS metric_4,
+    new_visitors::double precision AS metric_5,
+    returning_visitors::double precision AS metric_6,
+    avg_engagement_seconds::double precision AS metric_7,
+    entrances::double precision AS metric_8,
+    bounces::double precision AS metric_9,
+    conversions::double precision AS metric_10,
+    form_starts::double precision AS metric_11,
+    form_completions::double precision AS metric_12,
+    form_abandonments::double precision AS metric_13
+FROM summary_row
+UNION ALL
+SELECT
+    'source', source_group, NULL, NULL, NULL, NULL, NULL,
+    visitors,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL
+FROM source_rows
+UNION ALL
+SELECT
+    'click_location', placement, element_id, element_type, destination_host, destination_path, NULL,
+    clicks, clickers,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL
+FROM click_rows
+UNION ALL
+SELECT
+    'form', form_id, NULL, NULL, NULL, NULL, NULL,
+    form_views, form_viewers, form_starts, form_starters, form_completions, form_completers,
+    form_abandonments, form_abandoners,
+    NULL, NULL, NULL, NULL, NULL
+FROM form_rows
+UNION ALL
+SELECT
+    'form_abandonment', form_id, field_id, NULL, NULL, NULL, NULL,
+    abandonments, visitors,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL
+FROM abandonment_rows
+UNION ALL
+SELECT
+    'funnel', NULL, NULL, NULL, NULL, NULL, NULL,
+    page_visitors, challenge_cta_clickers, registrations, submissions,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL
+FROM funnel_row
+ORDER BY row_type, metric_1 DESC, dimension_1
+"""
+
+
 class QueryFailure(RuntimeError):
     """Raised when Redshift rejects or aborts a reporting query."""
 
@@ -427,6 +696,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 cache_key,
                 REPORT_CACHE_SECONDS,
                 lambda: _general_report(filters, context, query_token),
+                context,
+            )
+            return _response(200, report)
+        if route_key == "GET /v1/analytics/route":
+            filters = _route_filters(query)
+            cache_key = f"route:{json.dumps(filters, sort_keys=True)}"
+            report = _cached_report(
+                cache_key,
+                REPORT_CACHE_SECONDS,
+                lambda: _route_report(filters, context, query_token),
                 context,
             )
             return _response(200, report)
@@ -688,6 +967,173 @@ def _general_report(
     }
 
 
+def _route_report(
+    filters: dict[str, str],
+    context: Any,
+    query_token: str | None = None,
+) -> dict[str, Any]:
+    """Load and shape detailed engagement analytics for one exact page path.
+
+    Args:
+        filters: Validated date, surface, and query-free path filters.
+        context: Lambda context used to respect the remaining deadline.
+        query_token: Optional server-issued token that resumes a pending statement.
+
+    Returns:
+        Route totals, visitor-source groups, click locations, form activity, and
+        the ordered challenge funnel. No visitor identifiers are returned.
+
+    Raises:
+        QueryFailure or QueryTimeout when Redshift cannot return data.
+    """
+
+    rows = _execute_query(ROUTE_SQL, _sql_parameters(filters), context, query_token)
+    summary = next((row for row in rows if row.get("row_type") == "summary"), {})
+    funnel_row = next((row for row in rows if row.get("row_type") == "funnel"), {})
+    visitors = _integer(summary.get("metric_2"))
+    clickers = _integer(summary.get("metric_4"))
+    entrances = _integer(summary.get("metric_8"))
+    bounces = _integer(summary.get("metric_9"))
+    conversions = _integer(summary.get("metric_10"))
+    new_visitors = _integer(summary.get("metric_5"))
+    returning_visitors = _integer(summary.get("metric_6"))
+    visitor_sources = {
+        "organic": 0,
+        "paid": 0,
+        "social": 0,
+        "email": 0,
+        "other": 0,
+    }
+    for row in rows:
+        source_group = row.get("dimension_1")
+        if row.get("row_type") == "source" and source_group in visitor_sources:
+            visitor_sources[source_group] = _integer(row.get("metric_1"))
+
+    page_visitors = _integer(funnel_row.get("metric_1"))
+    challenge_cta_clickers = _integer(funnel_row.get("metric_2"))
+    registrations = _integer(funnel_row.get("metric_3"))
+    submissions = _integer(funnel_row.get("metric_4"))
+
+    return {
+        "generatedAt": _now_iso(),
+        "dataThrough": summary.get("dimension_6"),
+        "filters": filters,
+        "totals": {
+            "pageViews": _integer(summary.get("metric_1")),
+            "visitors": visitors,
+            "clicks": _integer(summary.get("metric_3")),
+            "clickers": clickers,
+            "clickThroughPercent": _percentage(clickers, visitors),
+            "newVisitors": new_visitors,
+            "returningVisitors": returning_visitors,
+            "unknownVisitorType": max(0, visitors - new_visitors - returning_visitors),
+            "averageEngagementSeconds": _number(summary.get("metric_7")),
+            "entrances": entrances,
+            "bounces": bounces,
+            "bounceRatePercent": _percentage(bounces, entrances),
+            "conversions": conversions,
+            "conversionRatePercent": _percentage(conversions, visitors),
+            "formStarts": _integer(summary.get("metric_11")),
+            "formCompletions": _integer(summary.get("metric_12")),
+            "formAbandonments": _integer(summary.get("metric_13")),
+        },
+        "visitorSources": [
+            {
+                "source": source,
+                "visitors": source_visitors,
+                "percent": _percentage(source_visitors, visitors),
+            }
+            for source, source_visitors in visitor_sources.items()
+        ],
+        "clickLocations": [
+            _route_click_location(row, visitors)
+            for row in rows if row.get("row_type") == "click_location"
+        ],
+        "forms": [
+            _route_form(row)
+            for row in rows if row.get("row_type") == "form"
+        ],
+        "formAbandonments": [
+            {
+                "formId": row.get("dimension_1") or "Unknown form",
+                "fieldId": row.get("dimension_2") or "Unknown field",
+                "abandonments": _integer(row.get("metric_1")),
+                "visitors": _integer(row.get("metric_2")),
+            }
+            for row in rows if row.get("row_type") == "form_abandonment"
+        ],
+        "funnel": {
+            "pageVisitors": page_visitors,
+            "challengeCtaClickers": challenge_cta_clickers,
+            "registrations": registrations,
+            "submissions": submissions,
+            "wins": None,
+            "clickThroughPercent": _percentage(challenge_cta_clickers, page_visitors),
+            "clickToRegistrationPercent": _percentage(registrations, challenge_cta_clickers),
+            "registrationToSubmissionPercent": _percentage(submissions, registrations),
+            "winTrackingAvailable": False,
+        },
+    }
+
+
+def _route_click_location(row: dict[str, Any], visitors: int) -> dict[str, Any]:
+    """Convert one route click aggregate to its privacy-safe wire shape.
+
+    Args:
+        row: Query row containing semantic element and destination dimensions.
+        visitors: Unique route visitors used as the location CTR denominator.
+
+    Returns:
+        Aggregate click-location object with no raw coordinates or rendered text.
+
+    Raises:
+        Does not raise.
+    """
+
+    clickers = _integer(row.get("metric_2"))
+    return {
+        "placement": row.get("dimension_1"),
+        "elementId": row.get("dimension_2"),
+        "elementType": row.get("dimension_3"),
+        "destinationHost": row.get("dimension_4"),
+        "destinationPath": row.get("dimension_5"),
+        "clicks": _integer(row.get("metric_1")),
+        "clickers": clickers,
+        "clickThroughPercent": _percentage(clickers, visitors),
+    }
+
+
+def _route_form(row: dict[str, Any]) -> dict[str, Any]:
+    """Convert one route form aggregate to completion and abandonment metrics.
+
+    Args:
+        row: Query row containing a safe form ID and lifecycle counts.
+
+    Returns:
+        Aggregate form activity with rates based on form starts.
+
+    Raises:
+        Does not raise.
+    """
+
+    starts = _integer(row.get("metric_3"))
+    completions = _integer(row.get("metric_5"))
+    abandonments = _integer(row.get("metric_7"))
+    return {
+        "formId": row.get("dimension_1") or "Unknown form",
+        "views": _integer(row.get("metric_1")),
+        "viewers": _integer(row.get("metric_2")),
+        "starts": starts,
+        "starters": _integer(row.get("metric_4")),
+        "completions": completions,
+        "completers": _integer(row.get("metric_6")),
+        "abandonments": abandonments,
+        "abandoners": _integer(row.get("metric_8")),
+        "completionRatePercent": _percentage(completions, starts),
+        "abandonmentRatePercent": _percentage(abandonments, starts),
+    }
+
+
 def _click_location(row: dict[str, Any]) -> dict[str, Any]:
     """Convert one normalized Redshift click-location row to the wire contract.
 
@@ -752,6 +1198,26 @@ def _general_filters(query: dict[str, Any]) -> dict[str, str]:
     return {
         **_date_filters(query),
         "surface": _safe_filter(query.get("surface"), "surface"),
+    }
+
+
+def _route_filters(query: dict[str, Any]) -> dict[str, str]:
+    """Validate the date, surface, and exact page path for a route report.
+
+    Args:
+        query: Untrusted API Gateway query string values.
+
+    Returns:
+        Complete normalized route filter dictionary.
+
+    Raises:
+        ValueError for malformed dates, unsafe surfaces, or invalid paths.
+    """
+
+    return {
+        **_date_filters(query),
+        "surface": _safe_filter(query.get("surface"), "surface"),
+        "path": _safe_path(query.get("path")),
     }
 
 
@@ -868,6 +1334,31 @@ def _safe_filter(value: Any, label: str) -> str:
     return value
 
 
+def _safe_path(value: Any) -> str:
+    """Validate one exact, query-free URL path used by the route lookup.
+
+    Args:
+        value: Untrusted query value after API Gateway URL decoding.
+
+    Returns:
+        Unchanged absolute path suitable for a named Data API parameter.
+
+    Raises:
+        ValueError when the path is missing, relative, unbounded, contains a
+        query/fragment, or includes control characters.
+    """
+
+    if not isinstance(value, str) or not value:
+        raise ValueError("The page path is required")
+    if len(value) > 500:
+        raise ValueError("The page path cannot exceed 500 characters")
+    if not value.startswith("/") or "?" in value or "#" in value:
+        raise ValueError("The page path must be an absolute query-free path")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError("The page path contains unsupported characters")
+    return value
+
+
 def _sql_parameters(filters: dict[str, str]) -> list[dict[str, str]]:
     """Map wire filters to Redshift Data API named parameters.
 
@@ -890,6 +1381,7 @@ def _sql_parameters(filters: dict[str, str]) -> list[dict[str, str]]:
         "source": "source",
         "medium": "medium",
         "surface": "surface",
+        "path": "path",
     }
     return [
         {"name": names[key], "value": value or NO_FILTER_PARAMETER}
@@ -1261,6 +1753,25 @@ def _integer(value: Any) -> int:
         return max(0, int(float(value or 0)))
     except (TypeError, ValueError):
         return 0
+
+
+def _number(value: Any) -> float:
+    """Convert a numeric aggregate to a non-negative two-decimal number.
+
+    Args:
+        value: Data API numeric field.
+
+    Returns:
+        Non-negative float rounded to two decimals, defaulting to zero.
+
+    Raises:
+        Does not raise for malformed provider values.
+    """
+
+    try:
+        return round(max(0.0, float(value or 0)), 2)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _percentage(numerator: int, denominator: int) -> float:

--- a/infrastructure/analytics-api/template.yaml
+++ b/infrastructure/analytics-api/template.yaml
@@ -256,6 +256,15 @@ Resources:
       RouteKey: GET /v1/analytics/general
       Target: !Sub 'integrations/${AnalyticsIntegration}'
 
+  RouteDetailRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref AnalyticsHttpApi
+      AuthorizationType: JWT
+      AuthorizerId: !Ref AnalyticsJwtAuthorizer
+      RouteKey: GET /v1/analytics/route
+      Target: !Sub 'integrations/${AnalyticsIntegration}'
+
   DefaultStage:
     Type: AWS::ApiGatewayV2::Stage
     DependsOn: AnalyticsApiAccessLogGroup
@@ -331,6 +340,15 @@ Resources:
       AuthorizationType: JWT
       AuthorizerId: !Ref SharedAnalyticsJwtAuthorizer
       RouteKey: GET /v1/analytics/general
+      Target: !Sub 'integrations/${SharedAnalyticsIntegration}'
+
+  SharedRouteDetailRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref SharedApiId
+      AuthorizationType: JWT
+      AuthorizerId: !Ref SharedAnalyticsJwtAuthorizer
+      RouteKey: GET /v1/analytics/route
       Target: !Sub 'integrations/${SharedAnalyticsIntegration}'
 
   SharedPreflightRoute:

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -279,6 +279,26 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertEqual(400, response["statusCode"])
         execute.assert_not_called()
 
+    def test_route_lookup_requires_a_bounded_query_free_absolute_path(self) -> None:
+        """Route reports reject missing, full-URL, query, and control-character values."""
+
+        invalid_paths = [None, "challenges", "https://www.topcoder.com/challenges", "/x?q=1", "/x\n"]
+        with patch.object(self.module, "_execute_query") as execute:
+            responses = [
+                self.module.handler(
+                    self._event(
+                        "GET /v1/analytics/route",
+                        ["analytics"],
+                        {"path": path} if path is not None else {},
+                    ),
+                    None,
+                )
+                for path in invalid_paths
+            ]
+
+        self.assertTrue(all(response["statusCode"] == 400 for response in responses))
+        execute.assert_not_called()
+
     def test_unset_filters_use_nonempty_data_api_parameters(self) -> None:
         """Optional filters use an unreachable sentinel because Data API rejects empty values."""
 
@@ -296,6 +316,11 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertIsNone(self.module.SAFE_FILTER_PATTERN.fullmatch(self.module.NO_FILTER_PARAMETER))
         self.assertIn(":campaign = '*' OR", self.module.CAMPAIGN_SQL)
         self.assertIn(":surface = '*' OR", self.module.GENERAL_SQL)
+        route_parameters = self.module._sql_parameters({"path": "/opportunities/challenge/example"})
+        self.assertEqual(
+            [{"name": "path", "value": "/opportunities/challenge/example"}],
+            route_parameters,
+        )
 
     def test_retries_one_failed_redshift_statement(self) -> None:
         """A transient failed statement is retried once inside the request deadline."""
@@ -512,6 +537,93 @@ class AnalyticsHandlerTests(unittest.TestCase):
         body = json.loads(response["body"])
         self.assertEqual(30, body["totals"]["pageViews"])
         self.assertEqual("/challenges", body["pages"][0]["path"])
+
+    def test_shapes_route_report_without_exposing_visitor_identifiers(self) -> None:
+        """Route rows become source, behavior, form, and ordered funnel aggregates."""
+
+        rows = [
+            {
+                "row_type": "summary",
+                "dimension_6": "2026-09-10",
+                "metric_1": 150,
+                "metric_2": 100,
+                "metric_3": 60,
+                "metric_4": 40,
+                "metric_5": 35,
+                "metric_6": 60,
+                "metric_7": 12.345,
+                "metric_8": 80,
+                "metric_9": 20,
+                "metric_10": 15,
+                "metric_11": 12,
+                "metric_12": 8,
+                "metric_13": 4,
+            },
+            {"row_type": "source", "dimension_1": "organic", "metric_1": 30},
+            {"row_type": "source", "dimension_1": "paid", "metric_1": 20},
+            {
+                "row_type": "click_location",
+                "dimension_1": "hero",
+                "dimension_2": "view-challenge",
+                "dimension_3": "a",
+                "dimension_4": "platform-ui.topcoder-dev.com",
+                "dimension_5": "/opportunities/challenge/123",
+                "metric_1": 25,
+                "metric_2": 20,
+            },
+            {
+                "row_type": "form",
+                "dimension_1": "contact-us",
+                "metric_1": 50,
+                "metric_2": 45,
+                "metric_3": 12,
+                "metric_4": 11,
+                "metric_5": 8,
+                "metric_6": 8,
+                "metric_7": 4,
+                "metric_8": 4,
+            },
+            {
+                "row_type": "form_abandonment",
+                "dimension_1": "contact-us",
+                "dimension_2": "company",
+                "metric_1": 3,
+                "metric_2": 3,
+            },
+            {
+                "row_type": "funnel",
+                "metric_1": 100,
+                "metric_2": 30,
+                "metric_3": 12,
+                "metric_4": 6,
+            },
+        ]
+        with patch.object(self.module, "_execute_query", return_value=rows):
+            response = self.module.handler(
+                self._event(
+                    "GET /v1/analytics/route",
+                    ["analytics"],
+                    {
+                        "from": "2026-09-01",
+                        "to": "2026-09-10",
+                        "path": "/landing",
+                    },
+                ),
+                None,
+            )
+
+        body = json.loads(response["body"])
+        self.assertEqual(200, response["statusCode"])
+        self.assertEqual(40.0, body["totals"]["clickThroughPercent"])
+        self.assertEqual(25.0, body["totals"]["bounceRatePercent"])
+        self.assertEqual(15.0, body["totals"]["conversionRatePercent"])
+        self.assertEqual(5, body["totals"]["unknownVisitorType"])
+        self.assertEqual(20.0, body["clickLocations"][0]["clickThroughPercent"])
+        self.assertEqual(66.67, body["forms"][0]["completionRatePercent"])
+        self.assertEqual(30.0, body["funnel"]["clickThroughPercent"])
+        self.assertIsNone(body["funnel"]["wins"])
+        self.assertFalse(body["funnel"]["winTrackingAvailable"])
+        self.assertNotIn("analyticsUserId", response["body"])
 
 
 if __name__ == "__main__":

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -504,6 +504,12 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertNotIn("click_x_bucket", self.module.CAMPAIGN_SQL)
         self.assertNotIn("click_y_bucket", self.module.CAMPAIGN_SQL)
 
+    def test_route_funnel_matches_the_exact_clicked_challenge(self) -> None:
+        """Route registrations and submissions retain the clicked challenge ID."""
+
+        self.assertIn("event.challenge_id = click.challenge_id", self.module.ROUTE_SQL)
+        self.assertIn("event.challenge_id = registration.challenge_id", self.module.ROUTE_SQL)
+
     def test_shapes_general_report(self) -> None:
         """General rows retain page, source, and surface dimensions."""
 

--- a/src/apps/analytics/README.md
+++ b/src/apps/analytics/README.md
@@ -39,6 +39,36 @@ the ranked page table is paginated twenty rows at a time. Traffic-source and
 page breakdowns remain available; the application-surface breakdown is not
 shown.
 
+The General tab also provides an exact route/page-URL lookup. It accepts an
+absolute query-free path or strips the query and fragment from a pasted HTTP(S)
+URL. The detailed request runs only after a route is selected, keeping the
+initial General report small. Its definitions are:
+
+- unique source counts are mutually exclusive and use the acquisition group on
+  each visitor's first view of the selected route: Organic, Paid, Social,
+  Email, or Other/direct;
+- click-through rate is distinct people who clicked divided by distinct route
+  visitors;
+- new/returning uses AWS Clickstream session number `1` versus greater than
+  `1` at a visitor's first selected-route view;
+- average time on page is focused foreground engagement seconds divided by
+  page views;
+- bounce rate is single-page entrance sessions divided by all entrance
+  sessions for the route;
+- a conversion is a distinct route visitor who successfully completes an
+  instrumented form there or registers after clicking a specific challenge
+  link there; and
+- the challenge funnel sequences route visitor, challenge-link click,
+  registration, and submission by the same pseudonymous visitor within the
+  selected period. A trusted winner event is not currently available, so the
+  final stage is explicitly shown as **Not tracked** rather than inferred.
+
+Form reporting begins when `form_viewed`, `form_started`, `form_completed`, and
+`form_abandoned` events are deployed on an opted-in form. Completion means its
+server accepted the submission. Abandonment stores only the last stable field
+identifier; form values and rendered labels are never collected. Historical
+periods before that instrumentation correctly show no form activity.
+
 Counts are daily aggregates from the AWS Clickstream reporting views. Date
 ranges are inclusive and limited to 366 days. The UI displays the warehouse's
 `dataThrough` value because the development transform currently runs daily.

--- a/src/apps/analytics/README.md
+++ b/src/apps/analytics/README.md
@@ -59,8 +59,8 @@ initial General report small. Its definitions are:
   instrumented form there or registers after clicking a specific challenge
   link there; and
 - the challenge funnel sequences route visitor, challenge-link click,
-  registration, and submission by the same pseudonymous visitor within the
-  selected period. A trusted winner event is not currently available, so the
+  registration, and submission for the same challenge ID and pseudonymous
+  visitor within the selected period. A trusted winner event is not currently available, so the
   final stage is explicitly shown as **Not tracked** rather than inferred.
 
 Form reporting begins when `form_viewed`, `form_started`, `form_completed`, and

--- a/src/apps/analytics/src/lib/models/analytics.models.ts
+++ b/src/apps/analytics/src/lib/models/analytics.models.ts
@@ -17,6 +17,11 @@ export interface GeneralFilters extends AnalyticsDateRange {
     surface?: string
 }
 
+/** Exact page-path filters supported by the detailed route endpoint. */
+export interface RouteFilters extends GeneralFilters {
+    path: string
+}
+
 /** Server-provided bounded filter options and data freshness. */
 export interface AnalyticsFilterOptions {
     campaigns: string[]
@@ -146,6 +151,84 @@ export interface GeneralReport {
     pages: PageBreakdown[]
     sources: SourceBreakdown[]
     surfaces: SurfaceBreakdown[]
+}
+
+/** Detailed engagement totals for one exact route. */
+export interface RouteTotals extends GeneralTotals {
+    clickThroughPercent: number
+    newVisitors: number
+    returningVisitors: number
+    unknownVisitorType: number
+    averageEngagementSeconds: number
+    entrances: number
+    bounces: number
+    bounceRatePercent: number
+    conversions: number
+    conversionRatePercent: number
+    formStarts: number
+    formCompletions: number
+    formAbandonments: number
+}
+
+/** Mutually exclusive acquisition group assigned from a visitor's first route view. */
+export interface RouteVisitorSource {
+    source: 'organic' | 'paid' | 'social' | 'email' | 'other'
+    visitors: number
+    percent: number
+}
+
+/** Privacy-safe click aggregate for one semantic item on the selected route. */
+export interface RouteClickLocation extends Omit<ClickLocation, 'pagePath'> {
+    clickThroughPercent: number
+}
+
+/** Aggregate lifecycle metrics for one instrumented form on the selected route. */
+export interface RouteFormBreakdown {
+    formId: string
+    views: number
+    viewers: number
+    starts: number
+    starters: number
+    completions: number
+    completers: number
+    abandonments: number
+    abandoners: number
+    completionRatePercent: number
+    abandonmentRatePercent: number
+}
+
+/** Last-interacted field aggregate emitted when an instrumented form is abandoned. */
+export interface RouteFormAbandonment {
+    formId: string
+    fieldId: string
+    abandonments: number
+    visitors: number
+}
+
+/** Ordered page-to-challenge funnel for the selected route and reporting period. */
+export interface RouteChallengeFunnel {
+    pageVisitors: number
+    challengeCtaClickers: number
+    registrations: number
+    submissions: number
+    wins: number | null
+    clickThroughPercent: number
+    clickToRegistrationPercent: number
+    registrationToSubmissionPercent: number
+    winTrackingAvailable: boolean
+}
+
+/** Complete detailed route report returned by analytics-api. */
+export interface RouteReport {
+    generatedAt: string
+    dataThrough?: string
+    filters: Required<RouteFilters>
+    totals: RouteTotals
+    visitorSources: RouteVisitorSource[]
+    clickLocations: RouteClickLocation[]
+    forms: RouteFormBreakdown[]
+    formAbandonments: RouteFormAbandonment[]
+    funnel: RouteChallengeFunnel
 }
 
 /** Safe request-error category rendered by the analytics UI. */

--- a/src/apps/analytics/src/lib/services/analytics.service.spec.ts
+++ b/src/apps/analytics/src/lib/services/analytics.service.spec.ts
@@ -6,6 +6,7 @@ import {
     getAnalyticsFilters,
     getCampaignReport,
     getGeneralReport,
+    getRouteReport,
     requestAnalyticsReport,
 } from './analytics.service'
 
@@ -52,6 +53,12 @@ describe('Analytics API service', () => {
             surface: 'platform_ui',
             to: '2026-08-30',
         })
+        await getRouteReport({
+            from: '2026-08-01',
+            path: '/opportunities/challenge/example',
+            surface: 'platform_ui',
+            to: '2026-08-30',
+        })
 
         expect(mockedXhrGetAsync)
             .toHaveBeenNthCalledWith(
@@ -69,6 +76,13 @@ describe('Analytics API service', () => {
                 3,
                 'https://api.example.com/v1/analytics/general'
                 + '?from=2026-08-01&to=2026-08-30&surface=platform_ui&async=true',
+            )
+        expect(mockedXhrGetAsync)
+            .toHaveBeenNthCalledWith(
+                4,
+                'https://api.example.com/v1/analytics/route'
+                + '?from=2026-08-01&to=2026-08-30&surface=platform_ui'
+                + '&path=%2Fopportunities%2Fchallenge%2Fexample&async=true',
             )
     })
 

--- a/src/apps/analytics/src/lib/services/analytics.service.ts
+++ b/src/apps/analytics/src/lib/services/analytics.service.ts
@@ -8,11 +8,13 @@ import {
     CampaignReport,
     GeneralFilters,
     GeneralReport,
+    RouteFilters,
+    RouteReport,
 } from '../models'
 
 export const ANALYTICS_API_BASE = EnvironmentConfig.ANALYTICS.API_URL.replace(/\/$/, '')
 
-type AnalyticsQueryValues = Partial<CampaignFilters & GeneralFilters>
+type AnalyticsQueryValues = Partial<CampaignFilters & GeneralFilters & RouteFilters>
 type AnalyticsPollWait = (milliseconds: number) => Promise<void>
 
 interface AnalyticsPendingResponse {
@@ -34,6 +36,7 @@ const ANALYTICS_QUERY_KEYS: Array<keyof AnalyticsQueryValues> = [
     'source',
     'medium',
     'surface',
+    'path',
 ]
 
 /**
@@ -174,4 +177,15 @@ export function getCampaignReport(filters: CampaignFilters): Promise<CampaignRep
  */
 export function getGeneralReport(filters: GeneralFilters): Promise<GeneralReport> {
     return requestAnalyticsReport('general', filters)
+}
+
+/**
+ * Loads detailed engagement, form, click, and funnel analytics for one page path.
+ *
+ * @param filters validated UI date, surface, and exact path filters.
+ * @returns route totals and privacy-safe aggregate breakdowns.
+ * @throws Rejects when configuration, authentication, authorization, or the API request fails.
+ */
+export function getRouteReport(filters: RouteFilters): Promise<RouteReport> {
+    return requestAnalyticsReport('route', filters)
 }

--- a/src/apps/analytics/src/lib/utils/analytics.utils.spec.ts
+++ b/src/apps/analytics/src/lib/utils/analytics.utils.spec.ts
@@ -2,10 +2,12 @@
 import {
     analyticsRequestKey,
     defaultAnalyticsDateRange,
+    formatAnalyticsDuration,
     formatAnalyticsFreshness,
     formatAnalyticsInteger,
     formatAnalyticsPercent,
     formatAnalyticsSurface,
+    normalizeAnalyticsPagePath,
     validateAnalyticsDateRange,
 } from './analytics.utils'
 
@@ -50,12 +52,25 @@ describe('Analytics utilities', () => {
             .toBe('12,345')
         expect(formatAnalyticsPercent(12.345))
             .toBe('12.35%')
+        expect(formatAnalyticsDuration(125.6))
+            .toBe('2m 6s')
         expect(formatAnalyticsSurface('topcoder_website'))
             .toBe('Topcoder Website')
         expect(formatAnalyticsFreshness('2026-08-30'))
             .toBe('Aug 30, 2026')
         expect(formatAnalyticsFreshness('not-a-date'))
             .toBe('not-a-date')
+    })
+
+    it('normalizes a route or full page URL without retaining queries or fragments', () => {
+        expect(normalizeAnalyticsPagePath('/challenges/example?utm_source=email#details'))
+            .toBe('/challenges/example')
+        expect(normalizeAnalyticsPagePath('https://www.topcoder.com/enterprise/page?q=private'))
+            .toBe('/enterprise/page')
+        expect(normalizeAnalyticsPagePath('challenges/example'))
+            .toBeUndefined()
+        expect(normalizeAnalyticsPagePath('mailto:analytics@example.com'))
+            .toBeUndefined()
     })
 
     it('creates a stable key regardless of filter property insertion order', () => {

--- a/src/apps/analytics/src/lib/utils/analytics.utils.ts
+++ b/src/apps/analytics/src/lib/utils/analytics.utils.ts
@@ -83,6 +83,41 @@ export function formatAnalyticsPercent(value: number): string {
 }
 
 /**
+ * Formats an average engagement duration as compact minutes and seconds.
+ *
+ * @param value finite duration in seconds.
+ * @returns human-readable duration with seconds rounded to the nearest whole number.
+ * @throws Does not throw.
+ */
+export function formatAnalyticsDuration(value: number): string {
+    const seconds = Math.max(0, Math.round(Number.isFinite(value) ? value : 0))
+    if (seconds < 60) return `${seconds}s`
+    const minutes = Math.floor(seconds / 60)
+    return `${minutes}m ${seconds % 60}s`
+}
+
+/**
+ * Converts either an absolute HTTP(S) page URL or an absolute route into a query-free path.
+ *
+ * @param value route or page URL entered by an analytics user.
+ * @returns encoded pathname of at most 500 characters, or undefined for unsupported input.
+ * @throws Does not throw for malformed URLs.
+ */
+export function normalizeAnalyticsPagePath(value: string): string | undefined {
+    const candidate = value.trim()
+    if (!candidate) return undefined
+    try {
+        const parsed = candidate.startsWith('/')
+            ? new URL(candidate, 'https://analytics.local')
+            : new URL(candidate)
+        if (!['http:', 'https:'].includes(parsed.protocol)) return undefined
+        return parsed.pathname.length <= 500 ? parsed.pathname : undefined
+    } catch {
+        return undefined
+    }
+}
+
+/**
  * Formats API freshness metadata in the viewer's local timezone.
  *
  * @param value ISO timestamp, YYYY-MM-DD, or absent value.

--- a/src/apps/analytics/src/pages/AnalyticsPages.module.scss
+++ b/src/apps/analytics/src/pages/AnalyticsPages.module.scss
@@ -102,6 +102,99 @@
     margin: 0;
 }
 
+.routeLookup {
+    align-items: center;
+    background: linear-gradient(135deg, #eef8f5 0%, #f7fbff 100%);
+    border: 1px solid #b9dcd1;
+    border-radius: 10px;
+    display: grid;
+    gap: $sp-6;
+    grid-template-columns: minmax(240px, 0.8fr) minmax(360px, 1.2fr);
+    padding: $sp-5;
+
+    h2 {
+        font-size: 22px;
+        margin: 2px 0 $sp-2;
+    }
+
+    p:not(.eyebrow) {
+        color: #5a6f78;
+        font-size: 13px;
+        margin: 0;
+    }
+
+    form,
+    label {
+        display: flex;
+        flex-direction: column;
+        gap: 7px;
+    }
+
+    label {
+        color: #455b65;
+        font-size: 12px;
+        font-weight: 800;
+    }
+
+    form > div {
+        display: grid;
+        gap: $sp-3;
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    input {
+        background: #ffffff;
+        border: 1px solid #8fa5ae;
+        border-radius: 6px;
+        color: #0d3445;
+        font: inherit;
+        height: 42px;
+        min-width: 0;
+        padding: 0 11px;
+
+        &:focus {
+            border-color: #137d60;
+            box-shadow: 0 0 0 2px rgba(19, 125, 96, 0.2);
+            outline: none;
+        }
+    }
+
+    .filterError {
+        margin-top: $sp-2;
+    }
+}
+
+.routeReport {
+    display: flex;
+    flex-direction: column;
+    gap: $sp-5;
+    scroll-margin-top: $sp-5;
+}
+
+.routeReportHeading {
+    align-items: flex-start;
+    display: flex;
+    gap: $sp-4;
+    justify-content: space-between;
+
+    h2 {
+        font-size: 25px;
+        margin: 2px 0 $sp-1;
+        overflow-wrap: anywhere;
+    }
+
+    p:not(.eyebrow),
+    > span {
+        color: #617681;
+        font-size: 13px;
+        margin: 0;
+    }
+
+    > span {
+        white-space: nowrap;
+    }
+}
+
 .freshness {
     color: #617681;
     font-size: 13px;
@@ -160,6 +253,63 @@
     display: grid;
     gap: $sp-5;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.funnelGrid {
+    display: grid;
+    gap: $sp-3;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.visitorTypeGrid {
+    display: grid;
+    gap: $sp-3;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+
+    > div {
+        background: #f2f6f8;
+        border-radius: 8px;
+        display: flex;
+        flex-direction: column;
+        gap: $sp-2;
+        padding: $sp-5;
+    }
+
+    span {
+        color: #617681;
+        font-size: 12px;
+        font-weight: 800;
+        text-transform: uppercase;
+    }
+
+    strong {
+        font-size: 28px;
+    }
+}
+
+.definitionNote,
+.emptyPanel {
+    color: #617681;
+    font-size: 13px;
+    margin: $sp-4 0 0;
+}
+
+.emptyPanel {
+    background: #f7f9fa;
+    border-radius: 8px;
+    padding: $sp-5;
+    text-align: center;
+}
+
+.abandonmentSection {
+    border-top: 1px solid #e4eaee;
+    margin-top: $sp-5;
+    padding-top: $sp-5;
+
+    h3 {
+        font-size: 16px;
+        margin: 0 0 $sp-3;
+    }
 }
 
 .tableScroll {
@@ -250,6 +400,28 @@
     display: block;
 }
 
+.pathCell {
+    max-width: 360px;
+    overflow-wrap: anywhere;
+}
+
+.tableAction {
+    background: transparent;
+    border: 0;
+    color: #086c50;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 700;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:focus-visible {
+        outline: 2px solid #137d60;
+        outline-offset: 3px;
+    }
+}
+
 .secondaryCell {
     color: #71838b;
     font-size: 11px;
@@ -281,12 +453,23 @@
     .twoColumnGrid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+
+    .funnelGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 @include ltesm {
     .filters,
     .metricGrid,
-    .twoColumnGrid {
+    .twoColumnGrid,
+    .funnelGrid,
+    .routeLookup,
+    .visitorTypeGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .routeLookup form > div {
         grid-template-columns: 1fr;
     }
 
@@ -296,6 +479,14 @@
 
     .panelHeader {
         flex-direction: column;
+    }
+
+    .routeReportHeading {
+        flex-direction: column;
+
+        > span {
+            white-space: normal;
+        }
     }
 
     .freshness {

--- a/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
+++ b/src/apps/analytics/src/pages/AnalyticsPages.spec.tsx
@@ -8,6 +8,7 @@ import {
     AnalyticsFilterOptions,
     CampaignReport,
     GeneralReport,
+    RouteReport,
 } from '../lib/models'
 
 import { CampaignAnalyticsPage } from './CampaignAnalyticsPage'
@@ -54,6 +55,7 @@ jest.mock('../lib/services', () => ({
     getAnalyticsFilters: jest.fn(),
     getCampaignReport: jest.fn(),
     getGeneralReport: jest.fn(),
+    getRouteReport: jest.fn(),
 }))
 
 const mockedUseAnalyticsResource = useAnalyticsResource as unknown as jest.Mock
@@ -68,20 +70,23 @@ const filterOptions: AnalyticsFilterOptions = {
 }
 
 let reportResource: object
+let routeReportResource: object
 
 /**
  * Configures the generic analytics resource mock for one page render.
  *
- * @param resource report lifecycle state returned for the non-filter request.
+ * @param resource report lifecycle state returned for the main non-filter request.
+ * @param routeResource optional lifecycle state returned for a selected route lookup.
  * @returns void after installing stable filter and report responses.
  * @throws Does not throw.
  */
-function mockAnalyticsResources(resource: object): void {
+function mockAnalyticsResources(resource: object, routeResource: object = resource): void {
     reportResource = resource
+    routeReportResource = routeResource
     mockedUseAnalyticsResource.mockImplementation((key: string) => (
         key === 'analytics-filters'
             ? { data: filterOptions, loading: false, refresh, refreshing: false }
-            : reportResource
+            : key?.startsWith('route:') ? routeReportResource : reportResource
     ))
 }
 
@@ -263,5 +268,123 @@ describe('Analytics report pages', () => {
             .toHaveAttribute('data-overlay', 'false')
         expect(screen.getByRole('button', { name: 'Apply' }))
             .toBeEnabled()
+    })
+
+    it('looks up a full page URL and renders route behavior, forms, and funnel definitions', () => {
+        const general: GeneralReport = {
+            dataThrough: '2026-09-10',
+            filters: { from: '2026-08-13', surface: '', to: '2026-09-11' },
+            generatedAt: '2026-09-11T00:00:00Z',
+            pages: [],
+            series: [],
+            sources: [],
+            surfaces: [],
+            totals: { clickers: 0, clicks: 0, pageViews: 0, visitors: 0 },
+        }
+        const route: RouteReport = {
+            clickLocations: [{
+                clickers: 20,
+                clicks: 25,
+                clickThroughPercent: 20,
+                destinationHost: 'platform-ui.topcoder-dev.com',
+                destinationPath: '/opportunities/challenge/example',
+                elementId: 'view-challenge',
+                elementType: 'a',
+                placement: 'hero',
+            }],
+            dataThrough: '2026-09-10',
+            filters: {
+                from: '2026-08-13',
+                path: '/landing',
+                surface: '',
+                to: '2026-09-11',
+            },
+            formAbandonments: [{
+                abandonments: 4,
+                fieldId: 'company',
+                formId: 'contact-us',
+                visitors: 4,
+            }],
+            forms: [{
+                abandoners: 4,
+                abandonmentRatePercent: 33.33,
+                abandonments: 4,
+                completers: 8,
+                completionRatePercent: 66.67,
+                completions: 8,
+                formId: 'contact-us',
+                starters: 11,
+                starts: 12,
+                viewers: 45,
+                views: 50,
+            }],
+            funnel: {
+                challengeCtaClickers: 30,
+                clickThroughPercent: 30,
+                clickToRegistrationPercent: 40,
+                pageVisitors: 100,
+                registrations: 12,
+                registrationToSubmissionPercent: 50,
+                submissions: 6,
+                // eslint-disable-next-line unicorn/no-null
+                wins: null,
+                winTrackingAvailable: false,
+            },
+            generatedAt: '2026-09-11T00:00:00Z',
+            totals: {
+                averageEngagementSeconds: 126,
+                bounceRatePercent: 25,
+                bounces: 20,
+                clickers: 40,
+                clicks: 60,
+                clickThroughPercent: 40,
+                conversionRatePercent: 15,
+                conversions: 15,
+                entrances: 80,
+                formAbandonments: 4,
+                formCompletions: 8,
+                formStarts: 12,
+                newVisitors: 35,
+                pageViews: 150,
+                returningVisitors: 60,
+                unknownVisitorType: 5,
+                visitors: 100,
+            },
+            visitorSources: [
+                { percent: 30, source: 'organic', visitors: 30 },
+                { percent: 20, source: 'paid', visitors: 20 },
+                { percent: 10, source: 'social', visitors: 10 },
+                { percent: 5, source: 'email', visitors: 5 },
+                { percent: 35, source: 'other', visitors: 35 },
+            ],
+        }
+        mockAnalyticsResources(
+            { data: general, loading: false, refresh, refreshing: false },
+            { data: route, loading: false, refresh, refreshing: false },
+        )
+        render(<GeneralAnalyticsPage />)
+
+        fireEvent.change(screen.getByLabelText('Route or page URL'), {
+            target: { value: 'https://www.topcoder.com/landing?utm_source=email#form' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Look up' }))
+
+        const detail = screen.getByRole('heading', { name: '/landing' })
+            .closest('section') as HTMLElement
+        expect(within(detail)
+            .getByText('2m 6s'))
+            .toBeInTheDocument()
+        expect(within(detail)
+            .getByRole('heading', { name: 'Visitors by source' }))
+            .toBeInTheDocument()
+        expect(within(detail)
+            .getByText('view-challenge'))
+            .toBeInTheDocument()
+        expect(within(detail)
+            .getAllByText('contact-us'))
+            .toHaveLength(2)
+        expect(within(detail)
+            .getByText('Not tracked'))
+            .toBeInTheDocument()
     })
 })

--- a/src/apps/analytics/src/pages/GeneralAnalyticsPage.tsx
+++ b/src/apps/analytics/src/pages/GeneralAnalyticsPage.tsx
@@ -3,6 +3,7 @@ import {
     ChangeEvent,
     FC,
     FormEvent,
+    MouseEvent,
     useCallback,
     useMemo,
     useState,
@@ -25,10 +26,13 @@ import {
     AnalyticsFilterOptions,
     GeneralFilters,
     GeneralReport,
+    RouteFilters,
+    RouteReport,
 } from '../lib/models'
 import {
     getAnalyticsFilters,
     getGeneralReport,
+    getRouteReport,
 } from '../lib/services'
 import {
     analyticsRequestKey,
@@ -36,9 +40,11 @@ import {
     formatAnalyticsFreshness,
     formatAnalyticsInteger,
     formatAnalyticsSurface,
+    normalizeAnalyticsPagePath,
     validateAnalyticsDateRange,
 } from '../lib/utils'
 
+import { RouteAnalyticsReport } from './RouteAnalyticsReport'
 import styles from './AnalyticsPages.module.scss'
 
 const MOST_VISITED_PAGE_SIZE = 20
@@ -127,11 +133,25 @@ export const GeneralAnalyticsPage: FC = () => {
     const [appliedFilters, setAppliedFilters] = useState<GeneralFilters>(initialFilters)
     const [filterError, setFilterError] = useState<string>()
     const [visitedPagesPage, setVisitedPagesPage] = useState(1)
+    const [routeDraft, setRouteDraft] = useState('')
+    const [routePath, setRoutePath] = useState<string>()
+    const [routeError, setRouteError] = useState<string>()
     const filterOptions = useAnalyticsResource<AnalyticsFilterOptions>('analytics-filters', getAnalyticsFilters)
     const reportKey = analyticsRequestKey('general', appliedFilters)
     const report = useAnalyticsResource<GeneralReport>(
         reportKey,
         useCallback(() => getGeneralReport(appliedFilters), [appliedFilters]),
+    )
+    const routeFilters = useMemo<RouteFilters | undefined>(
+        () => (routePath ? { ...appliedFilters, path: routePath } : undefined),
+        [appliedFilters, routePath],
+    )
+    const routeReport = useAnalyticsResource<RouteReport>(
+        routeFilters ? analyticsRequestKey('route', routeFilters) : undefined,
+        useCallback(
+            () => getRouteReport(routeFilters as RouteFilters),
+            [routeFilters],
+        ),
     )
 
     const updateFilter = useCallback((event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -154,6 +174,37 @@ export const GeneralAnalyticsPage: FC = () => {
         setVisitedPagesPage(1)
         setFilterError(undefined)
     }, [])
+    /** Normalizes and applies a manually entered route without retaining URL queries. */
+    const lookupRoute = useCallback((event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        const normalizedPath = normalizeAnalyticsPagePath(routeDraft)
+        if (!normalizedPath) {
+            setRouteError('Enter an absolute route or a complete HTTP(S) page URL.')
+            return
+        }
+
+        setRouteDraft(normalizedPath)
+        setRoutePath(normalizedPath)
+        setRouteError(undefined)
+    }, [routeDraft])
+    /** Opens route detail for one page selected from the ranked-page table. */
+    const analyzePage = useCallback((path: string) => {
+        setRouteDraft(path)
+        setRoutePath(path)
+        setRouteError(undefined)
+        window.requestAnimationFrame(() => {
+            document.getElementById('route-analytics-details')
+                ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        })
+    }, [])
+    /** Mirrors route input changes without starting a warehouse request. */
+    const updateRouteDraft = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+        setRouteDraft(event.target.value)
+    }, [])
+    /** Reads a ranked page path from a table action and opens its detail report. */
+    const analyzePageFromButton = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+        analyzePage(event.currentTarget.value)
+    }, [analyzePage])
 
     const data = report.data
     const reportPending = report.loading || report.refreshing
@@ -240,6 +291,47 @@ export const GeneralAnalyticsPage: FC = () => {
                         <p className={styles.filterError} role='alert'>{filterError}</p>
                     )}
                 </form>
+
+                <section className={styles.routeLookup}>
+                    <div>
+                        <p className={styles.eyebrow}>Page detail</p>
+                        <h2>Route / page URL lookup</h2>
+                        <p>
+                            Enter a query-free route or paste a complete page URL. Date and site-surface
+                            filters above apply to the lookup.
+                        </p>
+                    </div>
+                    <form onSubmit={lookupRoute}>
+                        <label htmlFor='analytics-route-path'>Route or page URL</label>
+                        <div>
+                            <input
+                                id='analytics-route-path'
+                                list='analytics-route-suggestions'
+                                onChange={updateRouteDraft}
+                                placeholder='/opportunities/challenge/...'
+                                required
+                                type='text'
+                                value={routeDraft}
+                            />
+                            <Button primary type='submit'>Look up</Button>
+                        </div>
+                        <datalist id='analytics-route-suggestions'>
+                            {(report.data?.pages ?? []).map(page => (
+                                <option key={`${page.surface}-${page.path}`} value={page.path}>{page.path}</option>
+                            ))}
+                        </datalist>
+                        {routeError && <p className={styles.filterError} role='alert'>{routeError}</p>}
+                    </form>
+                </section>
+
+                {routePath && (
+                    <RouteAnalyticsReport
+                        path={routePath}
+                        period={`${formatAnalyticsFreshness(appliedFilters.from)} – ${
+                            formatAnalyticsFreshness(appliedFilters.to)}`}
+                        resource={routeReport}
+                    />
+                )}
 
                 {reportPending && (
                     <AnalyticsLoadingState message='Loading general analytics…' />
@@ -338,6 +430,7 @@ export const GeneralAnalyticsPage: FC = () => {
                                             <th scope='col'>Page path</th>
                                             <th scope='col'>Page views</th>
                                             <th scope='col'>Visitors</th>
+                                            <th aria-label='Actions' scope='col' />
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -347,9 +440,19 @@ export const GeneralAnalyticsPage: FC = () => {
                                                 <th scope='row'>{row.path}</th>
                                                 <td>{formatAnalyticsInteger(row.pageViews)}</td>
                                                 <td>{formatAnalyticsInteger(row.visitors)}</td>
+                                                <td>
+                                                    <button
+                                                        className={styles.tableAction}
+                                                        onClick={analyzePageFromButton}
+                                                        type='button'
+                                                        value={row.path}
+                                                    >
+                                                        Analyze
+                                                    </button>
+                                                </td>
                                             </tr>
                                         ))}
-                                        {visibleVisitedPages.length === 0 && <EmptyTableRow columns={4} />}
+                                        {visibleVisitedPages.length === 0 && <EmptyTableRow columns={5} />}
                                     </tbody>
                                 </table>
                             </div>

--- a/src/apps/analytics/src/pages/RouteAnalyticsReport.tsx
+++ b/src/apps/analytics/src/pages/RouteAnalyticsReport.tsx
@@ -1,0 +1,459 @@
+/** Detailed route-level analytics report rendered inside the General tab. */
+import {
+    FC,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react'
+
+import {
+    AnalyticsLoadingState,
+    MetricCard,
+    ReportError,
+} from '../lib/components'
+import { AnalyticsResourceState } from '../lib/hooks'
+import { RouteClickLocation, RouteReport } from '../lib/models'
+import {
+    formatAnalyticsDuration,
+    formatAnalyticsFreshness,
+    formatAnalyticsInteger,
+    formatAnalyticsPercent,
+} from '../lib/utils'
+
+import styles from './AnalyticsPages.module.scss'
+
+const ROUTE_CLICK_PAGE_SIZE = 20
+
+const sourceLabels: Record<string, string> = {
+    email: 'Email',
+    organic: 'Organic',
+    other: 'Other / direct',
+    paid: 'Paid',
+    social: 'Social',
+}
+
+/**
+ * Combines optional host and path dimensions into one compact destination label.
+ *
+ * @param location aggregate semantic click location.
+ * @returns destination label or an em dash when the item has no HTTP destination.
+ * @throws Does not throw.
+ */
+function clickDestination(location: RouteClickLocation): string {
+    return [location.destinationHost, location.destinationPath]
+        .filter(Boolean)
+        .join('') || '—'
+}
+
+/**
+ * Builds a deterministic React key from the complete semantic click grouping.
+ *
+ * @param location aggregate semantic click location.
+ * @returns delimiter-joined key used only for stable list rendering.
+ * @throws Does not throw.
+ */
+function clickLocationKey(location: RouteClickLocation): string {
+    return [
+        location.placement,
+        location.elementId,
+        location.elementType,
+        location.destinationHost,
+        location.destinationPath,
+    ].join('|')
+}
+
+interface RouteAnalyticsReportProps {
+    path: string
+    period: string
+    resource: AnalyticsResourceState<RouteReport>
+}
+
+/**
+ * Renders route KPIs, visitor classification, click locations, forms, and the challenge funnel.
+ *
+ * @param props selected path, reporting-period label, and asynchronous route resource state.
+ * @returns detailed aggregate route report or its loading/error state.
+ * @throws Does not throw; request failures are rendered inline.
+ */
+export const RouteAnalyticsReport: FC<RouteAnalyticsReportProps> = props => {
+    const [clickPage, setClickPage] = useState(1)
+    const data = props.resource.data
+    const clickTotal = data?.clickLocations.length ?? 0
+    const clickPages = Math.max(1, Math.ceil(clickTotal / ROUTE_CLICK_PAGE_SIZE))
+    const activeClickPage = Math.min(clickPage, clickPages)
+    const visibleClicks = useMemo(
+        () => data?.clickLocations.slice(
+            (activeClickPage - 1) * ROUTE_CLICK_PAGE_SIZE,
+            activeClickPage * ROUTE_CLICK_PAGE_SIZE,
+        ) ?? [],
+        [activeClickPage, data?.clickLocations],
+    )
+
+    useEffect(() => {
+        setClickPage(1)
+    }, [props.path])
+    /** Shows the prior local click-location page. */
+    const showPreviousClicks = useCallback(() => {
+        setClickPage(current => Math.max(1, current - 1))
+    }, [])
+    /** Shows the next local click-location page without exceeding the result set. */
+    const showNextClicks = useCallback(() => {
+        setClickPage(current => Math.min(clickPages, current + 1))
+    }, [clickPages])
+
+    return (
+        <section aria-labelledby='route-report-title' className={styles.routeReport} id='route-analytics-details'>
+            <div className={styles.routeReportHeading}>
+                <div>
+                    <p className={styles.eyebrow}>Route lookup</p>
+                    <h2 id='route-report-title'>{props.path}</h2>
+                    <p>{props.period}</p>
+                </div>
+                {data && (
+                    <span>
+                        Data through
+                        {' '}
+                        <strong>{formatAnalyticsFreshness(data.dataThrough)}</strong>
+                    </span>
+                )}
+            </div>
+
+            {(props.resource.loading || props.resource.refreshing) && (
+                <AnalyticsLoadingState message={`Loading analytics for ${props.path}…`} />
+            )}
+            {props.resource.error && !data && (
+                <ReportError error={props.resource.error} onRetry={props.resource.refresh} />
+            )}
+            {props.resource.error && data && (
+                <div className={styles.staleWarning}>{props.resource.error.message}</div>
+            )}
+
+            {data && !props.resource.loading && !props.resource.refreshing && (
+                <>
+                    <section aria-label='Route engagement totals' className={styles.metricGrid}>
+                        <MetricCard
+                            label='Page views'
+                            value={formatAnalyticsInteger(data.totals.pageViews)}
+                        />
+                        <MetricCard
+                            label='Unique visitors'
+                            tone='highlight'
+                            value={formatAnalyticsInteger(data.totals.visitors)}
+                        />
+                        <MetricCard
+                            context={`${formatAnalyticsPercent(data.totals.clickThroughPercent)} of visitors`}
+                            label='People who clicked'
+                            tone='highlight'
+                            value={formatAnalyticsInteger(data.totals.clickers)}
+                        />
+                        <MetricCard
+                            context={`${formatAnalyticsInteger(data.totals.clicks)} total clicks`}
+                            label='Click-through rate'
+                            tone='success'
+                            value={formatAnalyticsPercent(data.totals.clickThroughPercent)}
+                        />
+                        <MetricCard
+                            context='Focused foreground time per page view'
+                            label='Average time on page'
+                            value={formatAnalyticsDuration(data.totals.averageEngagementSeconds)}
+                        />
+                        <MetricCard
+                            context={`${formatAnalyticsInteger(data.totals.bounces)} of ${formatAnalyticsInteger(
+                                data.totals.entrances,
+                            )} entrance sessions`}
+                            label='Bounce rate'
+                            value={formatAnalyticsPercent(data.totals.bounceRatePercent)}
+                        />
+                        <MetricCard
+                            context={`${formatAnalyticsInteger(data.totals.conversions)} converted visitors`}
+                            label='Conversion rate'
+                            tone='success'
+                            value={formatAnalyticsPercent(data.totals.conversionRatePercent)}
+                        />
+                        <MetricCard
+                            context={`${formatAnalyticsInteger(
+                                data.totals.formCompletions,
+                            )} completed · ${formatAnalyticsInteger(
+                                data.totals.formAbandonments,
+                            )} abandoned`}
+                            label='Form starts'
+                            value={formatAnalyticsInteger(data.totals.formStarts)}
+                        />
+                    </section>
+
+                    <section className={styles.twoColumnGrid}>
+                        <article className={styles.panel}>
+                            <div className={styles.panelHeader}>
+                                <div>
+                                    <h2>Visitors by source</h2>
+                                    <p>Mutually exclusive source from each visitor’s first route view.</p>
+                                </div>
+                            </div>
+                            <div className={styles.tableScroll}>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th scope='col'>Source</th>
+                                            <th scope='col'>Visitors</th>
+                                            <th scope='col'>Share</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {data.visitorSources.map(row => (
+                                            <tr key={row.source}>
+                                                <th scope='row'>{sourceLabels[row.source] ?? row.source}</th>
+                                                <td>{formatAnalyticsInteger(row.visitors)}</td>
+                                                <td>{formatAnalyticsPercent(row.percent)}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </article>
+
+                        <article className={styles.panel}>
+                            <div className={styles.panelHeader}>
+                                <div>
+                                    <h2>New versus returning</h2>
+                                    <p>Based on the AWS Clickstream session number at first route view.</p>
+                                </div>
+                            </div>
+                            <div className={styles.visitorTypeGrid}>
+                                <div>
+                                    <span>New</span>
+                                    <strong>{formatAnalyticsInteger(data.totals.newVisitors)}</strong>
+                                </div>
+                                <div>
+                                    <span>Returning</span>
+                                    <strong>{formatAnalyticsInteger(data.totals.returningVisitors)}</strong>
+                                </div>
+                                {data.totals.unknownVisitorType > 0 && (
+                                    <div>
+                                        <span>Unknown</span>
+                                        <strong>{formatAnalyticsInteger(data.totals.unknownVisitorType)}</strong>
+                                    </div>
+                                )}
+                            </div>
+                        </article>
+                    </section>
+
+                    <section className={styles.panel}>
+                        <div className={styles.panelHeader}>
+                            <div>
+                                <h2>Where people clicked</h2>
+                                <p>
+                                    Semantic items ranked by clicks; CTR is unique item clickers divided by
+                                    route visitors.
+                                </p>
+                            </div>
+                        </div>
+                        <div className={styles.tableScroll}>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th scope='col'>Element</th>
+                                        <th scope='col'>Placement</th>
+                                        <th scope='col'>Destination</th>
+                                        <th scope='col'>Clicks</th>
+                                        <th scope='col'>People</th>
+                                        <th scope='col'>CTR</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {visibleClicks.map(row => (
+                                        <tr key={clickLocationKey(row)}>
+                                            <th scope='row'>
+                                                <span className={styles.primaryCell}>
+                                                    {row.elementId || row.elementType || 'Unlabelled element'}
+                                                </span>
+                                                {row.elementId && row.elementType && (
+                                                    <span className={styles.secondaryCell}>{row.elementType}</span>
+                                                )}
+                                            </th>
+                                            <td>{row.placement || '—'}</td>
+                                            <td className={styles.pathCell}>
+                                                {clickDestination(row)}
+                                            </td>
+                                            <td>{formatAnalyticsInteger(row.clicks)}</td>
+                                            <td>{formatAnalyticsInteger(row.clickers)}</td>
+                                            <td>{formatAnalyticsPercent(row.clickThroughPercent)}</td>
+                                        </tr>
+                                    ))}
+                                    {visibleClicks.length === 0 && (
+                                        <tr>
+                                            <td className={styles.emptyTable} colSpan={6}>
+                                                No clicks match this route.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                        {clickTotal > ROUTE_CLICK_PAGE_SIZE && (
+                            <div className={styles.pagination}>
+                                <span>
+                                    {`Showing ${(activeClickPage - 1) * ROUTE_CLICK_PAGE_SIZE + 1}–${Math.min(
+                                        clickTotal,
+                                        activeClickPage * ROUTE_CLICK_PAGE_SIZE,
+                                    )} of ${clickTotal} clicked items`}
+                                </span>
+                                <nav aria-label='Route click locations pagination'>
+                                    <button
+                                        disabled={activeClickPage <= 1}
+                                        onClick={showPreviousClicks}
+                                        type='button'
+                                    >
+                                        Previous
+                                    </button>
+                                    <span>{`Page ${activeClickPage} of ${clickPages}`}</span>
+                                    <button
+                                        disabled={activeClickPage >= clickPages}
+                                        onClick={showNextClicks}
+                                        type='button'
+                                    >
+                                        Next
+                                    </button>
+                                </nav>
+                            </div>
+                        )}
+                    </section>
+
+                    <section className={styles.panel}>
+                        <div className={styles.panelHeader}>
+                            <div>
+                                <h2>Forms</h2>
+                                <p>
+                                    Successful completions and the last field touched before an instrumented
+                                    form was left.
+                                </p>
+                            </div>
+                        </div>
+                        {data.forms.length === 0 ? (
+                            <p className={styles.emptyPanel}>
+                                No instrumented form activity was recorded on this route in the selected
+                                period.
+                            </p>
+                        ) : (
+                            <div className={styles.tableScroll}>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th scope='col'>Form</th>
+                                            <th scope='col'>Views</th>
+                                            <th scope='col'>Starts</th>
+                                            <th scope='col'>Completed</th>
+                                            <th scope='col'>Completion rate</th>
+                                            <th scope='col'>Abandoned</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {data.forms.map(row => (
+                                            <tr key={row.formId}>
+                                                <th className={styles.pathCell} scope='row'>{row.formId}</th>
+                                                <td>{formatAnalyticsInteger(row.views)}</td>
+                                                <td>{formatAnalyticsInteger(row.starts)}</td>
+                                                <td>{formatAnalyticsInteger(row.completions)}</td>
+                                                <td>{formatAnalyticsPercent(row.completionRatePercent)}</td>
+                                                <td>
+                                                    {`${formatAnalyticsInteger(
+                                                        row.abandonments,
+                                                    )} (${formatAnalyticsPercent(
+                                                        row.abandonmentRatePercent,
+                                                    )})`}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                        {data.formAbandonments.length > 0 && (
+                            <div className={styles.abandonmentSection}>
+                                <h3>Where people abandoned forms</h3>
+                                <div className={styles.tableScroll}>
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th scope='col'>Form / last field</th>
+                                                <th scope='col'>Abandonments</th>
+                                                <th scope='col'>People</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {data.formAbandonments
+                                                .slice(0, 20)
+                                                .map(row => (
+                                                    <tr key={`${row.formId}|${row.fieldId}`}>
+                                                        <th scope='row'>
+                                                            <span className={styles.primaryCell}>{row.formId}</span>
+                                                            <span className={styles.secondaryCell}>{row.fieldId}</span>
+                                                        </th>
+                                                        <td>{formatAnalyticsInteger(row.abandonments)}</td>
+                                                        <td>{formatAnalyticsInteger(row.visitors)}</td>
+                                                    </tr>
+                                                ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        )}
+                    </section>
+
+                    <section className={styles.panel}>
+                        <div className={styles.panelHeader}>
+                            <div>
+                                <h2>Challenge funnel</h2>
+                                <p>Ordered activity by the same visitor within the selected period.</p>
+                            </div>
+                        </div>
+                        <div className={styles.funnelGrid}>
+                            <MetricCard
+                                label='Viewed page'
+                                value={formatAnalyticsInteger(data.funnel.pageVisitors)}
+                            />
+                            <MetricCard
+                                context={`${formatAnalyticsPercent(
+                                    data.funnel.clickThroughPercent,
+                                )} of viewers`}
+                                label='Clicked challenge CTA'
+                                tone='highlight'
+                                value={formatAnalyticsInteger(data.funnel.challengeCtaClickers)}
+                            />
+                            <MetricCard
+                                context={`${formatAnalyticsPercent(
+                                    data.funnel.clickToRegistrationPercent,
+                                )} of CTA clickers`}
+                                label='Registered'
+                                tone='highlight'
+                                value={formatAnalyticsInteger(data.funnel.registrations)}
+                            />
+                            <MetricCard
+                                context={`${formatAnalyticsPercent(
+                                    data.funnel.registrationToSubmissionPercent,
+                                )} of registrants`}
+                                label='Submitted'
+                                tone='success'
+                                value={formatAnalyticsInteger(data.funnel.submissions)}
+                            />
+                            <MetricCard
+                                context='No trusted winner event is available yet'
+                                label='Won'
+                                value={data.funnel.winTrackingAvailable && data.funnel.wins !== null
+                                    ? formatAnalyticsInteger(data.funnel.wins)
+                                    : 'Not tracked'}
+                            />
+                        </div>
+                        <p className={styles.definitionNote}>
+                            A challenge CTA is a tracked link from this route to a specific challenge URL.
+                            Registration and submission must happen later for the same visitor. Form completion
+                            or challenge registration counts as a conversion; each visitor is counted once.
+                        </p>
+                    </section>
+                </>
+            )}
+        </section>
+    )
+}
+
+export default RouteAnalyticsReport


### PR DESCRIPTION
## Summary

- add an exact route or full-page URL lookup to the General Analytics tab
- report page views, visitors, source groups, click locations and CTR, new versus returning visitors, engagement, bounce, form lifecycle, conversions, and an ordered challenge funnel
- match CTA click, registration, and submission by pseudonymous visitor and exact challenge ID
- add the protected GET /v1/analytics/route endpoint and a least-privilege Redshift projection
- show wins as unavailable until a trusted winner event exists

## Validation

- python3 -m unittest discover -s infrastructure/analytics-api/tests -v (20 passed)
- yarn lint
- focused analytics Jest suite (28 passed)
- NODE_OPTIONS=--max-old-space-size=8192 yarn run build
- deployed Lambda route report against dev Redshift (200; optimized query completed in under four seconds)
- public endpoint without a bearer token returns 401