### PR TITLE
fix(PM-6295): harden DocuSign confirmation

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -336,7 +336,10 @@ legacy DocuSign template fallback, replace placeholder Terms API text with the
 embedded recipient view in both registration and passive review. The frame
 returns through community-app's iframe callback, and registration remains
 blocked while Opportunities polls authenticated outstanding terms until the
-service confirms the signature.
+service confirms the signature. Confirmation reads bypass HTTP caches and use
+a bounded 91-second backoff window, including retries for transient Terms API
+failures; an unconfirmed signature remains blocked and can be checked again
+without creating another DocuSign recipient view.
 
 Task challenges are assignment-only work. Their details preserve Requirements,
 Registrants, and Winners for visibility, but do not request or expose voluntary

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -291,7 +291,7 @@ describe('ChallengeTermsModal', () => {
         expect(mockAgreeToTerms)
             .toHaveBeenCalledTimes(1)
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenCalledWith([standardTerms, nda])
+            .toHaveBeenCalledWith([standardTerms, nda], { fresh: true })
         addEventListener.mockRestore()
     })
 
@@ -936,7 +936,7 @@ describe('ChallengeTermsModal', () => {
             .not.toHaveBeenCalled()
     })
 
-    it('polls outstanding terms before completing DocuSign registration', async () => {
+    it('keeps polling past 20 seconds before completing DocuSign registration', async () => {
         const addEventListener = jest.spyOn(window, 'addEventListener')
         const nda: ChallengeTerm = {
             id: 'nda',
@@ -945,6 +945,10 @@ describe('ChallengeTermsModal', () => {
         const onComplete = jest.fn()
             .mockResolvedValue(undefined)
         mockGetSubmitterTermsDetails
+            .mockResolvedValueOnce([nda])
+            .mockResolvedValueOnce([nda])
+            .mockResolvedValueOnce([nda])
+            .mockResolvedValueOnce([nda])
             .mockResolvedValueOnce([nda])
             .mockResolvedValueOnce([])
         mockSWRResponse = {
@@ -977,12 +981,21 @@ describe('ChallengeTermsModal', () => {
         expect(onComplete)
             .not.toHaveBeenCalled()
 
-        await act(async () => {
-            jest.advanceTimersByTime(5000)
-            await Promise.resolve()
-        })
+        const retryDelays = [2000, 3000, 5000, 8000, 13000]
+
+        for (let retry = 0; retry < retryDelays.length; retry += 1) {
+            // Each completed read schedules the next backoff interval.
+            // eslint-disable-next-line no-await-in-loop
+            await act(async () => {
+                jest.advanceTimersByTime(retryDelays[retry])
+                await Promise.resolve()
+            })
+        }
+
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenCalledTimes(2)
+            .toHaveBeenCalledTimes(6)
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenLastCalledWith([nda], { fresh: true })
         expect(onComplete)
             .toHaveBeenCalledTimes(1)
         expect(mockAgreeToTerms)
@@ -990,6 +1003,62 @@ describe('ChallengeTermsModal', () => {
 
         jest.useRealTimers()
         view.unmount()
+    })
+
+    it('retries a transient Terms status failure before completing DocuSign registration', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onComplete = jest.fn()
+            .mockResolvedValue(undefined)
+        mockGetSubmitterTermsDetails
+            .mockRejectedValueOnce(Object.assign(new Error('Terms service unavailable'), { status: 503 }))
+            .mockResolvedValueOnce([])
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        await act(async () => Promise.resolve())
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+
+        await act(async () => {
+            jest.advanceTimersByTime(2000)
+            await Promise.resolve()
+        })
+
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(2)
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenNthCalledWith(1, [nda], { fresh: true })
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenNthCalledWith(2, [nda], { fresh: true })
+        expect(onComplete)
+            .toHaveBeenCalledTimes(1)
+        expect(mockAgreeToTerms)
+            .not.toHaveBeenCalled()
     })
 
     it('keeps registration blocked when DocuSign persistence cannot be confirmed', async () => {
@@ -1028,17 +1097,18 @@ describe('ChallengeTermsModal', () => {
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(1)
 
-        for (let attempt = 1; attempt < 5; attempt += 1) {
+        const retryDelays = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 20000]
+        for (let retry = 0; retry < retryDelays.length; retry += 1) {
             // Each status check schedules only the next retry.
             // eslint-disable-next-line no-await-in-loop
             await act(async () => {
-                jest.advanceTimersByTime(5000)
+                jest.advanceTimersByTime(retryDelays[retry])
                 await Promise.resolve()
             })
         }
 
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenCalledTimes(5)
+            .toHaveBeenCalledTimes(9)
         expect(screen.getByRole('alert'))
             .toHaveTextContent('couldn’t confirm your DocuSign agreement yet')
         expect(screen.getByRole('button', { name: 'Check again' }))
@@ -1046,6 +1116,19 @@ describe('ChallengeTermsModal', () => {
         expect(mockAgreeToTerms)
             .not.toHaveBeenCalled()
         expect(onComplete)
+            .not.toHaveBeenCalled()
+
+        mockGetSubmitterTermsDetails.mockResolvedValueOnce([])
+        fireEvent.click(screen.getByRole('button', { name: 'Check again' }))
+        await act(async () => Promise.resolve())
+
+        expect(onComplete)
+            .toHaveBeenCalledTimes(1)
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledTimes(1)
+        expect(mockGetSubmitterTermsDetails)
+            .toHaveBeenCalledTimes(10)
+        expect(mockAgreeToTerms)
             .not.toHaveBeenCalled()
     })
 

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -34,8 +34,10 @@ import styles from './ChallengeTermsModal.module.scss'
 
 export type ChallengeTermsMode = 'register' | 'view'
 
-const DOCUSIGN_POLL_DELAY_MS = 5000
-const DOCUSIGN_POLL_MAX_ATTEMPTS = 5
+// One immediate read followed by bounded backoff. The final attempt occurs
+// after 91 seconds, leaving enough time for DocuSign Connect and the Terms
+// receiver transaction without holding registration open indefinitely.
+const DOCUSIGN_POLL_RETRY_DELAYS_MS = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 20000]
 const NDA_TITLE_PATTERN = /\bnda\b|non[-\s]?disclosure/i
 
 interface ChallengeTermsModalProps {
@@ -98,6 +100,28 @@ function delay(durationMs: number): Promise<void> {
     return new Promise(resolve => {
         window.setTimeout(resolve, durationMs)
     })
+}
+
+/**
+ * Identifies status-read failures that are safe to retry. Network failures and
+ * timeout/rate-limit/server responses can clear while DocuSign confirmation is
+ * propagating; authorization and other client errors should surface immediately.
+ *
+ * @param error failure returned by the authenticated Terms status read.
+ * @returns true when another read may succeed without changing user state.
+ * @throws Does not throw.
+ */
+function isTransientDocuSignStatusError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') return true
+    const candidate = error as {
+        response?: { status?: unknown }
+        status?: unknown
+    }
+    const rawStatus = candidate.status ?? candidate.response?.status
+    if (rawStatus === undefined || rawStatus === null) return true
+    const status = Number(rawStatus)
+    if (!Number.isFinite(status) || status === 0) return true
+    return status === 408 || status === 425 || status === 429 || status >= 500
 }
 
 /**
@@ -382,23 +406,35 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
      * @param termId canonical term identifier signed in the recipient frame.
      * @param interaction modal interaction that owns the callback.
      * @returns remaining terms, or undefined when the interaction became stale or confirmation timed out.
-     * @throws Propagates Terms API failures.
+     * @throws Propagates non-transient Terms API failures; transient failures are retried.
      */
     const pollForDocuSignAgreement = async (
         termId: string,
         interaction: number,
     ): Promise<ChallengeTerm[] | undefined> => {
-        for (let attempt = 1; attempt <= DOCUSIGN_POLL_MAX_ATTEMPTS; attempt += 1) {
-            // Sequential polling is required because Terms service persistence is asynchronous.
-            // eslint-disable-next-line no-await-in-loop
-            const refreshedTerms = await getChallengeSubmitterTermsDetails(props.terms)
-            if (interaction !== interactionRef.current) return undefined
-            if (!refreshedTerms.some(term => term.id === termId)) return refreshedTerms
-            if (attempt < DOCUSIGN_POLL_MAX_ATTEMPTS) {
+        const attemptCount = DOCUSIGN_POLL_RETRY_DELAYS_MS.length + 1
+        for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+            if (attempt > 0) {
                 // eslint-disable-next-line no-await-in-loop
-                await delay(DOCUSIGN_POLL_DELAY_MS)
+                await delay(DOCUSIGN_POLL_RETRY_DELAYS_MS[attempt - 1])
                 if (interaction !== interactionRef.current) return undefined
             }
+
+            let refreshedTerms: ChallengeTerm[] | undefined
+            // Sequential polling is required because Terms service persistence is asynchronous.
+            try {
+                // A unique `nocache` value is required for each authoritative
+                // post-signature read; the Terms endpoint otherwise emits an ETag
+                // without an explicit no-store policy.
+                // eslint-disable-next-line no-await-in-loop
+                refreshedTerms = await getChallengeSubmitterTermsDetails(props.terms, { fresh: true })
+            } catch (error) {
+                if (interaction !== interactionRef.current) return undefined
+                if (!isTransientDocuSignStatusError(error)) throw error
+            }
+
+            if (interaction !== interactionRef.current) return undefined
+            if (refreshedTerms && !refreshedTerms.some(term => term.id === termId)) return refreshedTerms
         }
 
         return undefined

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -1885,6 +1885,31 @@ describe('opportunities service normalization', () => {
             .toHaveBeenNthCalledWith(2, 'https://api.example/v5/terms/term-uuid')
     })
 
+    it('uses a unique cache-buster for authoritative challenge term status reads', async () => {
+        const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
+        get.mockClear()
+        get
+            .mockResolvedValueOnce({ agreed: false, id: 'nda' })
+            .mockResolvedValueOnce({ agreed: true, id: 'nda' })
+
+        await getChallengeTermDetails({ id: 'nda' }, { fresh: true })
+        await getChallengeTermDetails({ id: 'nda' }, { fresh: true })
+
+        const requestUrls = get.mock.calls.map(call => new URL(String(call[0])))
+        expect(requestUrls.map(url => url.origin + url.pathname))
+            .toEqual([
+                'https://api.example/v5/terms/nda',
+                'https://api.example/v5/terms/nda',
+            ])
+        const cacheBusters = requestUrls.map(url => url.searchParams.get('nocache'))
+        expect(cacheBusters[0])
+            .toMatch(/^\d+-\d+$/)
+        expect(cacheBusters[1])
+            .toMatch(/^\d+-\d+$/)
+        expect(cacheBusters[1])
+            .not.toBe(cacheBusters[0])
+    })
+
     it('persists separate electronic agreement requests in caller order', async () => {
         const post = xhrPostAsync as jest.MockedFunction<typeof xhrPostAsync>
         post.mockClear()

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -2151,6 +2151,29 @@ interface DocuSignViewResponse {
     recipientViewUrl?: string
 }
 
+interface ChallengeTermsDetailsOptions {
+    fresh?: boolean
+}
+
+let challengeTermsFreshRequestSequence = 0
+
+/**
+ * Adds a unique query value when an agreement-status read must bypass browser
+ * and intermediary HTTP caches.
+ *
+ * @param url Terms API request URL.
+ * @param fresh whether the caller requires an authoritative status read.
+ * @returns the original URL or a uniquely cache-busted URL.
+ * @throws Does not throw.
+ */
+function buildChallengeTermDetailsUrl(url: string, fresh: boolean = false): string {
+    if (!fresh) return url
+
+    challengeTermsFreshRequestSequence += 1
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}nocache=${Date.now()}-${challengeTermsFreshRequestSequence}`
+}
+
 /**
  * Loads the complete title, agreement type, URL, and body for one challenge
  * term reference from the v5 Terms API.
@@ -2161,26 +2184,39 @@ interface DocuSignViewResponse {
  * either API response omits them.
  *
  * @param term lightweight challenge term reference.
+ * @param options request behavior; fresh reads bypass HTTP caches for post-signature polling.
  * @returns complete term details, or the original reference when it has no ID.
  * @throws Error when a legacy ID is not found; otherwise propagates API errors.
  */
-export async function getChallengeTermDetails(term: ChallengeTerm): Promise<ChallengeTerm> {
+export async function getChallengeTermDetails(
+    term: ChallengeTerm,
+    options: ChallengeTermsDetailsOptions = {},
+): Promise<ChallengeTerm> {
     if (!term.id) return term
     let details: ChallengeTerm
     if (/^[\d]{5,8}$/.test(term.id)) {
         const response = await xhrGetAsync<LegacyTermsSearchResponse>(
-            `${EnvironmentConfig.API.V5}/terms?legacyId=${encodeURIComponent(term.id)}`,
+            buildChallengeTermDetailsUrl(
+                `${EnvironmentConfig.API.V5}/terms?legacyId=${encodeURIComponent(term.id)}`,
+                options.fresh,
+            ),
         )
         const match = response.result?.[0]
         if (!match) throw new Error(`Challenge term ${term.id} was not found.`)
         if (!match.id) throw new Error(`Challenge term ${term.id} has no canonical identifier.`)
         const canonicalDetails = await xhrGetAsync<ChallengeTerm>(
-            `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(match.id)}`,
+            buildChallengeTermDetailsUrl(
+                `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(match.id)}`,
+                options.fresh,
+            ),
         )
         details = { ...match, ...canonicalDetails }
     } else {
         details = await xhrGetAsync<ChallengeTerm>(
-            `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(term.id)}`,
+            buildChallengeTermDetailsUrl(
+                `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(term.id)}`,
+                options.fresh,
+            ),
         )
     }
 
@@ -2191,11 +2227,15 @@ export async function getChallengeTermDetails(term: ChallengeTerm): Promise<Chal
  * Resolves all lightweight challenge term references for modal display.
  *
  * @param terms lightweight terms included with a Challenge API response.
+ * @param options request behavior shared by every detail read.
  * @returns complete Terms API records in challenge order.
  * @throws Propagates any individual term detail failure.
  */
-export function getChallengeTermsDetails(terms: ChallengeTerm[]): Promise<ChallengeTerm[]> {
-    return Promise.all(terms.map(getChallengeTermDetails))
+export function getChallengeTermsDetails(
+    terms: ChallengeTerm[],
+    options: ChallengeTermsDetailsOptions = {},
+): Promise<ChallengeTerm[]> {
+    return Promise.all(terms.map(term => getChallengeTermDetails(term, options)))
 }
 
 /**
@@ -2205,14 +2245,19 @@ export function getChallengeTermsDetails(terms: ChallengeTerm[]): Promise<Challe
  * agreed again during registration.
  *
  * @param terms lightweight role-scoped references from Challenge API.
+ * @param options request behavior shared by every detail read.
  * @returns unaccepted, complete Submitter term records in challenge order.
  * @throws Propagates Resource Role or Terms API failures.
  */
 export async function getChallengeSubmitterTermsDetails(
     terms: ChallengeTerm[],
+    options: ChallengeTermsDetailsOptions = {},
 ): Promise<ChallengeTerm[]> {
     const submitterRole = await getSubmitterRole()
-    const details = await getChallengeTermsDetails(terms.filter(term => term.roleId === submitterRole.id))
+    const details = await getChallengeTermsDetails(
+        terms.filter(term => term.roleId === submitterRole.id),
+        options,
+    )
     return details.filter(term => !term.agreed)
 }
 


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6295

# What's in this PR?

- Extends signed-agreement confirmation from about 20 seconds to a bounded 91-second backoff window.
- Retries transient Terms status failures and uses unique status URLs to avoid stale cached reads.
- Keeps registration fail-closed; Check again reuses the existing DocuSign recipient view and never bypasses DocuSign through the electronic agreement endpoint.
- Preserves cancellation when the modal closes or unmounts.
- Adds regression coverage and documents the confirmation behavior.

## Validation

- 86 focused Jest tests passed.
- Full ESLint passed.
- Full TypeScript check passed.
- Production build completed successfully (with existing repository warnings).
- git diff --check passed.