### PR TITLE
fix(PM-6295): bound DocuSign confirmation requests

### DIFF
--- a/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.spec.tsx
@@ -291,7 +291,11 @@ describe('ChallengeTermsModal', () => {
         expect(mockAgreeToTerms)
             .toHaveBeenCalledTimes(1)
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenCalledWith([standardTerms, nda], { fresh: true })
+            .toHaveBeenCalledWith([standardTerms, nda], expect.objectContaining({
+                fresh: true,
+                signal: expect.objectContaining({ aborted: false }),
+                timeoutMs: 10000,
+            }))
         addEventListener.mockRestore()
     })
 
@@ -888,6 +892,67 @@ describe('ChallengeTermsModal', () => {
             .not.toHaveBeenCalled()
     })
 
+    it('bounds a passive DocuSign refresh that never settles', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onClose = jest.fn()
+        const onComplete = jest.fn()
+        const mutate = jest.fn(() => new Promise(() => {
+            // Intentionally remains pending until the confirmation deadline.
+        }))
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+            mutate,
+        }
+
+        render(
+            <ChallengeTermsModal
+                mode='view'
+                onClose={onClose}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'viewing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        await act(async () => Promise.resolve())
+
+        expect(screen.getByText('Confirming your signature…'))
+            .toBeInTheDocument()
+        await act(async () => {
+            jest.advanceTimersByTime(91000)
+            await Promise.resolve()
+            await Promise.resolve()
+        })
+
+        expect(screen.getByRole('alert'))
+            .toHaveTextContent('couldn’t refresh this DocuSign agreement within 91 seconds')
+        expect(screen.getByRole('button', { name: 'Check again' }))
+            .toBeEnabled()
+        expect(mutate)
+            .toHaveBeenCalledTimes(1)
+        expect(mockGetDocuSignUrl)
+            .toHaveBeenCalledTimes(1)
+        expect(onClose)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
     it('ignores untrusted DocuSign callback messages and closes on trusted cancellation', async () => {
         const addEventListener = jest.spyOn(window, 'addEventListener')
         const nda: ChallengeTerm = {
@@ -995,7 +1060,11 @@ describe('ChallengeTermsModal', () => {
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(6)
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenLastCalledWith([nda], { fresh: true })
+            .toHaveBeenLastCalledWith([nda], expect.objectContaining({
+                fresh: true,
+                signal: expect.objectContaining({ aborted: false }),
+                timeoutMs: 10000,
+            }))
         expect(onComplete)
             .toHaveBeenCalledTimes(1)
         expect(mockAgreeToTerms)
@@ -1005,7 +1074,7 @@ describe('ChallengeTermsModal', () => {
         view.unmount()
     })
 
-    it('retries a transient Terms status failure before completing DocuSign registration', async () => {
+    it('retries a timed-out Terms status request before completing DocuSign registration', async () => {
         const addEventListener = jest.spyOn(window, 'addEventListener')
         const nda: ChallengeTerm = {
             id: 'nda',
@@ -1014,7 +1083,9 @@ describe('ChallengeTermsModal', () => {
         const onComplete = jest.fn()
             .mockResolvedValue(undefined)
         mockGetSubmitterTermsDetails
-            .mockRejectedValueOnce(Object.assign(new Error('Terms service unavailable'), { status: 503 }))
+            .mockRejectedValueOnce(Object.assign(new Error('Terms status request timed out'), {
+                code: 'ECONNABORTED',
+            }))
             .mockResolvedValueOnce([])
         mockSWRResponse = {
             ...mockSWRResponse,
@@ -1052,9 +1123,17 @@ describe('ChallengeTermsModal', () => {
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(2)
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenNthCalledWith(1, [nda], { fresh: true })
+            .toHaveBeenNthCalledWith(1, [nda], expect.objectContaining({
+                fresh: true,
+                signal: expect.objectContaining({ aborted: false }),
+                timeoutMs: 10000,
+            }))
         expect(mockGetSubmitterTermsDetails)
-            .toHaveBeenNthCalledWith(2, [nda], { fresh: true })
+            .toHaveBeenNthCalledWith(2, [nda], expect.objectContaining({
+                fresh: true,
+                signal: expect.objectContaining({ aborted: false }),
+                timeoutMs: 10000,
+            }))
         expect(onComplete)
             .toHaveBeenCalledTimes(1)
         expect(mockAgreeToTerms)
@@ -1097,7 +1176,7 @@ describe('ChallengeTermsModal', () => {
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(1)
 
-        const retryDelays = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 20000]
+        const retryDelays = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 19000]
         for (let retry = 0; retry < retryDelays.length; retry += 1) {
             // Each status check schedules only the next retry.
             // eslint-disable-next-line no-await-in-loop
@@ -1110,7 +1189,7 @@ describe('ChallengeTermsModal', () => {
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(9)
         expect(screen.getByRole('alert'))
-            .toHaveTextContent('couldn’t confirm your DocuSign agreement yet')
+            .toHaveTextContent('couldn’t confirm your DocuSign agreement within 91 seconds')
         expect(screen.getByRole('button', { name: 'Check again' }))
             .toBeInTheDocument()
         expect(mockAgreeToTerms)
@@ -1132,16 +1211,77 @@ describe('ChallengeTermsModal', () => {
             .not.toHaveBeenCalled()
     })
 
-    it('cancels DocuSign confirmation polling when the modal unmounts', async () => {
+    it('bounds a status read that never settles and leaves confirmation retryable', async () => {
         const addEventListener = jest.spyOn(window, 'addEventListener')
         const nda: ChallengeTerm = {
             id: 'nda',
             title: 'NDA',
         }
         const onComplete = jest.fn()
-        mockGetSubmitterTermsDetails
-            .mockResolvedValueOnce([nda])
-            .mockResolvedValueOnce([])
+        mockGetSubmitterTermsDetails.mockImplementation(() => new Promise(() => {
+            // Intentionally remains pending until the confirmation deadline.
+        }))
+        mockSWRResponse = {
+            ...mockSWRResponse,
+            data: [nda],
+            isValidating: false,
+        }
+        render(
+            <ChallengeTermsModal
+                mode='register'
+                onClose={jest.fn()}
+                onComplete={onComplete}
+                open
+                terms={[nda]}
+            />,
+        )
+        const frame = await screen.findByTitle('NDA')
+        await waitFor(() => expect(addEventListener)
+            .toHaveBeenCalledWith('message', expect.any(Function)))
+        jest.useFakeTimers()
+        fireEvent(window, new MessageEvent('message', {
+            data: { event: 'signing_complete', type: 'DocuSign' },
+            origin: 'https://www.topcoder-dev.com',
+            source: (frame as HTMLIFrameElement).contentWindow,
+        }))
+        await act(async () => Promise.resolve())
+
+        const firstOptions = mockGetSubmitterTermsDetails.mock.calls[0][1] as {
+            signal: AbortSignal
+        }
+        expect(screen.getByText('Confirming your signature…'))
+            .toBeInTheDocument()
+        expect(firstOptions.signal.aborted)
+            .toBe(false)
+
+        await act(async () => {
+            jest.advanceTimersByTime(91000)
+            await Promise.resolve()
+            await Promise.resolve()
+        })
+
+        expect(firstOptions.signal.aborted)
+            .toBe(true)
+        expect(screen.getByRole('alert'))
+            .toHaveTextContent('couldn’t confirm your DocuSign agreement within 91 seconds')
+        expect(screen.getByRole('button', { name: 'Check again' }))
+            .toBeEnabled()
+        expect(mockAgreeToTerms)
+            .not.toHaveBeenCalled()
+        expect(onComplete)
+            .not.toHaveBeenCalled()
+    })
+
+    it('aborts an in-flight DocuSign status read when the modal unmounts', async () => {
+        const addEventListener = jest.spyOn(window, 'addEventListener')
+        const nda: ChallengeTerm = {
+            id: 'nda',
+            title: 'NDA',
+        }
+        const onComplete = jest.fn()
+        mockGetSubmitterTermsDetails.mockImplementation(() => new Promise(() => {
+            // Intentionally remains pending so unmount must cancel the interaction.
+        }))
         mockSWRResponse = {
             ...mockSWRResponse,
             data: [nda],
@@ -1171,13 +1311,19 @@ describe('ChallengeTermsModal', () => {
         })
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(1)
+        const firstOptions = mockGetSubmitterTermsDetails.mock.calls[0][1] as {
+            signal: AbortSignal
+        }
+        expect(firstOptions.signal.aborted)
+            .toBe(false)
 
         view.unmount()
         await act(async () => {
-            jest.advanceTimersByTime(30000)
             await Promise.resolve()
         })
 
+        expect(firstOptions.signal.aborted)
+            .toBe(true)
         expect(mockGetSubmitterTermsDetails)
             .toHaveBeenCalledTimes(1)
         expect(mockMutateTermsCache)

--- a/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
+++ b/src/apps/opportunities/src/components/ChallengeTermsModal.tsx
@@ -34,10 +34,12 @@ import styles from './ChallengeTermsModal.module.scss'
 
 export type ChallengeTermsMode = 'register' | 'view'
 
-// One immediate read followed by bounded backoff. The final attempt occurs
-// after 91 seconds, leaving enough time for DocuSign Connect and the Terms
-// receiver transaction without holding registration open indefinitely.
-const DOCUSIGN_POLL_RETRY_DELAYS_MS = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 20000]
+// One immediate read followed by bounded backoff. Confirmation has a separate
+// 91-second wall-clock deadline so slow requests and throttled browser timers
+// cannot extend the registration gate indefinitely.
+const DOCUSIGN_POLL_RETRY_DELAYS_MS = [2000, 3000, 5000, 8000, 13000, 20000, 20000, 19000]
+const DOCUSIGN_CONFIRMATION_TIMEOUT_MS = 91_000
+const DOCUSIGN_STATUS_REQUEST_TIMEOUT_MS = 10_000
 const NDA_TITLE_PATTERN = /\bnda\b|non[-\s]?disclosure/i
 
 interface ChallengeTermsModalProps {
@@ -90,15 +92,74 @@ function buildDocuSignReturnUrl(): string {
 }
 
 /**
- * Delays a DocuSign agreement-status retry without blocking the browser.
+ * Delays a DocuSign agreement-status retry without blocking the browser and
+ * clears the timer when the owning confirmation is cancelled.
  *
  * @param durationMs delay in milliseconds.
- * @returns promise resolved after the requested delay.
+ * @param signal signal that cancels the pending delay.
+ * @returns promise resolving true after the delay or false after cancellation.
  * @throws Does not throw.
  */
-function delay(durationMs: number): Promise<void> {
+function delay(durationMs: number, signal: AbortSignal): Promise<boolean> {
+    if (signal.aborted) return Promise.resolve(false)
+
     return new Promise(resolve => {
-        window.setTimeout(resolve, durationMs)
+        let settled = false
+        let timeout = 0
+        const onAbort = (): void => {
+            if (settled) return
+            settled = true
+            window.clearTimeout(timeout)
+            resolve(false)
+        }
+
+        timeout = window.setTimeout(() => {
+            if (settled) return
+            settled = true
+            signal.removeEventListener('abort', onAbort)
+            resolve(true)
+        }, durationMs)
+        signal.addEventListener('abort', onAbort, { once: true })
+    })
+}
+
+/**
+ * Rejects an in-flight status read as soon as its confirmation signal aborts,
+ * even if a mocked or non-Axios request fails to observe the signal itself.
+ *
+ * @param request status request to settle.
+ * @param signal signal bounding the owning confirmation interaction.
+ * @returns the request result when it settles before cancellation.
+ * @throws AbortError after cancellation, or the original request failure.
+ */
+function awaitWithAbort<T>(request: Promise<T>, signal: AbortSignal): Promise<T> {
+    if (signal.aborted) {
+        return Promise.reject(new DOMException('DocuSign confirmation cancelled.', 'AbortError'))
+    }
+
+    return new Promise((resolve, reject) => {
+        let settled = false
+        const onAbort = (): void => {
+            if (settled) return
+            settled = true
+            reject(new DOMException('DocuSign confirmation cancelled.', 'AbortError'))
+        }
+
+        signal.addEventListener('abort', onAbort, { once: true })
+        request.then(
+            value => {
+                if (settled) return
+                settled = true
+                signal.removeEventListener('abort', onAbort)
+                resolve(value)
+            },
+            error => {
+                if (settled) return
+                settled = true
+                signal.removeEventListener('abort', onAbort)
+                reject(error)
+            },
+        )
     })
 }
 
@@ -164,6 +225,7 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const closeRef = useRef<() => void>(() => undefined)
     const docuSignCallbackHandledRef = useRef(false)
     const docuSignCompletionRef = useRef<() => Promise<void>>(async () => undefined)
+    const docuSignConfirmationControllerRef = useRef<AbortController>()
     const docuSignFrameRef = useRef<HTMLIFrameElement>(null)
     const docuSignUrlRequestRef = useRef(0)
     const interactionRef = useRef(0)
@@ -239,6 +301,8 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
     const fullTitle = activeTerm?.title || terms[0]?.title || props.terms[0]?.title || 'Challenge Terms'
 
     useEffect(() => {
+        docuSignConfirmationControllerRef.current?.abort()
+        docuSignConfirmationControllerRef.current = undefined
         interactionRef.current += 1
         if (props.open) {
             setAccepted(false)
@@ -253,8 +317,10 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         }
 
         return () => {
-            // Cancel delayed agreement polling and late URL requests on scope
-            // changes or unmount so they cannot complete an obsolete registration.
+            // Cancel agreement polling, its active HTTP request, and late URL
+            // callbacks so they cannot complete an obsolete registration.
+            docuSignConfirmationControllerRef.current?.abort()
+            docuSignConfirmationControllerRef.current = undefined
             interactionRef.current += 1
         }
     }, [props.open, props.mode, memberScope, termKey])
@@ -395,6 +461,8 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
      * @throws Does not throw.
      */
     const close = (): void => {
+        docuSignConfirmationControllerRef.current?.abort()
+        docuSignConfirmationControllerRef.current = undefined
         interactionRef.current += 1
         props.onClose()
     }
@@ -405,20 +473,33 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
      *
      * @param termId canonical term identifier signed in the recipient frame.
      * @param interaction modal interaction that owns the callback.
+     * @param signal signal bounding all retry delays and status requests.
+     * @param deadlineAt absolute time when confirmation must stop.
      * @returns remaining terms, or undefined when the interaction became stale or confirmation timed out.
      * @throws Propagates non-transient Terms API failures; transient failures are retried.
      */
     const pollForDocuSignAgreement = async (
         termId: string,
         interaction: number,
+        signal: AbortSignal,
+        deadlineAt: number,
     ): Promise<ChallengeTerm[] | undefined> => {
         const attemptCount = DOCUSIGN_POLL_RETRY_DELAYS_MS.length + 1
         for (let attempt = 0; attempt < attemptCount; attempt += 1) {
             if (attempt > 0) {
                 // eslint-disable-next-line no-await-in-loop
-                await delay(DOCUSIGN_POLL_RETRY_DELAYS_MS[attempt - 1])
-                if (interaction !== interactionRef.current) return undefined
+                const delayCompleted = await delay(
+                    Math.min(
+                        DOCUSIGN_POLL_RETRY_DELAYS_MS[attempt - 1],
+                        Math.max(0, deadlineAt - Date.now()),
+                    ),
+                    signal,
+                )
+                if (!delayCompleted || interaction !== interactionRef.current) return undefined
             }
+
+            const remainingMs = deadlineAt - Date.now()
+            if (signal.aborted || remainingMs <= 0) return undefined
 
             let refreshedTerms: ChallengeTerm[] | undefined
             // Sequential polling is required because Terms service persistence is asynchronous.
@@ -427,9 +508,16 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                 // post-signature read; the Terms endpoint otherwise emits an ETag
                 // without an explicit no-store policy.
                 // eslint-disable-next-line no-await-in-loop
-                refreshedTerms = await getChallengeSubmitterTermsDetails(props.terms, { fresh: true })
+                refreshedTerms = await awaitWithAbort(
+                    getChallengeSubmitterTermsDetails(props.terms, {
+                        fresh: true,
+                        signal,
+                        timeoutMs: Math.min(DOCUSIGN_STATUS_REQUEST_TIMEOUT_MS, remainingMs),
+                    }),
+                    signal,
+                )
             } catch (error) {
-                if (interaction !== interactionRef.current) return undefined
+                if (signal.aborted || interaction !== interactionRef.current) return undefined
                 if (!isTransientDocuSignStatusError(error)) throw error
             }
 
@@ -451,11 +539,19 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
         if (!docuSignTerm || docuSignCompleting) return
         const interaction = interactionRef.current
         const termId = docuSignTerm.id
+        const confirmationController = new AbortController()
+        const deadlineAt = Date.now() + DOCUSIGN_CONFIRMATION_TIMEOUT_MS
+        docuSignConfirmationControllerRef.current?.abort()
+        docuSignConfirmationControllerRef.current = confirmationController
+        const confirmationTimeout = window.setTimeout(
+            () => confirmationController.abort(),
+            DOCUSIGN_CONFIRMATION_TIMEOUT_MS,
+        )
         setDocuSignCompleting(true)
         setExternalError('')
         try {
             if (!registrationMode) {
-                await response.mutate()
+                await awaitWithAbort(Promise.resolve(response.mutate()), confirmationController.signal)
                 if (interaction === interactionRef.current) close()
                 return
             }
@@ -464,10 +560,18 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
                 throw new Error('We couldn\u2019t verify this DocuSign agreement because it is missing an identifier.')
             }
 
-            const refreshedTerms = await pollForDocuSignAgreement(termId, interaction)
+            const refreshedTerms = await pollForDocuSignAgreement(
+                termId,
+                interaction,
+                confirmationController.signal,
+                deadlineAt,
+            )
             if (interaction !== interactionRef.current) return
             if (!refreshedTerms) {
-                throw new Error('We couldn\u2019t confirm your DocuSign agreement yet. Please try again.')
+                throw new Error(
+                    'We couldn\u2019t confirm your DocuSign agreement within 91 seconds. '
+                    + 'Select Check again to retry.',
+                )
             }
 
             const outstandingTermIds = new Set(refreshedTerms
@@ -486,10 +590,23 @@ export const ChallengeTermsModal: FC<ChallengeTermsModalProps> = props => {
             }
         } catch (error) {
             if (interaction !== interactionRef.current) return
-            setExternalError(error instanceof Error && error.message.trim()
-                ? error.message
-                : 'We couldn\u2019t confirm your DocuSign agreement. Please try again.')
+            if (confirmationController.signal.aborted) {
+                setExternalError(registrationMode
+                    ? 'We couldn\u2019t confirm your DocuSign agreement within 91 seconds. '
+                        + 'Select Check again to retry.'
+                    : 'We couldn\u2019t refresh this DocuSign agreement within 91 seconds. '
+                        + 'Select Check again to retry.')
+            } else {
+                setExternalError(error instanceof Error && error.message.trim()
+                    ? error.message
+                    : 'We couldn\u2019t confirm your DocuSign agreement. Please try again.')
+            }
         } finally {
+            window.clearTimeout(confirmationTimeout)
+            if (docuSignConfirmationControllerRef.current === confirmationController) {
+                docuSignConfirmationControllerRef.current = undefined
+            }
+
             if (interaction === interactionRef.current) setDocuSignCompleting(false)
         }
     }

--- a/src/apps/opportunities/src/services/opportunities.service.spec.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.spec.ts
@@ -1579,7 +1579,11 @@ describe('opportunities service normalization', () => {
                 totalPages: 2,
             })
         expect(get)
-            .toHaveBeenCalledWith('https://api.example/v6/resource-roles')
+            .toHaveBeenCalledWith(
+                'https://api.example/v6/resource-roles',
+                undefined,
+                { signal: undefined, timeout: undefined },
+            )
         expect(globalGet)
             .toHaveBeenLastCalledWith(
                 'https://api.example/v6/resources?challengeId=challenge&page=2&perPage=20&roleId=submitter-role'
@@ -1880,9 +1884,19 @@ describe('opportunities service normalization', () => {
                 title: 'Rules',
             })
         expect(get)
-            .toHaveBeenNthCalledWith(1, 'https://api.example/v5/terms?legacyId=123456')
+            .toHaveBeenNthCalledWith(
+                1,
+                'https://api.example/v5/terms?legacyId=123456',
+                undefined,
+                { signal: undefined, timeout: undefined },
+            )
         expect(get)
-            .toHaveBeenNthCalledWith(2, 'https://api.example/v5/terms/term-uuid')
+            .toHaveBeenNthCalledWith(
+                2,
+                'https://api.example/v5/terms/term-uuid',
+                undefined,
+                { signal: undefined, timeout: undefined },
+            )
     })
 
     it('uses a unique cache-buster for authoritative challenge term status reads', async () => {
@@ -1942,8 +1956,53 @@ describe('opportunities service normalization', () => {
                 roleId: 'submitter-role',
                 text: '<p>Rules</p>',
             }])
+        expect(get.mock.calls.map(call => call[0]))
+            .not.toContain('https://api.example/v5/terms/reviewer-term')
+    })
+
+    it('forwards cancellation and timeout controls through submitter term detail reads', async () => {
+        const get = xhrGetAsync as jest.MockedFunction<typeof xhrGetAsync>
+        const controller = new AbortController()
+        const requestConfig = { signal: controller.signal, timeout: 10_000 }
+        get
+            .mockResolvedValueOnce([{ id: 'submitter-role', name: 'Submitter' }])
+            .mockResolvedValueOnce({
+                result: [{ agreed: false, id: 'canonical-term', title: 'NDA' }],
+            })
+            .mockResolvedValueOnce({ agreed: false, id: 'canonical-term', text: '<p>NDA</p>' })
+
+        await expect(getChallengeSubmitterTermsDetails(
+            [{ id: '123456', roleId: 'submitter-role' }],
+            { signal: controller.signal, timeoutMs: 10_000 },
+        ))
+            .resolves.toEqual([{
+                agreed: false,
+                id: 'canonical-term',
+                roleId: 'submitter-role',
+                text: '<p>NDA</p>',
+                title: 'NDA',
+            }])
         expect(get)
-            .not.toHaveBeenCalledWith('https://api.example/v5/terms/reviewer-term')
+            .toHaveBeenNthCalledWith(
+                1,
+                'https://api.example/v6/resource-roles',
+                undefined,
+                requestConfig,
+            )
+        expect(get)
+            .toHaveBeenNthCalledWith(
+                2,
+                'https://api.example/v5/terms?legacyId=123456',
+                undefined,
+                requestConfig,
+            )
+        expect(get)
+            .toHaveBeenNthCalledWith(
+                3,
+                'https://api.example/v5/terms/canonical-term',
+                undefined,
+                requestConfig,
+            )
     })
 
     it('returns the Terms API DocuSign recipient view', async () => {

--- a/src/apps/opportunities/src/services/opportunities.service.ts
+++ b/src/apps/opportunities/src/services/opportunities.service.ts
@@ -1939,15 +1939,25 @@ export async function getChallengeResources(
     return normalizePage(response, page, perPage)
 }
 
+interface ChallengeTermsRequestOptions {
+    signal?: AbortSignal
+    timeoutMs?: number
+}
+
 /**
  * Resolves the canonical Submitter role used by challenge registration.
  *
+ * @param options optional cancellation and timeout controls for the Resource API request.
  * @returns Submitter resource role.
  * @throws Error when Resource API does not expose a Submitter role.
  */
-export async function getSubmitterRole(): Promise<ChallengeResourceRole> {
+export async function getSubmitterRole(
+    options: ChallengeTermsRequestOptions = {},
+): Promise<ChallengeResourceRole> {
     const response = await xhrGetAsync<ChallengeResourceRole[] | ApiEnvelope<ChallengeResourceRole[]>>(
         `${V6_URL}/resource-roles`,
+        undefined,
+        { signal: options.signal, timeout: options.timeoutMs },
     )
     const role = unwrap(response)
         .find(item => item.name.trim()
@@ -2151,7 +2161,7 @@ interface DocuSignViewResponse {
     recipientViewUrl?: string
 }
 
-interface ChallengeTermsDetailsOptions {
+interface ChallengeTermsDetailsOptions extends ChallengeTermsRequestOptions {
     fresh?: boolean
 }
 
@@ -2184,7 +2194,7 @@ function buildChallengeTermDetailsUrl(url: string, fresh: boolean = false): stri
  * either API response omits them.
  *
  * @param term lightweight challenge term reference.
- * @param options request behavior; fresh reads bypass HTTP caches for post-signature polling.
+ * @param options request behavior; fresh reads bypass HTTP caches while signal and timeoutMs bound each request.
  * @returns complete term details, or the original reference when it has no ID.
  * @throws Error when a legacy ID is not found; otherwise propagates API errors.
  */
@@ -2193,6 +2203,10 @@ export async function getChallengeTermDetails(
     options: ChallengeTermsDetailsOptions = {},
 ): Promise<ChallengeTerm> {
     if (!term.id) return term
+    const requestConfig = {
+        signal: options.signal,
+        timeout: options.timeoutMs,
+    }
     let details: ChallengeTerm
     if (/^[\d]{5,8}$/.test(term.id)) {
         const response = await xhrGetAsync<LegacyTermsSearchResponse>(
@@ -2200,6 +2214,8 @@ export async function getChallengeTermDetails(
                 `${EnvironmentConfig.API.V5}/terms?legacyId=${encodeURIComponent(term.id)}`,
                 options.fresh,
             ),
+            undefined,
+            requestConfig,
         )
         const match = response.result?.[0]
         if (!match) throw new Error(`Challenge term ${term.id} was not found.`)
@@ -2209,6 +2225,8 @@ export async function getChallengeTermDetails(
                 `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(match.id)}`,
                 options.fresh,
             ),
+            undefined,
+            requestConfig,
         )
         details = { ...match, ...canonicalDetails }
     } else {
@@ -2217,6 +2235,8 @@ export async function getChallengeTermDetails(
                 `${EnvironmentConfig.API.V5}/terms/${encodeURIComponent(term.id)}`,
                 options.fresh,
             ),
+            undefined,
+            requestConfig,
         )
     }
 
@@ -2227,7 +2247,7 @@ export async function getChallengeTermDetails(
  * Resolves all lightweight challenge term references for modal display.
  *
  * @param terms lightweight terms included with a Challenge API response.
- * @param options request behavior shared by every detail read.
+ * @param options cache, cancellation, and timeout behavior shared by every detail read.
  * @returns complete Terms API records in challenge order.
  * @throws Propagates any individual term detail failure.
  */
@@ -2245,7 +2265,7 @@ export function getChallengeTermsDetails(
  * agreed again during registration.
  *
  * @param terms lightweight role-scoped references from Challenge API.
- * @param options request behavior shared by every detail read.
+ * @param options cache, cancellation, and timeout behavior shared by the role and detail reads.
  * @returns unaccepted, complete Submitter term records in challenge order.
  * @throws Propagates Resource Role or Terms API failures.
  */
@@ -2253,7 +2273,7 @@ export async function getChallengeSubmitterTermsDetails(
     terms: ChallengeTerm[],
     options: ChallengeTermsDetailsOptions = {},
 ): Promise<ChallengeTerm[]> {
-    const submitterRole = await getSubmitterRole()
+    const submitterRole = await getSubmitterRole(options)
     const details = await getChallengeTermsDetails(
         terms.filter(term => term.roleId === submitterRole.id),
         options,

--- a/src/libs/core/lib/xhr/xhr-functions/xhr.functions.spec.ts
+++ b/src/libs/core/lib/xhr/xhr-functions/xhr.functions.spec.ts
@@ -1,8 +1,8 @@
-import { AxiosHeaders, InternalAxiosRequestConfig } from 'axios'
+import { AxiosHeaders, AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 
 import { tokenGetAsync } from '../../auth'
 
-import { createInstance, postAsync } from './xhr.functions'
+import { createInstance, getAsync, postAsync } from './xhr.functions'
 
 jest.mock('~/config', () => ({
     EnvironmentConfig: {
@@ -59,5 +59,26 @@ describe('xhr post serialization', () => {
             .toBe('Bearer auth-token')
         expect(captured?.signal)
             .toBe(controller.signal)
+    })
+})
+
+describe('xhr get request configuration', () => {
+    it('forwards cancellation and timeout controls to Axios', async () => {
+        const controller = new AbortController()
+        const get = jest.fn()
+            .mockResolvedValue({ data: { id: 'term-id' } })
+        const xhr = { get } as unknown as AxiosInstance
+
+        await expect(getAsync(
+            'https://api.example/v5/terms/term-id',
+            xhr,
+            { signal: controller.signal, timeout: 10_000 },
+        ))
+            .resolves.toEqual({ id: 'term-id' })
+        expect(get)
+            .toHaveBeenCalledWith(
+                'https://api.example/v5/terms/term-id',
+                { signal: controller.signal, timeout: 10_000 },
+            )
     })
 })

--- a/src/libs/core/lib/xhr/xhr-functions/xhr.functions.ts
+++ b/src/libs/core/lib/xhr/xhr-functions/xhr.functions.ts
@@ -60,11 +60,21 @@ export async function deleteAsync<T>(
     return output.data
 }
 
+/**
+ * Performs a GET request and returns its response payload.
+ *
+ * @param url request URL.
+ * @param xhrInstance Axios instance used to execute the request.
+ * @param config optional Axios request configuration, including cancellation and timeout controls.
+ * @returns response data returned by the server.
+ * @throws Propagates Axios request, cancellation, and timeout errors.
+ */
 export async function getAsync<T>(
     url: string,
-    xhrInstance: AxiosInstance = globalInstance,
+    xhrInstance?: AxiosInstance,
+    config?: AxiosRequestConfig,
 ): Promise<T> {
-    const output: AxiosResponse<T> = await xhrInstance.get(url)
+    const output: AxiosResponse<T> = await (xhrInstance ?? globalInstance).get(url, config)
     return output.data
 }
 


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6295

# What is in this PR?
- gives DocuSign confirmation a fixed 91-second wall-clock deadline
- applies a 10-second timeout and cancellation signal to Submitter-role and Terms status GETs
- aborts active confirmation work when the modal closes, changes scope, or unmounts
- converts stalled registration and passive refresh requests into a clear Check again state
- retains the current recipient URL for confirmation retries and keeps registration fail-closed

## Validation
- 91 focused Jest tests
- full yarn lint
- yarn tsc --noEmit --pretty false
- production yarn build (existing warnings only)
- git diff --check