### PR TITLE
fix(PM-6295): embed DocuSign NDA signing

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -331,9 +331,12 @@ registers or agrees on a member's behalf. Terms API HTML retains its semantic
 structure and safe links, but document-authored inline styles are removed so
 modal-scoped Figtree headings, Nunito Sans body copy, and spacing remain
 authoritative.
-DocuSign-template terms expose the Terms API recipient flow and return to the
-challenge route after signing; registration remains blocked until the service
-reports that every external agreement is complete.
+DocuSign-template terms, plus NDA-titled terms that use the environment's
+legacy DocuSign template fallback, replace placeholder Terms API text with the
+embedded recipient view in both registration and passive review. The frame
+returns through community-app's iframe callback, and registration remains
+blocked while Opportunities polls authenticated outstanding terms until the
+service confirms the signature.
 
 Task challenges are assignment-only work. Their details preserve Requirements,
 Registrants, and Winners for visibility, but do not request or expose voluntary

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.module.scss
@@ -220,21 +220,31 @@
     }
 }
 
-.externalButton {
-    align-self: flex-start;
-    background: #007d79;
-    border: 0;
-    border-radius: 4px;
-    color: #fff;
-    cursor: pointer;
-    font: inherit;
-    font-weight: 700;
-    padding: 8px 24px;
+.docuSign {
+    min-height: min(532px, 60vh);
+    position: relative;
+    width: 100%;
+}
 
-    &:disabled {
-        cursor: wait;
-        opacity: .6;
-    }
+.docuSignFrame {
+    border: 0;
+    display: block;
+    height: min(532px, 60vh);
+    width: 100%;
+}
+
+.docuSignStatus {
+    align-items: center;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    inset: 0;
+    justify-content: center;
+    min-height: min(532px, 60vh);
+    position: absolute;
+    text-align: center;
+    z-index: 1;
 }
 
 @media (max-width: 700px) {

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -26,6 +26,7 @@ interface MockSWRResponse {
 let mockSWRResponse: MockSWRResponse
 const mockBaseModal = jest.fn()
 const mockAgreeToTerms = jest.fn()
+const mockGetDocuSignUrl = jest.fn()
 const mockGetSubmitterTermsDetails = jest.fn()
 const mockMutateTermsCache = jest.fn()
 const mockUseSWR = jest.fn()
@@ -42,9 +43,16 @@ jest.mock('swr', () => ({
 jest.mock('../services', () => ({
     agreeToChallengeTerms: (...args: unknown[]) => mockAgreeToTerms(...args),
     getChallengeSubmitterTermsDetails: (...args: unknown[]) => mockGetSubmitterTermsDetails(...args),
-    getChallengeTermDocuSignUrl: jest.fn(),
+    getChallengeTermDocuSignUrl: (...args: unknown[]) => mockGetDocuSignUrl(...args),
     getChallengeTermsDetails: jest.fn(),
 }))
+
+jest.mock('~/config', () => ({
+    EnvironmentConfig: {
+        COMMUNITY_APP_URL: 'https://www.topcoder-dev.com/',
+        NDA_DOCUSIGN_TEMPLATE_ID: 'configured-nda-template',
+    },
+}), { virtual: true })
 
 jest.mock('~/libs/cms', () => ({
     getSafeCmsLink: (value: string): string => value,
@@ -85,6 +93,8 @@ describe('ChallengeTermsModal', () => {
         mockBaseModal.mockClear()
         mockAgreeToTerms.mockReset()
         mockAgreeToTerms.mockResolvedValue(undefined)
+        mockGetDocuSignUrl.mockReset()
+        mockGetDocuSignUrl.mockResolvedValue('https://docusign.example/recipient')
         mockGetSubmitterTermsDetails.mockReset()
         mockMutateTermsCache.mockReset()
         mockMutateTermsCache.mockImplementation(async (_key, update) => (typeof update === 'function'
@@ -97,6 +107,11 @@ describe('ChallengeTermsModal', () => {
             isValidating: true,
             mutate: jest.fn(),
         }
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        jest.restoreAllMocks()
     })
 
     it('does not flash unresolved terms before showing the compact registration reminder', () => {
@@ -192,7 +207,8 @@ describe('ChallengeTermsModal', () => {
             .not.toBeInTheDocument()
     })
 
-    it('persists Standard Terms and NDA separately before completing registration', async () => {
+    it('embeds the configured DocuSign NDA after persisting Standard Terms', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
         const standardTerms: ChallengeTerm = {
             agreeabilityType: 'Electronically-agreeable',
             id: 'standard-terms',
@@ -202,11 +218,12 @@ describe('ChallengeTermsModal', () => {
         const nda: ChallengeTerm = {
             agreeabilityType: 'Electronically-agreeable',
             id: 'nda',
-            text: '<p>NDA body</p>',
+            text: 'Test',
             title: 'Topcoder Member Non-Disclosure Agreement v3.0',
         }
         const onComplete = jest.fn()
             .mockResolvedValue(undefined)
+        mockGetSubmitterTermsDetails.mockResolvedValueOnce([])
         mockSWRResponse = {
             ...mockSWRResponse,
             data: [standardTerms, nda],
@@ -229,7 +246,7 @@ describe('ChallengeTermsModal', () => {
             .toBeInTheDocument()
         expect(screen.getByText('Standard terms body'))
             .toBeInTheDocument()
-        expect(screen.queryByText('NDA body'))
+        expect(screen.queryByText('Test'))
             .not.toBeInTheDocument()
 
         fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
@@ -244,19 +261,91 @@ describe('ChallengeTermsModal', () => {
             .toBeInTheDocument()
         expect(screen.getByText('Agreement 2 of 2'))
             .toBeInTheDocument()
-        expect(screen.getByText('NDA body'))
-            .toBeInTheDocument()
+        await waitFor(() => expect(screen.queryByText('Loading DocuSign agreement…'))
+            .not.toBeInTheDocument())
+        const frame = screen.getByTitle('Topcoder Member Non-Disclosure Agreement v3.0')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        expect(frame)
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledWith(
+                'configured-nda-template',
+                'https://www.topcoder-dev.com/community-app-assets/iframe-break',
+            )
+        expect(screen.queryByText('Test'))
+            .not.toBeInTheDocument()
         expect(screen.queryByText('Standard terms body'))
             .not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'I agree' }))
+            .not.toBeInTheDocument()
 
-        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
 
         await waitFor(() => expect(onComplete)
             .toHaveBeenCalledTimes(1))
         expect(mockAgreeToTerms)
-            .toHaveBeenNthCalledWith(2, [nda])
-        expect(mockAgreeToTerms.mock.invocationCallOrder[1])
-            .toBeLessThan(onComplete.mock.invocationCallOrder[0])
+            .toHaveBeenCalledTimes(1)
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledWith([standardTerms, nda])
+        addEventListener.mockRestore()
+    })
+
+    it('keeps an earlier term outstanding when the server returns it after DocuSign completion', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const standardTerms: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'standard-terms',
+            text: '<p>Standard terms body</p>',
+            title: 'Standard Terms 2026',
+        }
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: 'Test',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const onComplete = jest.fn()
+        mockGetSubmitterTermsDetails.mockResolvedValueOnce([standardTerms])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [standardTerms, nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[standardTerms, nda]}
+            />,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
+        const frame = await screen.findByTitle('Topcoder Member Non-Disclosure Agreement v3.0')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+
+        await waitFor(() => expect(screen.getByRole('dialog', { name: 'Standard Terms 2026' }))
+            .toBeInTheDocument())
+        expect(mockMutateTermsCache)
+            .toHaveBeenLastCalledWith(expect.any(Array), [standardTerms], { revalidate: false })
+        expect(mockAgreeToTerms)
+            .toHaveBeenCalledTimes(1)
+        expect(onComplete)
+            .not.toHaveBeenCalled()
     })
 
     it('stays on the active term and does not register when agreement fails', async () => {
@@ -354,6 +443,8 @@ describe('ChallengeTermsModal', () => {
             )
         expect(screen.queryByRole('alert'))
             .not.toBeInTheDocument()
+        expect(await screen.findByTitle('NDA'))
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
         expect(onComplete)
             .not.toHaveBeenCalled()
     })
@@ -369,7 +460,7 @@ describe('ChallengeTermsModal', () => {
             agreeabilityType: 'Electronically-agreeable',
             id: 'nda',
             text: '<p>NDA body</p>',
-            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+            title: 'Additional Challenge Terms',
         }
         mockSWRResponse = {
             ...mockSWRResponse,
@@ -393,7 +484,7 @@ describe('ChallengeTermsModal', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
         await waitFor(() => expect(screen.getByRole('dialog', {
-            name: 'Topcoder Member Non-Disclosure Agreement v3.0',
+            name: 'Additional Challenge Terms',
         }))
             .toBeInTheDocument())
         let resolveAgreement: (() => void) | undefined
@@ -409,7 +500,7 @@ describe('ChallengeTermsModal', () => {
             .not.toHaveBeenCalled()
         view.rerender(<ChallengeTermsModal {...props} open />)
         expect(screen.getByRole('dialog', {
-            name: 'Topcoder Member Non-Disclosure Agreement v3.0',
+            name: 'Additional Challenge Terms',
         }))
             .toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Agreeing…' }))
@@ -440,7 +531,7 @@ describe('ChallengeTermsModal', () => {
             id: 'nda',
             roleId: 'viewer-role',
             text: '<p>Passive NDA body</p>',
-            title: 'NDA reference',
+            title: 'Passive terms reference',
         }
         const registrationKey = [
             'opportunities:challenge-terms',
@@ -527,7 +618,7 @@ describe('ChallengeTermsModal', () => {
                 agreeabilityType: 'Electronically-agreeable',
                 id: 'nda',
                 text: '<p>NDA body</p>',
-                title: 'NDA',
+                title: 'Additional Rules',
             },
             {
                 agreeabilityType: 'Electronically-agreeable',
@@ -553,7 +644,7 @@ describe('ChallengeTermsModal', () => {
             .closest('article')?.parentElement
 
         fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
-        await waitFor(() => expect(screen.getByRole('dialog', { name: 'NDA' }))
+        await waitFor(() => expect(screen.getByRole('dialog', { name: 'Additional Rules' }))
             .toBeInTheDocument())
         const secondScrollContainer = screen.getByText('NDA body')
             .closest('article')?.parentElement
@@ -562,7 +653,7 @@ describe('ChallengeTermsModal', () => {
         mockSWRResponse = { ...mockSWRResponse, data: terms.slice(1) }
         view.rerender(<ChallengeTermsModal {...props} />)
 
-        expect(screen.getByRole('dialog', { name: 'NDA' }))
+        expect(screen.getByRole('dialog', { name: 'Additional Rules' }))
             .toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: 'I agree' }))
         await waitFor(() => expect(screen.getByRole('dialog', { name: 'Challenge Rules' }))
@@ -613,7 +704,7 @@ describe('ChallengeTermsModal', () => {
             ])
     })
 
-    it('fails closed on the active external agreement', () => {
+    it('prefers an API DocuSign template and suppresses ordinary agreement controls', async () => {
         const externalNda: ChallengeTerm = {
             agreeabilityType: 'DocuSign-template',
             docusignTemplateId: 'nda-template',
@@ -638,16 +729,412 @@ describe('ChallengeTermsModal', () => {
             />,
         )
 
-        expect(screen.getByRole('button', { name: 'I agree' }))
-            .toBeDisabled()
-        expect(screen.getByRole('button', { name: 'Complete with DocuSign' }))
+        expect(await screen.findByTitle('Topcoder Member Non-Disclosure Agreement v3.0'))
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledWith(
+                'nda-template',
+                'https://www.topcoder-dev.com/community-app-assets/iframe-break',
+            )
+        expect(screen.queryByRole('button', { name: 'I agree' }))
+            .not.toBeInTheDocument()
+        expect(screen.queryByText('NDA body'))
+            .not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Close' }))
             .toBeInTheDocument()
-        expect(screen.getByRole('alert'))
-            .toHaveTextContent('Complete this external agreement before registering.')
         expect(mockAgreeToTerms)
             .not.toHaveBeenCalled()
         expect(onComplete)
             .not.toHaveBeenCalled()
+    })
+
+    it('reuses the active recipient view when SWR replaces a term with an equivalent object', async () => {
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'DocuSign-template',
+            docusignTemplateId: 'nda-template',
+            id: 'nda',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const props = {
+            mode: 'register' as const,
+            onClose: jest.fn(),
+            onComplete: jest.fn(),
+            open: true,
+            terms: [nda],
+        }
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        const view = render(<ChallengeTermsModal {...props} />)
+
+        expect(await screen.findByTitle(nda.title as string))
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [{ ...nda }],
+        }
+        view.rerender(<ChallengeTermsModal {...props} />)
+        await act(async () => Promise.resolve())
+
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledTimes(1)
+        expect(screen.getByTitle(nda.title as string))
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
+    })
+
+    it('does not render a previous single-use URL while advancing between DocuSign terms', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const firstNda: ChallengeTerm = {
+            agreeabilityType: 'DocuSign-template',
+            docusignTemplateId: 'first-template',
+            id: 'first-nda',
+            title: 'First NDA',
+        }
+        const secondNda: ChallengeTerm = {
+            agreeabilityType: 'DocuSign-template',
+            docusignTemplateId: 'second-template',
+            id: 'second-nda',
+            title: 'Second NDA',
+        }
+        mockGetDocuSignUrl
+            .mockResolvedValueOnce('https://docusign.example/first-recipient')
+            .mockImplementationOnce(() => new Promise(() => {
+                // Keep the successor request pending to inspect its loading state.
+            }))
+        mockGetSubmitterTermsDetails.mockResolvedValueOnce([secondNda])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [firstNda, secondNda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={jest.fn()}
+                open
+                terms={[firstNda, secondNda]}
+            />,
+        )
+
+        const frame = await screen.findByTitle('First NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+
+        await waitFor(() => expect(screen.getByRole('dialog', { name: 'Second NDA' }))
+            .toBeInTheDocument())
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledTimes(2)
+        expect(document.querySelector('iframe[src="https://docusign.example/first-recipient"]'))
+            .toBeNull()
+        expect(screen.queryByTitle('Second NDA'))
+            .not.toBeInTheDocument()
+        expect(screen.getByText('Loading DocuSign agreement…'))
+            .toBeInTheDocument()
+    })
+
+    it('embeds the configured NDA in passive review without registering after completion', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            agreeabilityType: 'Electronically-agreeable',
+            id: 'nda',
+            text: 'Test',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }
+        const onClose = jest.fn()
+        const onComplete = jest.fn()
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='view'
+                onClose={onClose}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+
+        const frame = await screen.findByTitle('Topcoder Member Non-Disclosure Agreement v3.0')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        expect(screen.queryByText('Test'))
+            .not.toBeInTheDocument()
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'viewing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+
+        await waitFor(() => expect(onClose)
+            .toHaveBeenCalledTimes(1))
+        expect(mockSWRResponse.mutate)
+            .toHaveBeenCalledTimes(1)
+        expect(mockGetSubmitterTermsDetails)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('ignores untrusted DocuSign callback messages and closes on trusted cancellation', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onClose = jest.fn()
+        const onComplete = jest.fn()
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={onClose}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://attacker.example',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        expect(mockGetSubmitterTermsDetails)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'cancel', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        expect(onClose)
+            .toHaveBeenCalledTimes(1)
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('polls outstanding terms before completing DocuSign registration', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onComplete = jest.fn()
+            .mockResolvedValue(undefined)
+        mockGetSubmitterTermsDetails
+            .mockResolvedValueOnce([nda])
+            .mockResolvedValueOnce([])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        const view = render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        await act(async () => Promise.resolve())
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(1)
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+
+        await act(async () => {
+            jest.advanceTimersByTime(5000)
+            await Promise.resolve()
+        })
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(2)
+        expect(onComplete)
+            .toHaveBeenCalledTimes(1)
+        expect(mockAgreeToTerms)
+            .not.toHaveBeenCalled()
+
+        jest.useRealTimers()
+        view.unmount()
+    })
+
+    it('keeps registration blocked when DocuSign persistence cannot be confirmed', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onComplete = jest.fn()
+        mockGetSubmitterTermsDetails.mockResolvedValue([nda])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+
+        await act(async () => Promise.resolve())
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(1)
+
+        for (let attempt = 1; attempt < 5; attempt += 1) {
+            // Each status check schedules only the next retry.
+            // eslint-disable-next-line no-await-in-loop
+            await act(async () => {
+                jest.advanceTimersByTime(5000)
+                await Promise.resolve()
+            })
+        }
+
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(5)
+        expect(screen.getByRole('alert'))
+            .toHaveTextContent('couldn’t confirm your DocuSign agreement yet')
+        expect(screen.getByRole('button', { name: 'Check again' }))
+            .toBeInTheDocument()
+        expect(mockAgreeToTerms)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('cancels DocuSign confirmation polling when the modal unmounts', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onComplete = jest.fn()
+        mockGetSubmitterTermsDetails
+            .mockResolvedValueOnce([nda])
+            .mockResolvedValueOnce([])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        const view = render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        await act(async () => {
+            await Promise.resolve()
+            await Promise.resolve()
+        })
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(1)
+
+        view.unmount()
+        await act(async () => {
+            jest.advanceTimersByTime(30000)
+            await Promise.resolve()
+        })
+
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(1)
+        expect(mockMutateTermsCache)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('shows a retry when the Terms service cannot create the DocuSign view', async () => {
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            text: 'Test',
+            title: 'NDA',
+        }
+        mockGetDocuSignUrl.mockRejectedValueOnce(new Error('Terms service unavailable'))
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={jest.fn()}
+                open
+                terms={[nda]}
+            />,
+        )
+
+        expect(await screen.findByRole('alert'))
+            .toHaveTextContent('Terms service unavailable')
+        expect(screen.queryByText('Test'))
+            .not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+        expect(await screen.findByTitle('NDA'))
+            .toHaveAttribute('src', 'https://docusign.example/recipient')
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledTimes(2)
     })
 
     it('still opens a retryable dialog when accepted-term hydration fails', () => {

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -13,6 +13,7 @@ import useSWR, {
     useSWRConfig,
 } from 'swr'
 
+import { EnvironmentConfig } from '~/config'
 import { getSafeCmsLink } from '~/libs/cms'
 import {
     BaseModal,
@@ -33,6 +34,10 @@ import styles from './ChallengeTermsModal.module.scss'
 
 export type ChallengeTermsMode = 'register' | 'view'
 
+const DOCUSIGN_POLL_DELAY_MS = 5000
+const DOCUSIGN_POLL_MAX_ATTEMPTS = 5
+const NDA_TITLE_PATTERN = /\bnda\b|non[-\s]?disclosure/i
+
 interface ChallengeTermsModalProps {
     busy?: boolean
     memberId?: number | string
@@ -41,6 +46,58 @@ interface ChallengeTermsModalProps {
     onComplete: () => Promise<void> | void
     open: boolean
     terms: ChallengeTerm[]
+}
+
+/**
+ * Resolves the DocuSign template backing a challenge term.
+ *
+ * Terms API metadata takes precedence. The configured template is a legacy
+ * compatibility fallback for NDA records whose current API detail contains
+ * placeholder electronic-agreement content but no template identifier.
+ *
+ * @param term complete Terms API record.
+ * @param configuredTemplateId environment-specific default NDA template.
+ * @returns the API template, configured NDA fallback, or undefined.
+ * @throws Does not throw.
+ */
+export function resolveChallengeTermDocuSignTemplateId(
+    term: ChallengeTerm,
+    configuredTemplateId: string | undefined = EnvironmentConfig.NDA_DOCUSIGN_TEMPLATE_ID,
+): string | number | undefined {
+    const apiTemplateId = typeof term.docusignTemplateId === 'string'
+        ? term.docusignTemplateId.trim()
+        : term.docusignTemplateId
+    if (apiTemplateId) return apiTemplateId
+
+    const fallbackTemplateId = configuredTemplateId?.trim()
+    return fallbackTemplateId && NDA_TITLE_PATTERN.test(term.title ?? '')
+        ? fallbackTemplateId
+        : undefined
+}
+
+/**
+ * Builds the legacy iframe callback URL used by the Terms service.
+ *
+ * @returns the community-app endpoint that posts the DocuSign event to its parent frame.
+ * @throws Does not throw.
+ */
+function buildDocuSignReturnUrl(): string {
+    const communityAppUrl = EnvironmentConfig.COMMUNITY_APP_URL?.replace(/\/$/, '')
+        || window.location.origin
+    return `${communityAppUrl}/community-app-assets/iframe-break`
+}
+
+/**
+ * Delays a DocuSign agreement-status retry without blocking the browser.
+ *
+ * @param durationMs delay in milliseconds.
+ * @returns promise resolved after the requested delay.
+ * @throws Does not throw.
+ */
+function delay(durationMs: number): Promise<void> {
+    return new Promise(resolve => {
+        window.setTimeout(resolve, durationMs)
+    })
 }
 
 /**
@@ -53,7 +110,7 @@ interface ChallengeTermsModalProps {
  */
 export function requiresExternalAgreement(term: ChallengeTerm): boolean {
     return !term.agreed
-        && (!!term.docusignTemplateId
+        && (!!resolveChallengeTermDocuSignTemplateId(term)
             || (!!term.agreeabilityType
                 && term.agreeabilityType.toLowerCase() !== 'electronically-agreeable'))
 }
@@ -73,10 +130,18 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const [completedTermIds, setCompletedTermIds] = useState<string[]>([])
     const [agreementBusy, setAgreementBusy] = useState(false)
     const [agreementError, setAgreementError] = useState('')
-    const [externalBusy, setExternalBusy] = useState(false)
+    const [docuSignCompleting, setDocuSignCompleting] = useState(false)
+    const [docuSignLoading, setDocuSignLoading] = useState(false)
+    const [docuSignRetry, setDocuSignRetry] = useState(0)
+    const [docuSignView, setDocuSignView] = useState<{ key: string; url: string }>()
     const [externalError, setExternalError] = useState('')
     const agreementRequestRef = useRef(0)
     const activeAgreementRequestRef = useRef<number>()
+    const closeRef = useRef<() => void>(() => undefined)
+    const docuSignCallbackHandledRef = useRef(false)
+    const docuSignCompletionRef = useRef<() => Promise<void>>(async () => undefined)
+    const docuSignFrameRef = useRef<HTMLIFrameElement>(null)
+    const docuSignUrlRequestRef = useRef(0)
     const interactionRef = useRef(0)
     const { mutate: mutateTermsCache }: FullConfiguration = useSWRConfig()
     const memberScope = props.memberId === undefined ? 'anonymous' : String(props.memberId)
@@ -120,6 +185,25 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const activePosition = completedTermIds.length
     const agreementTotal = completedTermIds.length + pendingTerms.length
     const activeExternalAgreement = !!activeTerm && requiresExternalAgreement(activeTerm)
+    const docuSignTerm = registrationMode
+        ? activeTerm && resolveChallengeTermDocuSignTemplateId(activeTerm) ? activeTerm : undefined
+        : displayedTerms.find(term => !!resolveChallengeTermDocuSignTemplateId(term))
+    const docuSignTemplateId = docuSignTerm
+        ? resolveChallengeTermDocuSignTemplateId(docuSignTerm)
+        : undefined
+    const docuSignRequestKey = docuSignTerm && docuSignTemplateId
+        ? JSON.stringify([
+            props.mode,
+            memberScope,
+            termKey,
+            docuSignTerm.id ?? docuSignTerm.url ?? docuSignTerm.title ?? 'term',
+            docuSignTemplateId,
+        ])
+        : undefined
+    const docuSignUrl = docuSignView?.key === docuSignRequestKey
+        ? docuSignView?.url
+        : undefined
+    const docuSignBusy = docuSignLoading || docuSignCompleting
     const compactRegistration = registrationMode
         && !response.error
         && !response.isValidating
@@ -136,10 +220,55 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
             setAccepted(false)
             setCompletedTermIds([])
             setAgreementError('')
-            setExternalBusy(false)
+            setDocuSignCompleting(false)
+            setDocuSignLoading(false)
+            setDocuSignRetry(0)
+            setDocuSignView(undefined)
             setExternalError('')
+            docuSignCallbackHandledRef.current = false
+        }
+
+        return () => {
+            // Cancel delayed agreement polling and late URL requests on scope
+            // changes or unmount so they cannot complete an obsolete registration.
+            interactionRef.current += 1
         }
     }, [props.open, props.mode, memberScope, termKey])
+
+    useEffect(() => {
+        const request = docuSignUrlRequestRef.current + 1
+        docuSignUrlRequestRef.current = request
+        docuSignCallbackHandledRef.current = false
+        setDocuSignView(undefined)
+        setDocuSignLoading(false)
+        setExternalError('')
+        if (!props.open || !docuSignRequestKey || !docuSignTemplateId) return
+
+        const interaction = interactionRef.current
+        setDocuSignLoading(true)
+        getChallengeTermDocuSignUrl(docuSignTemplateId, buildDocuSignReturnUrl())
+            .then(url => {
+                if (interaction !== interactionRef.current
+                    || request !== docuSignUrlRequestRef.current) return
+                setDocuSignView({ key: docuSignRequestKey, url })
+            })
+            .catch(error => {
+                if (interaction !== interactionRef.current
+                    || request !== docuSignUrlRequestRef.current) return
+                setExternalError(error instanceof Error && error.message.trim()
+                    ? error.message
+                    : 'We couldn\u2019t load the DocuSign agreement. Please try again.')
+            })
+            .finally(() => {
+                if (interaction === interactionRef.current
+                    && request === docuSignUrlRequestRef.current) setDocuSignLoading(false)
+            })
+    }, [
+        docuSignRetry,
+        docuSignRequestKey,
+        docuSignTemplateId,
+        props.open,
+    ])
 
     /**
      * Sanitizes Terms API HTML while removing document-authored inline CSS.
@@ -246,30 +375,149 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         props.onClose()
     }
 
-    /** Opens the Terms API's authenticated DocuSign recipient flow. */
-    const startDocuSign = async (term: ChallengeTerm): Promise<void> => {
-        if (!term.docusignTemplateId || externalBusy) return
+    /**
+     * Polls authenticated outstanding terms until the signed DocuSign term is
+     * absent, accounting for the Terms service's asynchronous persistence.
+     *
+     * @param termId canonical term identifier signed in the recipient frame.
+     * @param interaction modal interaction that owns the callback.
+     * @returns remaining terms, or undefined when the interaction became stale or confirmation timed out.
+     * @throws Propagates Terms API failures.
+     */
+    const pollForDocuSignAgreement = async (
+        termId: string,
+        interaction: number,
+    ): Promise<ChallengeTerm[] | undefined> => {
+        for (let attempt = 1; attempt <= DOCUSIGN_POLL_MAX_ATTEMPTS; attempt += 1) {
+            // Sequential polling is required because Terms service persistence is asynchronous.
+            // eslint-disable-next-line no-await-in-loop
+            const refreshedTerms = await getChallengeSubmitterTermsDetails(props.terms)
+            if (interaction !== interactionRef.current) return undefined
+            if (!refreshedTerms.some(term => term.id === termId)) return refreshedTerms
+            if (attempt < DOCUSIGN_POLL_MAX_ATTEMPTS) {
+                // eslint-disable-next-line no-await-in-loop
+                await delay(DOCUSIGN_POLL_DELAY_MS)
+                if (interaction !== interactionRef.current) return undefined
+            }
+        }
+
+        return undefined
+    }
+
+    /**
+     * Reconciles a trusted DocuSign callback before advancing terms or
+     * registering. Passive review refreshes details but never registers.
+     *
+     * @returns promise settled after refresh, advancement, or a visible confirmation error.
+     * @throws Does not throw; errors remain visible inside the active modal.
+     */
+    const completeDocuSignAgreement = async (): Promise<void> => {
+        if (!docuSignTerm || docuSignCompleting) return
         const interaction = interactionRef.current
-        setExternalBusy(true)
+        const termId = docuSignTerm.id
+        setDocuSignCompleting(true)
         setExternalError('')
         try {
-            const url = await getChallengeTermDocuSignUrl(term.docusignTemplateId, window.location.href)
+            if (!registrationMode) {
+                await response.mutate()
+                if (interaction === interactionRef.current) close()
+                return
+            }
+
+            if (!termId || !termsCacheKey) {
+                throw new Error('We couldn\u2019t verify this DocuSign agreement because it is missing an identifier.')
+            }
+
+            const refreshedTerms = await pollForDocuSignAgreement(termId, interaction)
             if (interaction !== interactionRef.current) return
-            window.location.assign(url)
+            if (!refreshedTerms) {
+                throw new Error('We couldn\u2019t confirm your DocuSign agreement yet. Please try again.')
+            }
+
+            const outstandingTermIds = new Set(refreshedTerms
+                .map(term => term.id)
+                .filter((id): id is string => !!id))
+            const confirmedCompletedIds = Array.from(new Set([...completedTermIds, termId]))
+                .filter(id => !outstandingTermIds.has(id))
+            await mutateTermsCache(termsCacheKey, refreshedTerms, { revalidate: false })
+            if (interaction !== interactionRef.current) return
+            if (refreshedTerms.length === 0) {
+                await props.onComplete()
+            } else {
+                // A term returned by the server is still outstanding, even if
+                // this modal previously recorded it as completed locally.
+                setCompletedTermIds(confirmedCompletedIds)
+            }
         } catch (error) {
             if (interaction !== interactionRef.current) return
-            setExternalError(error instanceof Error
+            setExternalError(error instanceof Error && error.message.trim()
                 ? error.message
-                : 'The external agreement could not be opened.')
+                : 'We couldn\u2019t confirm your DocuSign agreement. Please try again.')
         } finally {
-            if (interaction === interactionRef.current) setExternalBusy(false)
+            if (interaction === interactionRef.current) setDocuSignCompleting(false)
         }
     }
 
-    const buttons = registrationMode ? (
+    /**
+     * Retries either recipient-view creation or post-signature confirmation,
+     * depending on which stage produced the visible DocuSign error.
+     *
+     * @returns void after scheduling the relevant retry.
+     * @throws Does not throw.
+     */
+    const retryDocuSign = (): void => {
+        if (docuSignUrl) completeDocuSignAgreement()
+        else setDocuSignRetry(current => current + 1)
+    }
+
+    closeRef.current = close
+    docuSignCompletionRef.current = completeDocuSignAgreement
+
+    useEffect(() => {
+        // Subscribe before the recipient iframe is rendered so a fast callback
+        // cannot arrive between the iframe commit and this passive effect.
+        if (!props.open || !docuSignRequestKey) return undefined
+        let trustedOrigin: string
+        try {
+            trustedOrigin = new URL(buildDocuSignReturnUrl()).origin
+        } catch {
+            return undefined
+        }
+
+        /** Handles only messages sent by the active, same-origin callback frame. */
+        const handleDocuSignMessage = (event: MessageEvent): void => {
+            const frameWindow = docuSignFrameRef.current?.contentWindow
+            if (!frameWindow || event.source !== frameWindow || event.origin !== trustedOrigin) return
+            if (!event.data || event.data.type !== 'DocuSign') return
+
+            if (event.data.event === 'signing_complete' || event.data.event === 'viewing_complete') {
+                if (docuSignCallbackHandledRef.current) return
+                docuSignCallbackHandledRef.current = true
+                docuSignCompletionRef.current()
+            } else {
+                closeRef.current()
+            }
+        }
+
+        window.addEventListener('message', handleDocuSignMessage)
+        return () => window.removeEventListener('message', handleDocuSignMessage)
+    }, [docuSignRequestKey, props.open])
+
+    const buttons = registrationMode && activeExternalAgreement ? (
+        <Button
+            className={styles.modalAction}
+            customRadius
+            disabled={props.busy || docuSignCompleting}
+            label='Close'
+            noCaps
+            onClick={close}
+            primary
+            size='lg'
+        />
+    ) : registrationMode ? (
         <>
             <Button
-                disabled={props.busy || agreementBusy || externalBusy}
+                disabled={props.busy || agreementBusy}
                 className={styles.modalAction}
                 customRadius
                 label={compactRegistration ? 'Cancel' : 'I disagree'}
@@ -282,7 +530,6 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                 disabled={(compactRegistration && !accepted)
                     || props.busy
                     || agreementBusy
-                    || externalBusy
                     || response.isValidating
                     || !!response.error
                     || (!compactRegistration && (!activeTerm || activeExternalAgreement))}
@@ -374,39 +621,56 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                         className={styles.terms}
                         key={registrationMode ? activeTerm?.id : 'view'}
                     >
-                        {displayedTerms.map((term: ChallengeTerm, index: number) => (
-                            <article
-                                className={styles.term}
-                                key={term.id ?? term.url ?? term.title ?? `term-${index}`}
-                            >
-                                {!registrationMode && (terms.length > 1 || index > 0) && (
-                                    <h3>{term.title || `Challenge term ${index + 1}`}</h3>
-                                )}
-                                {term.text && (
-                                    <div dangerouslySetInnerHTML={{ __html: sanitizedText(term.text) }} />
-                                )}
-                                {getSafeCmsLink(term.url) && (
-                                    <a href={getSafeCmsLink(term.url)} rel='noreferrer' target='_blank'>
-                                        Open this term in a new window
-                                        <IconOutline.ExternalLinkIcon aria-hidden='true' />
-                                    </a>
-                                )}
-                                {registrationMode && requiresExternalAgreement(term) && term.docusignTemplateId && (
-                                    <button
-                                        className={styles.externalButton}
-                                        disabled={externalBusy}
-                                        onClick={() => startDocuSign(term)}
-                                        type='button'
-                                    >
-                                        {externalBusy ? 'Opening DocuSign…' : 'Complete with DocuSign'}
-                                    </button>
-                                )}
-                                {term.agreed && <small>You have already accepted this term.</small>}
-                            </article>
-                        ))}
+                        {displayedTerms.map((term: ChallengeTerm, index: number) => {
+                            const displayedDocuSignTerm = term === docuSignTerm && !!docuSignTemplateId
+                            return (
+                                <article
+                                    className={styles.term}
+                                    key={term.id ?? term.url ?? term.title ?? `term-${index}`}
+                                >
+                                    {!registrationMode && (terms.length > 1 || index > 0) && (
+                                        <h3>{term.title || `Challenge term ${index + 1}`}</h3>
+                                    )}
+                                    {displayedDocuSignTerm ? (
+                                        <div className={styles.docuSign}>
+                                            {docuSignBusy && (
+                                                <div className={styles.docuSignStatus} role='status'>
+                                                    <LoadingSpinner />
+                                                    <span>
+                                                        {docuSignCompleting
+                                                            ? 'Confirming your signature…'
+                                                            : 'Loading DocuSign agreement…'}
+                                                    </span>
+                                                </div>
+                                            )}
+                                            {docuSignUrl && (
+                                                <iframe
+                                                    className={styles.docuSignFrame}
+                                                    ref={docuSignFrameRef}
+                                                    src={docuSignUrl}
+                                                    title={term.title || 'DocuSign agreement'}
+                                                />
+                                            )}
+                                        </div>
+                                    ) : term.text ? (
+                                        <div dangerouslySetInnerHTML={{ __html: sanitizedText(term.text) }} />
+                                    ) : undefined}
+                                    {!displayedDocuSignTerm && getSafeCmsLink(term.url) && (
+                                        <a href={getSafeCmsLink(term.url)} rel='noreferrer' target='_blank'>
+                                            Open this term in a new window
+                                            <IconOutline.ExternalLinkIcon aria-hidden='true' />
+                                        </a>
+                                    )}
+                                    {term.agreed && <small>You have already accepted this term.</small>}
+                                </article>
+                            )
+                        })}
                     </div>
                 )}
-                {!compactRegistration && registrationMode && activeExternalAgreement && (
+                {!compactRegistration
+                    && registrationMode
+                    && activeExternalAgreement
+                    && !docuSignTemplateId && (
                     <div className={styles.error} role='alert'>
                         Complete this external agreement before registering.
                     </div>
@@ -415,7 +679,12 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                     <div className={styles.error} role='alert'>{agreementError}</div>
                 )}
                 {!compactRegistration && externalError && (
-                    <div className={styles.error} role='alert'>{externalError}</div>
+                    <div className={styles.error} role='alert'>
+                        <span>{externalError}</span>
+                        <button disabled={docuSignBusy} onClick={retryDocuSign} type='button'>
+                            {docuSignUrl ? 'Check again' : 'Try again'}
+                        </button>
+                    </div>
                 )}
                 {compactRegistration && (
                     <label>

--- a/src/apps/opportunities/src/components/opportunity.utils.spec.ts
+++ b/src/apps/opportunities/src/components/opportunity.utils.spec.ts
@@ -6,7 +6,10 @@ import {
     markdownHeadingText,
 } from './ChallengeMarkdown'
 import { paginationWindow } from './OpportunityPagination'
-import { requiresExternalAgreement } from './ChallengeTermsModal'
+import {
+    requiresExternalAgreement,
+    resolveChallengeTermDocuSignTemplateId,
+} from './ChallengeTermsModal'
 import {
     engagementSkillNames,
     formatAnticipatedStart,
@@ -17,15 +20,26 @@ import { buildLegacyOpportunityRedirect } from '../pages/LegacyOpportunityRedire
 import { parseSkillsFilter } from '../utils/opportunity-filter.utils'
 
 jest.mock('react-markdown', () => () => undefined)
+jest.mock('rehype-raw', () => jest.fn())
+jest.mock('rehype-sanitize', () => ({ default: jest.fn(), defaultSchema: {} }))
 jest.mock('remark-breaks', () => jest.fn())
 jest.mock('remark-gfm', () => jest.fn())
+jest.mock('~/apps/copilots', () => ({ absoluteRootRoute: '/copilots' }), { virtual: true })
 jest.mock('~/config', () => ({
-    EnvironmentConfig: { ENGAGEMENTS_URL: 'https://engagements.example' },
+    EnvironmentConfig: {
+        COMMUNITY_APP_URL: 'https://community.example',
+        ENGAGEMENTS_URL: 'https://engagements.example',
+        NDA_DOCUSIGN_TEMPLATE_ID: 'configured-nda-template',
+    },
 }), { virtual: true })
 jest.mock('~/libs/cms', () => ({ getSafeCmsLink: jest.fn(value => value) }), { virtual: true })
 jest.mock('~/libs/ui', () => ({ IconOutline: {} }), { virtual: true })
 jest.mock('dompurify', () => ({ sanitize: jest.fn(value => value) }))
-jest.mock('../services', () => ({ getChallengeSubmitterTermsDetails: jest.fn() }))
+jest.mock('../services', () => ({
+    getChallengeSubmitterTermsDetails: jest.fn(),
+    getChallengeTermDocuSignUrl: jest.fn(),
+    getChallengeTermsDetails: jest.fn(),
+}))
 
 describe('opportunity presentation utilities', () => {
     it('creates stable Markdown table-of-contents fragments including duplicate headings', () => {
@@ -134,6 +148,24 @@ describe('opportunity presentation utilities', () => {
             .toBe('/opportunities/challenge/challenge-id?tab=submissions#requirements')
     })
 
+    it('prefers Terms API DocuSign templates and falls back for NDA titles', () => {
+        expect(resolveChallengeTermDocuSignTemplateId({
+            docusignTemplateId: 'api-template',
+            title: 'Topcoder NDA',
+        }, 'configured-template'))
+            .toBe('api-template')
+        expect(resolveChallengeTermDocuSignTemplateId({
+            agreeabilityType: 'Electronically-agreeable',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }, 'configured-template'))
+            .toBe('configured-template')
+        expect(resolveChallengeTermDocuSignTemplateId({
+            agreeabilityType: 'Electronically-agreeable',
+            title: 'Standard Terms 2026',
+        }, 'configured-template'))
+            .toBeUndefined()
+    })
+
     it('blocks challenge registration for outstanding external agreements only', () => {
         expect(requiresExternalAgreement({
             agreeabilityType: 'DocuSign-template',
@@ -154,9 +186,23 @@ describe('opportunity presentation utilities', () => {
         }))
             .toBe(false)
         expect(requiresExternalAgreement({
+            agreeabilityType: 'Electronically-agreeable',
+            agreed: false,
+            id: 'nda',
+            title: 'Topcoder Member Non-Disclosure Agreement v3.0',
+        }))
+            .toBe(true)
+        expect(requiresExternalAgreement({
             agreeabilityType: 'DocuSign-template',
             agreed: true,
             id: 'accepted-nda',
+        }))
+            .toBe(false)
+        expect(requiresExternalAgreement({
+            agreeabilityType: 'Electronically-agreeable',
+            agreed: true,
+            id: 'accepted-title-nda',
+            title: 'NDA',
         }))
             .toBe(false)
     })

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -1933,4 +1933,17 @@ describe('opportunities service normalization', () => {
                 templateId: 'template',
             })
     })
+
+    it.each([
+        // eslint-disable-next-line no-script-url
+        'javascript:alert(document.domain)',
+        'data:text/html,<script>parent.postMessage({type:"DocuSign"},"*")</script>',
+        '/relative-recipient-view',
+    ])('rejects an unsafe Terms API DocuSign URL: %s', async recipientViewUrl => {
+        const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
+        post.mockResolvedValueOnce({ recipientViewUrl })
+
+        await expect(getChallengeTermDocuSignUrl('template', 'https://topcoder-dev.com/opportunities'))
+            .rejects.toThrow('Terms API returned an invalid DocuSign URL.')
+    })
 })

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -2223,7 +2223,7 @@ export async function getChallengeSubmitterTermsDetails(
  * @param templateId Terms API DocuSign template identifier.
  * @param returnUrl challenge route restored after signing.
  * @returns recipient URL supplied by Terms API.
- * @throws Error when Terms API omits the URL; otherwise propagates API errors.
+ * @throws Error when Terms API omits a valid absolute HTTPS URL; otherwise propagates API errors.
  */
 export async function getChallengeTermDocuSignUrl(
     templateId: string | number,
@@ -2237,5 +2237,17 @@ export async function getChallengeTermDocuSignUrl(
         templateId,
     })
     if (!response.recipientViewUrl) throw new Error('Terms API did not return a DocuSign URL.')
+
+    let recipientViewUrl: URL
+    try {
+        recipientViewUrl = new URL(response.recipientViewUrl)
+    } catch {
+        throw new Error('Terms API returned an invalid DocuSign URL.')
+    }
+
+    if (recipientViewUrl.protocol !== 'https:') {
+        throw new Error('Terms API returned an invalid DocuSign URL.')
+    }
+
     return response.recipientViewUrl
 }


### PR DESCRIPTION
## Summary

- replace the placeholder NDA text with the embedded DocuSign recipient view used by legacy community-app
- prefer Terms API template metadata and fall back to the environment NDA template for legacy NDA and non-disclosure titles
- use the community-app iframe callback, validate both callback origin and frame source, and accept the legacy completion events
- poll authenticated outstanding Submitter terms before advancing or registering, treating the server response as authoritative
- key one-time recipient URLs to the active term, cancel stale polling on unmount, and require an absolute HTTPS iframe URL
- add loading, error, retry, passive-review, sequencing, race, and security regression coverage

## Validation

- focused Opportunities suites: 4 suites, 94 tests passing
- full `yarn lint`: pass
- production build with 8 GB heap: pass with existing repository warnings
- `git diff --check`: pass

## Companion backend work

- https://github.com/topcoder-platform/terms-service/pull/112 fixes the development 503 by moving BUS publication after the recipient URL and deploying against the v6 BUS configuration
- end-to-end callback persistence still requires the development data xref `400b989d-1c75-4889-b6f6-421e1f924709 -> e5811a7b-43d1-407a-a064-69e5015b4900` and the DocuSign agreeability type to be verified or configured

Ticket: https://topcoder.atlassian.net/browse/PM-6295