### PR TITLE
PM-6305: Gate Design deletion by submission phase

### DIFF
--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -1265,6 +1265,59 @@ describe('ChallengeDetailsPage member flows', () => {
             .not.toBeDisabled())
     })
 
+    it.each([
+        ['Submission', 'contest-submission', 'checkpoint-submission'],
+        ['Checkpoint Submission', 'checkpoint-submission', 'contest-submission'],
+    ])(
+        'only enables the matching submission type during the Design %s phase',
+        (activePhase, enabledSubmissionId, disabledSubmissionId) => {
+            mockProfile = { handle: 'coder', userId: 123 }
+            mockRegistration = { id: 'resource-id' }
+            mockChallenge = {
+                ...mockChallenge,
+                phases: [
+                    { isOpen: activePhase === 'Checkpoint Submission', name: 'Checkpoint Submission' },
+                    { isOpen: activePhase === 'Submission', name: 'Submission' },
+                ],
+                track: 'Design',
+            }
+            mockSubmissions = [
+                {
+                    createdAt: '2026-06-03T09:30:00.000Z',
+                    id: 'contest-submission',
+                    type: 'CONTEST_SUBMISSION',
+                },
+                {
+                    createdAt: '2026-06-02T09:30:00.000Z',
+                    id: 'checkpoint-submission',
+                    type: 'CHECKPOINT_SUBMISSION',
+                },
+            ]
+
+            renderPage()
+            fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+            expect(screen.getByRole('button', { name: `Delete submission ${enabledSubmissionId}` }))
+                .toBeEnabled()
+            const disabledDeleteButton = screen.getByRole('button', {
+                name: `Delete submission ${disabledSubmissionId}`,
+            })
+            expect(disabledDeleteButton)
+                .toBeDisabled()
+            expect(disabledDeleteButton)
+                .toHaveAttribute('title', 'Submission deletion is closed')
+            expect(screen.getByRole('button', { name: `Download submission ${disabledSubmissionId}` }))
+                .toBeEnabled()
+            expect(screen.getByRole('link', {
+                name: `Open submission ${disabledSubmissionId} in Review App`,
+            }))
+                .toBeInTheDocument()
+            fireEvent.click(disabledDeleteButton)
+            expect(mockDeleteSubmission)
+                .not.toHaveBeenCalled()
+        },
+    )
+
     it('disables Design submission deletion after the submission phase closes', () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -114,21 +114,32 @@ const STALE_REGISTRATION_MESSAGE
 const ACTIVE_SUBMISSIONS_REFRESH_INTERVAL_MS = 30_000
 
 /**
- * Determines whether a Design submission can still be removed while an
- * authored submission phase is open.
+ * Determines whether a Design submission can still be removed while the
+ * phase that produced that submission is open.
  *
  * @param challenge challenge with expanded or compact current-phase data.
- * @returns true during Submission or Checkpoint Submission only.
+ * @param submission authored submission whose phase ownership is checked.
+ * @returns true only when the submission type matches the active authored phase.
  * @throws Does not throw.
  */
-export function challengeAllowsDesignSubmissionDeletion(challenge: ChallengeOpportunity): boolean {
+export function challengeAllowsDesignSubmissionDeletion(
+    challenge: ChallengeOpportunity,
+    submission: ChallengeSubmission,
+): boolean {
     const openPhaseKeys = [
         ...(challenge.phases ?? [])
             .filter(phase => phase.isOpen === true)
             .map(phase => challengeCatalogKey(phase.name)),
         ...(challenge.currentPhaseNames ?? []).map(challengeCatalogKey),
     ]
-    return openPhaseKeys.some(key => key === 'submission' || key === 'checkpointsubmission')
+    const submissionTypeKey = challengeCatalogKey(submission.type)
+    const requiredPhaseKey = submissionTypeKey === 'checkpointsubmission'
+        ? 'checkpointsubmission'
+        : submissionTypeKey === 'contestsubmission'
+            ? 'submission'
+            : undefined
+
+    return !!requiredPhaseKey && openPhaseKeys.includes(requiredPhaseKey)
 }
 
 interface SortableColumnHeaderProps {
@@ -1287,9 +1298,6 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         props.challenge,
         submissions,
     )
-    const designDeletionAllowed = isDesign
-        && challengeAllowsDesignSubmissionDeletion(props.challenge)
-
     /**
      * Opens an authorized clean-storage download without exposing private URLs in list data.
      *
@@ -1473,6 +1481,8 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                 const statusClass = progress.status
                                     ? styles[`testStatus${progress.status.replace(' ', '')}`]
                                     : ''
+                                const designDeletionAllowed = isDesign
+                                    && challengeAllowsDesignSubmissionDeletion(props.challenge, submission)
                                 return (
                                     <tr key={submission.id}>
                                         <td data-mobile-label='Submission ID'>


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6305

# What is in this PR?

- Enables deletion of a Design submission only while its originating phase is open.
- Keeps checkpoint submissions read-only during the final Submission phase, while preserving download and Review App actions.
- Adds bidirectional regression coverage for Checkpoint Submission and Submission phases.

## Validation

- 62 focused challenge-detail tests passed.
- Full lint passed.
- TypeScript no-emit check passed.
- Production build passed with existing warnings only.