### PR TITLE
Speed up route analytics lookup

### DIFF
--- a/infrastructure/analytics-api/README.md
+++ b/infrastructure/analytics-api/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the development infrastructure and Lambda code for the
 role-gated Analytics UI. The API is a read-only adapter over the existing AWS
-Clickstream Redshift reporting views; it is not an ingestion endpoint.
+Clickstream Redshift reporting relations; it is not an ingestion endpoint.
 
 ## Architecture and security boundary
 
@@ -13,7 +13,7 @@ Platform UI
   -> Lambda exact analytics-role check and fixed queries
   -> Redshift Data API
   -> analytics_api_reader database role
-  -> approved reporting views
+  -> approved reporting views and materialized projection
 ```
 
 API Gateway validates the configured Auth0 issuer, audience, signature, and
@@ -34,18 +34,25 @@ validated parameters, retry attempt, and current or previous four-hour window.
 The four-hour window remains below the Data API's eight-hour idempotency
 retention and permits one complete boundary-crossing window without making
 tokens reusable for other reports. An EventBridge schedule invokes the default
-Campaigns report and filter-option queries at each new window, allowing their
-statements to finish before an interactive request while preserving Redshift
-Serverless idle cost controls. Browser polling is bounded. Concurrency and API
-throttles cap warehouse pressure, and successful responses use `Cache-Control:
-private, no-store`. Logs contain request IDs and service-owned error categories
-only.
+Campaigns report, filter-option query, and `/opportunities` route report at each
+new window, allowing their statements to finish before an interactive request
+while preserving Redshift Serverless idle cost controls. Browser polling is
+bounded. Concurrency and API throttles cap warehouse pressure, and successful
+responses use `Cache-Control: private, no-store`. Logs contain request IDs and
+service-owned error categories only.
 
 The General report applies an inclusive timestamp range and uses Redshift
 `GROUPING SETS` to calculate its summary, daily, page, traffic-source, and
 surface sections in one scan of the reporting view. This avoids repeating the
 view's JSON-derived field work for each section while preserving exact visitor
 counts and the existing response contract.
+
+The Route report reads an auto-refreshed, timestamp-sorted materialized
+projection containing only its approved event types and fields. Replicated
+distribution keeps the report's repeated session and funnel joins local and
+avoids re-extracting JSON fields from the wide Clickstream table. The response
+continues to expose `dataThrough` so consumers can see the latest included route
+page-view date while Redshift schedules incremental refreshes.
 
 ## Files
 
@@ -55,10 +62,10 @@ counts and the existing response contract.
   The former dedicated API remains during the cutover observation window.
 - `src/handler.py` validates and shapes filter, campaign, general, and exact-route reports.
 - `bootstrap.sql` creates the read-only Redshift database role and grants only
-  the reporting objects required by the handler. Its route event view projects
-  only timestamp, pseudonymous join key, session, source group, semantic click,
-  challenge join key, and form lifecycle fields; the Lambda role cannot select
-  the raw event table.
+  the reporting objects required by the handler. Its route event view and
+  materialized projection expose only timestamp, pseudonymous join key,
+  session, source group, semantic click, challenge join key, and form lifecycle
+  fields; the Lambda role cannot select the raw event table.
 - `collector-host-migration.yaml` creates `events.<domain>` on the existing
   ingestion ALB so `analytics.<domain>` can become the reporting UI host.
 - `tests/test_handler.py` verifies authorization, validation, parameterization,
@@ -77,12 +84,14 @@ secret values into parameters, source files, or shell history.
    preflight/request to `/collect` before changing either client configuration.
 4. Package `src/handler.py` as a versioned zip in the encrypted Clickstream
    templates bucket.
-5. Deploy `template.yaml` with `CAPABILITY_NAMED_IAM`, the shared HTTP API ID,
+5. Run `bootstrap.sql` through the Data API using the Redshift namespace's
+   managed administrator secret before deploying code that reads a new
+   reporting relation. On reapplication, omit existing `CREATE ROLE` and
+   `CREATE MATERIALIZED VIEW` statements, then run the replaceable view and
+   idempotent `GRANT` statements.
+6. Deploy `template.yaml` with `CAPABILITY_NAMED_IAM`, the shared HTTP API ID,
    and the exact workgroup, wildcard certificate, public hosted zone, code
    bucket, and code key.
-6. Run `bootstrap.sql` through the Data API using the Redshift namespace's
-   managed administrator secret. On reapplication, omit `CREATE ROLE` if the
-   role already exists and run the idempotent `GRANT` statements.
 7. Exercise Lambda directly with missing, wrong, and exact role claims, then
    exercise the public API with no token, an unauthorized token, and an
    authorized token. A direct invocation does not replace the positive public

--- a/infrastructure/analytics-api/bootstrap.sql
+++ b/infrastructure/analytics-api/bootstrap.sql
@@ -51,7 +51,72 @@ SELECT
     NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'challenge_id', true), '') AS challenge_id
 FROM topcoder_web.event_v2;
 
+-- Route reports reuse the same event subsets many times for session, form,
+-- source, and challenge-funnel calculations. Materialize this narrow,
+-- read-only projection so those calculations do not repeatedly extract JSON
+-- fields from the wide Clickstream table. DISTSTYLE ALL is appropriate for
+-- this small reporting relation and keeps its self-joins local.
+CREATE MATERIALIZED VIEW topcoder_web.route_analytics_events_mv_v1
+BACKUP NO
+DISTSTYLE ALL
+SORTKEY(event_timestamp, page_path)
+AUTO REFRESH YES AS
+SELECT
+    event_timestamp,
+    event_timestamp::date AS event_date,
+    COALESCE(NULLIF(user_id, ''), user_pseudo_id) AS analytics_user_id,
+    event_name,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'surface', true), '') AS surface,
+    COALESCE(
+        NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'page_path', true), ''),
+        NULLIF(page_view_page_url_path, '')
+    ) AS page_path,
+    CASE
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%email%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('email', 'e-mail', 'newsletter')
+            THEN 'email'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%paid%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN (
+              'affiliate', 'cpc', 'cpm', 'cpv', 'display', 'paid', 'paid_search', 'ppc'
+          )
+          OR NULLIF(traffic_source_clid, '') IS NOT NULL
+            THEN 'paid'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%social%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('social', 'social-media', 'social_media')
+            THEN 'social'
+        WHEN LOWER(COALESCE(traffic_source_channel_group, '')) LIKE '%organic%'
+          OR LOWER(COALESCE(traffic_source_medium, '')) IN ('organic', 'organic_search', 'seo')
+          OR LOWER(COALESCE(traffic_source_category, '')) = 'search'
+            THEN 'organic'
+        ELSE 'other'
+    END AS source_group,
+    session_id,
+    session_number,
+    page_view_entrances,
+    user_engagement_time_msec,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'placement', true), '') AS placement,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'element_id', true), '') AS element_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'element_type', true), '') AS element_type,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_host', true), '') AS destination_host,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'destination_path', true), '') AS destination_path,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'form_id', true), '') AS form_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'field_id', true), '') AS field_id,
+    NULLIF(JSON_EXTRACT_PATH_TEXT(custom_parameters_json_str, 'challenge_id', true), '') AS challenge_id
+FROM topcoder_web.event_v2
+WHERE event_name IN (
+    '_page_view',
+    '_user_engagement',
+    'ui_click',
+    'form_viewed',
+    'form_started',
+    'form_completed',
+    'form_abandoned',
+    'challenge_registered',
+    'challenge_submitted'
+);
+
 GRANT USAGE ON SCHEMA topcoder_web TO ROLE analytics_api_reader;
 GRANT SELECT ON topcoder_web.product_analytics_events_v1 TO ROLE analytics_api_reader;
 GRANT SELECT ON topcoder_web.challenge_funnel_daily_v1 TO ROLE analytics_api_reader;
 GRANT SELECT ON topcoder_web.route_analytics_events_v1 TO ROLE analytics_api_reader;
+GRANT SELECT ON topcoder_web.route_analytics_events_mv_v1 TO ROLE analytics_api_reader;

--- a/infrastructure/analytics-api/src/handler.py
+++ b/infrastructure/analytics-api/src/handler.py
@@ -3,7 +3,7 @@
 API Gateway verifies the current Topcoder Auth0 access token before invoking
 this Lambda. The handler independently requires the exact ``analytics`` role,
 validates every filter, and executes fixed parameterized queries against the
-Topcoder AWS Clickstream reporting views.
+Topcoder AWS Clickstream reporting relations.
 """
 
 from __future__ import annotations
@@ -379,7 +379,7 @@ ORDER BY row_type, date_value, metric_1 DESC
 ROUTE_SQL = """
 WITH date_events AS (
     SELECT *
-    FROM topcoder_web.route_analytics_events_v1
+    FROM topcoder_web.route_analytics_events_mv_v1
     WHERE event_timestamp >= CAST(:from_date AS timestamp)
       AND event_timestamp < DATEADD(day, 1, CAST(:to_date AS timestamp))
       AND event_name IN (
@@ -398,7 +398,6 @@ route_events AS (
     SELECT *
     FROM date_events
     WHERE page_path = :path
-      AND (:surface = '*' OR surface = :surface)
 ),
 route_page_views AS (
     SELECT *
@@ -661,6 +660,12 @@ SELECT
 FROM funnel_row
 ORDER BY row_type, metric_1 DESC, dimension_1
 """
+
+ROUTE_SURFACE_SQL = ROUTE_SQL.replace(
+    "    WHERE page_path = :path\n",
+    "    WHERE page_path = :path\n      AND surface = :surface\n",
+    1,
+)
 
 
 class QueryFailure(RuntimeError):
@@ -1004,6 +1009,11 @@ def _route_report(
 ) -> dict[str, Any]:
     """Load and shape detailed engagement analytics for one exact page path.
 
+    Requests without a surface use a fixed query that omits the surface
+    predicate and parameter; filtered requests use the exact-match variant.
+    This lets Redshift prune the replicated route projection without evaluating
+    a bound wildcard branch during each reused event scan.
+
     Args:
         filters: Validated date, surface, and query-free path filters.
         context: Lambda context used to respect the remaining deadline.
@@ -1017,7 +1027,14 @@ def _route_report(
         QueryFailure or QueryTimeout when Redshift cannot return data.
     """
 
-    rows = _execute_query(ROUTE_SQL, _sql_parameters(filters), context, query_token)
+    query_filters = dict(filters)
+    query_sql = ROUTE_SQL
+    if filters["surface"]:
+        query_sql = ROUTE_SURFACE_SQL
+    else:
+        query_filters.pop("surface")
+
+    rows = _execute_query(query_sql, _sql_parameters(query_filters), context, query_token)
     summary = next((row for row in rows if row.get("row_type") == "summary"), {})
     funnel_row = next((row for row in rows if row.get("row_type") == "funnel"), {})
     visitors = _integer(summary.get("metric_2"))

--- a/infrastructure/analytics-api/template.yaml
+++ b/infrastructure/analytics-api/template.yaml
@@ -162,6 +162,10 @@ Resources:
           Id: analytics-default-campaign
           Input: !Sub >-
             {"routeKey":"GET /v1/analytics/campaign","queryStringParameters":{"async":"true"},"requestContext":{"requestId":"scheduled-campaign-prewarm","authorizer":{"jwt":{"claims":{"${HumanRoleClaim}":["analytics"]}}}}}
+        - Arn: !GetAtt AnalyticsFunction.Arn
+          Id: analytics-default-opportunities-route
+          Input: !Sub >-
+            {"routeKey":"GET /v1/analytics/route","queryStringParameters":{"path":"/opportunities","async":"true"},"requestContext":{"requestId":"scheduled-route-prewarm","authorizer":{"jwt":{"claims":{"${HumanRoleClaim}":["analytics"]}}}}}
 
   AnalyticsPrewarmInvokePermission:
     Type: AWS::Lambda::Permission

--- a/infrastructure/analytics-api/tests/test_handler.py
+++ b/infrastructure/analytics-api/tests/test_handler.py
@@ -521,8 +521,48 @@ class AnalyticsHandlerTests(unittest.TestCase):
     def test_route_funnel_matches_the_exact_clicked_challenge(self) -> None:
         """Route registrations and submissions retain the clicked challenge ID."""
 
+        self.assertIn("topcoder_web.route_analytics_events_mv_v1", self.module.ROUTE_SQL)
+        self.assertNotIn(":surface", self.module.ROUTE_SQL)
+        self.assertIn("AND surface = :surface", self.module.ROUTE_SURFACE_SQL)
         self.assertIn("event.challenge_id = click.challenge_id", self.module.ROUTE_SQL)
         self.assertIn("event.challenge_id = registration.challenge_id", self.module.ROUTE_SQL)
+
+    def test_route_query_omits_unused_surface_wildcard(self) -> None:
+        """Unfiltered routes avoid a bound wildcard branch in each warehouse scan."""
+
+        with patch.object(self.module, "_execute_query", return_value=[]) as execute:
+            response = self.module.handler(
+                self._event(
+                    "GET /v1/analytics/route",
+                    ["analytics"],
+                    {"path": "/opportunities"},
+                ),
+                None,
+            )
+
+        self.assertEqual(200, response["statusCode"])
+        query_sql, parameters = execute.call_args.args[:2]
+        self.assertIs(self.module.ROUTE_SQL, query_sql)
+        self.assertNotIn("surface", {parameter["name"] for parameter in parameters})
+
+        self.module._cache.clear()
+        with patch.object(self.module, "_execute_query", return_value=[]) as execute:
+            response = self.module.handler(
+                self._event(
+                    "GET /v1/analytics/route",
+                    ["analytics"],
+                    {"path": "/opportunities", "surface": "platform_ui"},
+                ),
+                None,
+            )
+
+        self.assertEqual(200, response["statusCode"])
+        query_sql, parameters = execute.call_args.args[:2]
+        self.assertEqual(self.module.ROUTE_SURFACE_SQL, query_sql)
+        parameter_values = {
+            parameter["name"]: parameter["value"] for parameter in parameters
+        }
+        self.assertEqual("platform_ui", parameter_values["surface"])
 
     def test_shapes_general_report(self) -> None:
         """General rows retain page, source, and surface dimensions."""


### PR DESCRIPTION
## Summary
- query a narrow auto-refreshed Redshift materialized projection for route reports
- use replicated distribution and timestamp/path sorting for repeated session and funnel joins
- omit the bound wildcard surface predicate for unfiltered routes
- use a separate fixed exact-match query for surface-filtered routes
- prewarm the default /opportunities report each Data API token window
- document bootstrap and refresh behavior

## Validation
- analytics API unit tests: 22 passed
- Python compilation and diff checks: passed
- CloudFormation template validation: passed
- platform-ui lint: passed
- platform-ui production build: passed with existing warnings
- exact result equivalence: all 12 Redshift rows matched the previous query
- original warehouse request: approximately 76 seconds
- optimized parameterized query: approximately 1.9 seconds
- deployed unfiltered Lambda request: 200 in approximately 3.3 seconds
- deployed surface-filtered Lambda request: 200 in approximately 7.8 seconds