### PR TITLE
PM-6311: Remove My Submissions desktop scrollbar

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -202,8 +202,9 @@ All Submissions and My Submissions use the same responsive record-card
 contract. Every track-specific field and action receives a visible mobile key,
 while Submission Date sorting stays above the card and continues to request
 owner-sorted pages.
-Marathon My Submissions retains its wider score columns and horizontal overflow
-on larger screens, while phone record cards fit the available content width.
+Marathon My Submissions uses compact column spacing so the complete scorer table
+fits within its desktop card. Narrow table layouts retain contained horizontal
+overflow until phone record cards take over at the mobile breakpoint.
 
 The My Submissions heading keeps its Review App handoff, but phone layouts
 stack that action below the heading copy at full content width so neither the
@@ -396,9 +397,8 @@ exception. Scores retain the full numeric precision available from the API
 without display rounding across Submissions, My Submissions, Winners,
 submission history, and Marathon Match dashboard tooltips and accessible data.
 Thousands separators, valid zero, and negative scorer sentinels retain their
-established handling. The wide My Submissions scorer table scrolls within its
-card so those full-precision values cannot overlap adjacent score or action
-columns.
+established handling. Compact My Submissions columns preserve those
+full-precision values without overlapping adjacent score or action columns.
 The Figma keeps separate Provisional Score and Final Score columns and uses
 `-` when a final value is not yet available. Winners use Review API's canonical
 `GET /v6/projectResult` member-and-placement result instead of inferring a

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -1577,6 +1577,15 @@ describe('ChallengeDetailsPage member flows', () => {
             .toMatchObject({ shouldRetryOnError: false })
     })
 
+    it('keeps the Marathon Match submissions table compact on desktop', () => {
+        expect(challengeDetailStyles)
+            .toMatch(/\.myMarathonTable\s*\{[\s\S]*?th,\s*td\s*\{\s*padding-inline: 8px;/)
+        expect(challengeDetailStyles)
+            .toMatch(/\.myMarathonTableCard\s*\{[\s\S]*?\.myMarathonTable\s*\{\s*min-width: 1200px;/)
+        expect(challengeDetailStyles)
+            .not.toContain('min-width: 1280px;')
+    })
+
     it('preserves full precision for both Marathon Match score phases in Submissions', () => {
         mockProfile = { handle: 'coder', userId: 123 }
         mockRegistration = { id: 'resource-id' }

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
@@ -429,14 +429,19 @@
 }
 
 .myMarathonTable {
-    th:first-child { width: 138px; }
-    th:nth-child(2) { width: 208px; }
-    th:nth-child(3) { width: 168px; }
-    th:nth-child(4) { width: 120px; }
-    th:nth-child(5) { width: 149px; }
+    th,
+    td {
+        padding-inline: 8px;
+    }
+
+    th:first-child { width: 120px; }
+    th:nth-child(2) { width: 190px; }
+    th:nth-child(3) { width: 150px; }
+    th:nth-child(4) { width: 105px; }
+    th:nth-child(5) { width: 140px; }
     th:nth-child(6),
-    th:nth-child(7) { width: 170px; }
-    th:nth-child(8) { width: 144px; }
+    th:nth-child(7) { width: 150px; }
+    th:nth-child(8) { width: 120px; }
 
     th:nth-child(2),
     td:nth-child(2) {
@@ -458,7 +463,7 @@
     overflow-x: auto;
 
     .myMarathonTable {
-        min-width: 1280px;
+        min-width: 1200px;
     }
 }
 


### PR DESCRIPTION
## Related JIRA Ticket:
https://topcoder.atlassian.net/browse/PM-6311

# What's in this PR?

- compacts the Marathon Match My Submissions columns and cell spacing
- removes the unnecessary horizontal scrollbar at the desktop design width
- preserves contained overflow on narrower table layouts and the mobile record-card layout
- adds a regression assertion and updates the Opportunities documentation

## Validation

- focused Opportunities flow tests: 61/61 passed
- full lint passed
- TypeScript no-emit check passed
- production build passed with an 8 GB heap (existing warnings only)
- Chromium layout checks confirmed equal client and scroll widths at the reported desktop size and on mobile
- git diff --check passed