### PR TITLE
PM-6306: Preserve My Submissions through refresh errors

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -384,7 +384,10 @@ tab, and that tab exists only when Work Manager enables its challenge metadata.
 Review API submissions and Marathon Match review summations own provisional
 and final scores. Active My Submissions pages periodically revalidate so an
 asynchronous AI decision score appears without requiring the member to reload
-the page; failed score requests do not enter an automatic retry loop. Final
+the page. A transient background failure retains the last successful submission
+page, retries twice with a delay, and revalidates when the member returns to the
+tab; initial failures still expose the explicit retry action. Optional score
+requests do not enter an automatic retry loop. Final
 Marathon Match values remain hidden while a submission
 phase is open, then appear after Review closes or Review API publishes a final
 result. Non-Marathon final scores appear only for completed challenges. The

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -26,6 +26,7 @@ const mockGetSubmissionDownloadUrl = jest.fn()
 const mockChallengeMutate = jest.fn()
 const mockChallengeForumRender = jest.fn()
 const mockMySubmissionCountMutate = jest.fn()
+const mockSubmissionsMutate = jest.fn()
 const mockRegister = jest.fn()
 const mockRegistrationMutate = jest.fn()
 const mockUnregister = jest.fn()
@@ -43,6 +44,8 @@ let mockPreviewSubmissions: Record<string, unknown>[]
 let mockRegistrants: Record<string, unknown>[]
 let mockReviewSummations: Record<string, unknown>[]
 let mockSubmissions: Record<string, unknown>[]
+let mockSubmissionsError: Error | undefined
+let mockSubmissionsLoaded: boolean
 let mockWinnerStats: Record<string, unknown>[]
 const challengeDetailStyles = readFileSync(`${__dirname}/ChallengeDetailsPage.module.scss`, 'utf8')
 
@@ -419,6 +422,8 @@ describe('ChallengeDetailsPage member flows', () => {
         mockRegistrants = []
         mockReviewSummations = []
         mockSubmissions = []
+        mockSubmissionsError = undefined
+        mockSubmissionsLoaded = true
         mockWinnerStats = []
         mockChallenge = {
             description: 'Challenge requirements',
@@ -440,6 +445,7 @@ describe('ChallengeDetailsPage member flows', () => {
             typeof update === 'function' ? update(mockChallenge) : update
         ))
         mockMySubmissionCountMutate.mockResolvedValue(mockMySubmissionCount)
+        mockSubmissionsMutate.mockResolvedValue(undefined)
         mockRegistrationMutate.mockImplementation(async () => (
             mockRegistrationRemoved ? undefined : mockRegistration
         ))
@@ -467,7 +473,13 @@ describe('ChallengeDetailsPage member flows', () => {
             }
 
             if (Array.isArray(key) && key[0] === 'opportunities:submissions') {
-                return swrResponse(submissionPage(mockSubmissions))
+                return {
+                    ...swrResponse(mockSubmissionsLoaded
+                        ? submissionPage(mockSubmissions)
+                        : undefined),
+                    error: mockSubmissionsError,
+                    mutate: mockSubmissionsMutate,
+                }
             }
 
             if (Array.isArray(key) && key[0] === 'opportunities:my-submission-count') {
@@ -1178,7 +1190,51 @@ describe('ChallengeDetailsPage member flows', () => {
             && key[2] === '123'
         ))
         expect(submissionRequest?.[2])
-            .toMatchObject({ refreshInterval: 30000, shouldRetryOnError: false })
+            .toMatchObject({
+                errorRetryCount: 2,
+                errorRetryInterval: 10000,
+                refreshInterval: 30000,
+                revalidateOnFocus: true,
+                shouldRetryOnError: true,
+            })
+    })
+
+    it('keeps loaded My Submissions visible through a transient refresh failure', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockChallenge = { ...mockChallenge, status: 'ACTIVE' }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'cached-submission',
+            status: 'ACTIVE',
+            type: 'CONTEST_SUBMISSION',
+        }]
+        mockSubmissionsError = new Error('Temporary Review API failure')
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByText('cached-submission'))
+            .toBeInTheDocument()
+        expect(screen.queryByRole('heading', { name: 'This section could not be loaded.' }))
+            .not.toBeInTheDocument()
+    })
+
+    it('keeps the explicit retry action for an initial My Submissions failure', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockChallenge = { ...mockChallenge, status: 'ACTIVE' }
+        mockSubmissionsError = new Error('Review API unavailable')
+        mockSubmissionsLoaded = false
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByRole('heading', { name: 'This section could not be loaded.' }))
+            .toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+        expect(mockSubmissionsMutate)
+            .toHaveBeenCalledTimes(1)
     })
 
     it('does not offer a clean-storage download for an external URL submission', () => {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -112,6 +112,8 @@ type ChallengeTab = ChallengeDetailTab
 const STALE_REGISTRATION_MESSAGE
     = 'Your registration is no longer active. Register again before submitting.'
 const ACTIVE_SUBMISSIONS_REFRESH_INTERVAL_MS = 30_000
+const ACTIVE_SUBMISSIONS_ERROR_RETRY_INTERVAL_MS = 10_000
+const ACTIVE_SUBMISSIONS_ERROR_RETRY_COUNT = 2
 
 /**
  * Determines whether a Design submission can still be removed while an
@@ -1205,6 +1207,8 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
     const isDesign = trackKey === 'design'
     const isQa = trackKey === 'qualityassurance'
     const isMarathonMatch = isMarathonMatchChallenge(props.challenge)
+    const refreshActiveMySubmissions = !!props.mine
+        && props.challenge.status?.toUpperCase() === 'ACTIVE'
     const privateDesignSubmissions = isDesign
         && !props.mine
         && !challengeMetadataFlag(props.challenge, 'submissionsViewable')
@@ -1232,11 +1236,13 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                 sortOrder,
             )),
         {
-            refreshInterval: props.mine && props.challenge.status?.toUpperCase() === 'ACTIVE'
+            errorRetryCount: ACTIVE_SUBMISSIONS_ERROR_RETRY_COUNT,
+            errorRetryInterval: ACTIVE_SUBMISSIONS_ERROR_RETRY_INTERVAL_MS,
+            refreshInterval: refreshActiveMySubmissions
                 ? ACTIVE_SUBMISSIONS_REFRESH_INTERVAL_MS
                 : 0,
-            revalidateOnFocus: false,
-            shouldRetryOnError: false,
+            revalidateOnFocus: refreshActiveMySubmissions,
+            shouldRetryOnError: refreshActiveMySubmissions,
         },
     )
     const previewResponse: SWRResponse<OpportunityPage<ChallengeSubmission>, Error> = useSWR(
@@ -1351,7 +1357,10 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         return <OpportunityTabLoading label='Loading submissions' />
     }
 
-    if (response.error) return <TabError onRetry={() => response.mutate()} />
+    if (response.error && response.data === undefined) {
+        return <TabError onRetry={() => response.mutate()} />
+    }
+
     if (!response.data?.items.length) {
         if (props.mine) {
             return (


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6306

# What is in this PR?

- Preserves the last successful My Submissions page when a background refresh fails.
- Reserves the full retry state for initial loads with no cached data.
- Adds bounded retry and focus revalidation for active My Submissions pages.
- Documents and tests the recovery behavior.

## Validation

- 54 focused challenge-detail tests passed.
- Full lint passed.
- TypeScript no-emit check passed.
- Production build passed with existing warnings only.