### PR TITLE
PM-6302: Show completed submission review status

### DIFF
--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -1181,6 +1181,95 @@ describe('ChallengeDetailsPage member flows', () => {
             .toMatchObject({ refreshInterval: 30000, shouldRetryOnError: false })
     })
 
+    it('shows an active submission as completed after its challenge completes', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-1',
+            status: 'ACTIVE',
+            type: 'CONTEST_SUBMISSION',
+        }]
+        mockChallenge = { ...mockChallenge, status: 'COMPLETED' }
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByText('Completed'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('In Review'))
+            .not.toBeInTheDocument()
+    })
+
+    it('shows an active submission as completed once the Review phase actually ends', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-1',
+            status: 'ACTIVE',
+            type: 'CONTEST_SUBMISSION',
+        }]
+        mockChallenge = {
+            ...mockChallenge,
+            phases: [{
+                actualEndDate: '2026-06-04T09:30:00.000Z',
+                isOpen: false,
+                name: 'Review',
+            }],
+            status: 'ACTIVE',
+        }
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByText('Completed'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('In Review'))
+            .not.toBeInTheDocument()
+    })
+
+    it('shows an active submission as completed when its final review summation arrives', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-1',
+            reviewSummation: [{ aggregateScore: 92.5, isFinal: true }],
+            status: 'ACTIVE',
+            type: 'CONTEST_SUBMISSION',
+        }]
+        mockChallenge = { ...mockChallenge, phases: [], status: 'ACTIVE' }
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByText('Completed'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('In Review'))
+            .not.toBeInTheDocument()
+    })
+
+    it('preserves an explicit failed submission status after challenge completion', () => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockSubmissions = [{
+            createdAt: '2026-06-03T09:30:00.000Z',
+            id: 'submission-1',
+            status: 'FAILED_REVIEW',
+            type: 'CONTEST_SUBMISSION',
+        }]
+        mockChallenge = { ...mockChallenge, status: 'COMPLETED' }
+
+        renderPage()
+        fireEvent.click(screen.getByRole('tab', { name: 'My Submissions' }))
+
+        expect(screen.getByText('Failed Review'))
+            .toBeInTheDocument()
+        expect(screen.queryByText('Completed'))
+            .not.toBeInTheDocument()
+    })
+
     it('does not offer a clean-storage download for an external URL submission', () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -207,15 +207,37 @@ function submissionTypeLabel(value?: string): string {
 /**
  * Formats the member-facing lifecycle shown in My Submissions.
  *
- * @param value optional Review API status token.
+ * @param submission Review API submission and any attached review aggregates.
+ * @param challenge owning challenge lifecycle and phases.
  * @returns normalized lifecycle label or an em dash.
  * @throws Does not throw.
  */
-function submissionStatusLabel(value?: string): string {
+function submissionStatusLabel(
+    submission: ChallengeSubmission,
+    challenge: ChallengeOpportunity,
+): string {
+    const value = submission.status
     if (!value) return '—'
     if (value.trim()
-        .toUpperCase() === 'ACTIVE') return 'In Review'
-    return submissionTypeLabel(value)
+        .toUpperCase() !== 'ACTIVE') return submissionTypeLabel(value)
+
+    const reviewCompleted = challenge.status?.trim()
+        .toUpperCase() === 'COMPLETED'
+        || (challenge.phases ?? []).some(phase => (
+            challengeCatalogKey(phase.name) === 'review' && !!phase.actualEndDate
+        ))
+        || [
+            ...(submission.reviewSummation ?? []),
+            ...(submission.reviewSummations ?? []),
+        ].some(summation => (
+            summation.isFinal === true
+            || summation.is_final === true
+            || summation.type?.trim()
+                .toLowerCase() === 'final'
+        ))
+
+    if (reviewCompleted) return 'Completed'
+    return 'In Review'
 }
 
 interface TabConfig {
@@ -1527,7 +1549,7 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
                                             <>
                                                 <td data-mobile-label='Current Status'>
                                                     <span className={styles.currentStatus}>
-                                                        {submissionStatusLabel(submission.status)}
+                                                        {submissionStatusLabel(submission, props.challenge)}
                                                     </span>
                                                 </td>
                                                 <td data-mobile-label='Score'>


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6302

# What is in this PR?

- Treats Review API ACTIVE as a record state rather than unconditional proof that review is ongoing.
- Shows Completed when the challenge, Review phase, or final review summation establishes completion.
- Preserves In Review for active reviews and explicit failure labels for failed submissions.
- Adds regression coverage for each lifecycle signal and precedence case.

## Validation

- 56 focused challenge-detail tests passed.
- Full lint passed.
- TypeScript no-emit check passed.
- Production build passed with existing warnings only.