### PR TITLE
Speed up general analytics loading

### DIFF
--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -41,6 +41,12 @@ throttles cap warehouse pressure, and successful responses use `Cache-Control:
 private, no-store`. Logs contain request IDs and service-owned error categories
 only.
 
+The General report applies an inclusive timestamp range and uses Redshift
+`GROUPING SETS` to calculate its summary, daily, page, traffic-source, and
+surface sections in one scan of the reporting view. This avoids repeating the
+view's JSON-derived field work for each section while preserving exact visitor
+counts and the existing response contract.
+
 ## Files
 
 - `template.yaml` registers protected analytics routes on the shared API and

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -255,111 +255,123 @@ ORDER BY row_type, date_value, metric_1 DESC
 
 GENERAL_SQL = """
 WITH filtered_events AS (
-    SELECT *
-    FROM topcoder_web.product_analytics_events_v1
-    WHERE event_date BETWEEN CAST(:from_date AS date) AND CAST(:to_date AS date)
-      AND (:surface = '*' OR surface = :surface)
-),
-summary_row AS (
     SELECT
-        CAST(MAX(event_date) AS varchar(10)) AS data_through,
-        COUNT(CASE WHEN event_name = '_page_view' THEN 1 END)::bigint AS page_views,
-        COUNT(DISTINCT CASE WHEN event_name = '_page_view' THEN analytics_user_id END)::bigint AS visitors,
-        COUNT(CASE WHEN event_name = 'ui_click' THEN 1 END)::bigint AS clicks,
-        COUNT(DISTINCT CASE WHEN event_name = 'ui_click' THEN analytics_user_id END)::bigint AS clickers
-    FROM filtered_events
-),
-daily_rows AS (
-    SELECT
-        event_date,
-        COUNT(CASE WHEN event_name = '_page_view' THEN 1 END)::bigint AS page_views,
-        COUNT(DISTINCT CASE WHEN event_name = '_page_view' THEN analytics_user_id END)::bigint AS visitors,
-        COUNT(CASE WHEN event_name = 'ui_click' THEN 1 END)::bigint AS clicks,
-        COUNT(DISTINCT CASE WHEN event_name = 'ui_click' THEN analytics_user_id END)::bigint AS clickers
-    FROM filtered_events
-    GROUP BY event_date
-),
-page_rows AS (
-    SELECT
+        event_timestamp::date AS event_date,
+        event_name,
+        analytics_user_id,
         surface,
         page_path,
-        COUNT(*)::bigint AS page_views,
-        COUNT(DISTINCT analytics_user_id)::bigint AS visitors
-    FROM filtered_events
-    WHERE event_name = '_page_view' AND page_path IS NOT NULL
-    GROUP BY surface, page_path
-    ORDER BY page_views DESC, page_path
-    LIMIT 50
+        utm_source
+    FROM topcoder_web.product_analytics_events_v1
+    WHERE event_timestamp >= CAST(:from_date AS timestamp)
+      AND event_timestamp < DATEADD(day, 1, CAST(:to_date AS timestamp))
+      AND (:surface = '*' OR surface = :surface)
 ),
-source_rows AS (
+aggregated_rows AS (
     SELECT
-        utm_source,
-        COUNT(*)::bigint AS page_views,
-        COUNT(DISTINCT analytics_user_id)::bigint AS visitors
-    FROM filtered_events
-    WHERE event_name = '_page_view'
-    GROUP BY utm_source
-    ORDER BY page_views DESC, utm_source
-    LIMIT 25
-),
-surface_rows AS (
-    SELECT
+        event_date,
         surface,
+        page_path,
+        utm_source,
+        GROUPING(event_date) AS date_is_grouped,
+        GROUPING(surface) AS surface_is_grouped,
+        GROUPING(page_path) AS page_is_grouped,
+        GROUPING(utm_source) AS source_is_grouped,
+        MAX(event_date) AS data_through,
         COUNT(CASE WHEN event_name = '_page_view' THEN 1 END)::bigint AS page_views,
-        COUNT(DISTINCT CASE
-            WHEN event_name = '_page_view' THEN analytics_user_id
-        END)::bigint AS visitors,
-        COUNT(CASE WHEN event_name = 'ui_click' THEN 1 END)::bigint AS clicks
+        COUNT(DISTINCT CASE WHEN event_name = '_page_view' THEN analytics_user_id END)::bigint AS visitors,
+        COUNT(CASE WHEN event_name = 'ui_click' THEN 1 END)::bigint AS clicks,
+        COUNT(DISTINCT CASE WHEN event_name = 'ui_click' THEN analytics_user_id END)::bigint AS clickers
     FROM filtered_events
-    WHERE surface IS NOT NULL
-    GROUP BY surface
-    ORDER BY page_views DESC, surface
-    LIMIT 25
+    GROUP BY GROUPING SETS (
+        (),
+        (event_date),
+        (surface, page_path),
+        (utm_source),
+        (surface)
+    )
+),
+typed_rows AS (
+    SELECT
+        CASE
+            WHEN date_is_grouped = 0 THEN 'daily'
+            WHEN page_is_grouped = 0 THEN 'page'
+            WHEN source_is_grouped = 0 THEN 'source'
+            WHEN surface_is_grouped = 0 THEN 'surface'
+            ELSE 'summary'
+        END::varchar AS row_type,
+        CASE
+            WHEN date_is_grouped = 0 THEN CAST(event_date AS varchar(10))
+        END AS date_value,
+        CASE
+            WHEN date_is_grouped = 0 THEN NULL
+            WHEN page_is_grouped = 0 THEN surface
+            WHEN source_is_grouped = 0 THEN utm_source
+            WHEN surface_is_grouped = 0 THEN surface
+            ELSE CAST(data_through AS varchar(10))
+        END::varchar AS dimension_1,
+        CASE
+            WHEN page_is_grouped = 0 THEN page_path
+        END::varchar AS dimension_2,
+        NULL::varchar AS dimension_3,
+        NULL::varchar AS dimension_4,
+        page_views::double precision AS metric_1,
+        visitors::double precision AS metric_2,
+        CASE
+            WHEN page_is_grouped = 0 OR source_is_grouped = 0 THEN NULL
+            ELSE clicks
+        END::double precision AS metric_3,
+        CASE
+            WHEN date_is_grouped = 0
+              OR (
+                  date_is_grouped = 1
+                  AND surface_is_grouped = 1
+                  AND page_is_grouped = 1
+                  AND source_is_grouped = 1
+              )
+            THEN clickers
+        END::double precision AS metric_4
+    FROM aggregated_rows
+    WHERE
+        (
+            date_is_grouped = 1
+            AND surface_is_grouped = 1
+            AND page_is_grouped = 1
+            AND source_is_grouped = 1
+        )
+        OR date_is_grouped = 0
+        OR (page_is_grouped = 0 AND page_path IS NOT NULL AND page_views > 0)
+        OR (source_is_grouped = 0 AND page_views > 0)
+        OR (
+            surface_is_grouped = 0
+            AND page_is_grouped = 1
+            AND surface IS NOT NULL
+        )
+),
+ranked_rows AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY row_type
+            ORDER BY metric_1 DESC, dimension_2, dimension_1
+        ) AS row_rank
+    FROM typed_rows
 )
 SELECT
-    'summary'::varchar AS row_type,
-    NULL::varchar AS date_value,
-    data_through::varchar AS dimension_1,
-    NULL::varchar AS dimension_2,
-    NULL::varchar AS dimension_3,
-    NULL::varchar AS dimension_4,
-    page_views::double precision AS metric_1,
-    visitors::double precision AS metric_2,
-    clicks::double precision AS metric_3,
-    clickers::double precision AS metric_4
-FROM summary_row
-UNION ALL
-SELECT
-    'daily',
-    CAST(event_date AS varchar(10)),
-    NULL, NULL, NULL, NULL,
-    page_views, visitors, clicks, clickers
-FROM daily_rows
-UNION ALL
-SELECT
-    'page',
-    NULL,
-    surface,
-    page_path,
-    NULL, NULL,
-    page_views, visitors, NULL, NULL
-FROM page_rows
-UNION ALL
-SELECT
-    'source',
-    NULL,
-    utm_source,
-    NULL, NULL, NULL,
-    page_views, visitors, NULL, NULL
-FROM source_rows
-UNION ALL
-SELECT
-    'surface',
-    NULL,
-    surface,
-    NULL, NULL, NULL,
-    page_views, visitors, clicks, NULL
-FROM surface_rows
+    row_type,
+    date_value,
+    dimension_1,
+    dimension_2,
+    dimension_3,
+    dimension_4,
+    metric_1,
+    metric_2,
+    metric_3,
+    metric_4
+FROM ranked_rows
+WHERE (row_type <> 'page' OR row_rank <= 50)
+  AND (row_type <> 'source' OR row_rank <= 25)
+  AND (row_type <> 'surface' OR row_rank <= 25)
 ORDER BY row_type, date_value, metric_1 DESC
 """
 

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -504,6 +504,20 @@ class AnalyticsHandlerTests(unittest.TestCase):
         self.assertNotIn("click_x_bucket", self.module.CAMPAIGN_SQL)
         self.assertNotIn("click_y_bucket", self.module.CAMPAIGN_SQL)
 
+    def test_general_query_uses_one_timestamp_pruned_event_scan(self) -> None:
+        """General report dimensions share one grouping-sets scan of the event view."""
+
+        self.assertEqual(
+            1,
+            self.module.GENERAL_SQL.count("topcoder_web.product_analytics_events_v1"),
+        )
+        self.assertIn("GROUP BY GROUPING SETS", self.module.GENERAL_SQL)
+        self.assertIn("event_timestamp >= CAST(:from_date AS timestamp)", self.module.GENERAL_SQL)
+        self.assertIn(
+            "event_timestamp < DATEADD(day, 1, CAST(:to_date AS timestamp))",
+            self.module.GENERAL_SQL,
+        )
+
     def test_route_funnel_matches_the_exact_clicked_challenge(self) -> None:
         """Route registrations and submissions retain the clicked challenge ID."""
 


### PR DESCRIPTION
## Summary
- calculate General Analytics sections with one Redshift GROUPING SETS scan
- use timestamp range predicates for storage pruning
- preserve the existing aggregate response and limits
- document and regression-test the query shape

## Validation
- Python analytics API unit tests: 21 passed
- platform-ui lint: passed
- platform-ui production build: passed with existing warnings
- result equivalence: all 83 rows matched the previous query
- uncached Redshift execution: approximately 48s before, 1.6s after
- deployed Lambda exact request: 200 in approximately 3.0s end to end