### PR TITLE
PM-6309 Fix completed submission empty state and tab counts

### DIFF
--- a/src/apps/opportunities/README.md
+++ b/src/apps/opportunities/README.md
@@ -366,6 +366,19 @@ Design challenges without the flag keep challenge-wide submissions private and
 render the explicit private state. A registered member's My Submissions table
 remains available independently of that public release flag.
 
+For registered members with no submissions, completed or cancelled challenges
+show Daniela's [PM-6309 empty state](https://www.figma.com/design/ox68RqPcbhD7oJvU3TkhLP/Topcoder-Opportunities-Experience---Final-Aug-2026?node-id=14868-57021):
+“Submission phase has ended” and “This challenge is no longer accepting
+submissions.” The panel retains the Review App link and omits the upload button.
+An upload action is available only while `challengeSubmissionIsOpen` reports an
+open submission phase, including checkpoint, final-fix, and legacy Open phases.
+Other closed phases keep neutral empty-state copy, so registration or a gap
+between submission rounds does not incorrectly claim the challenge has ended.
+
+Challenge detail tabs (Registrants, Submissions, My Submissions, and Forum) and
+the review opportunity Applications tab show count badges only for positive
+counts. Zero or unavailable counts leave the tab label and navigation intact.
+
 Opportunity detail tabs keep their page header and tab navigation mounted while
 the selected panel changes. Lazy challenge panels use a panel-scoped loading
 state, so loading Registrants, Submissions, Dashboard, Forum, or a forum topic

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.flows.spec.tsx
@@ -208,6 +208,7 @@ jest.mock('../components', () => ({
 }))
 
 jest.mock('../components/challenge-card.utils', () => ({
+    ...jest.requireActual('../components/challenge-card.utils'),
     challengeCatalogKey: (value?: string | { name?: string }): string => (
         typeof value === 'string' ? value : value?.name ?? ''
     )
@@ -442,6 +443,8 @@ describe('ChallengeDetailsPage member flows', () => {
             numOfPosts: 3,
             numOfRegistrants: 8,
             numOfSubmissions: 5,
+            phases: [{ isOpen: true, name: 'Submission' }],
+            status: 'ACTIVE',
             track: 'Development',
             type: 'Challenge',
         }
@@ -975,6 +978,92 @@ describe('ChallengeDetailsPage member flows', () => {
             .toContain('.mySubmissionHeading {')
         expect(challengeDetailStyles)
             .toContain('flex-direction: column;')
+    })
+
+    it.each([
+        ['Design', 'Challenge', 'COMPLETED'],
+        ['Development', 'Challenge', 'Completed'],
+        ['Quality Assurance', 'Challenge', 'completed'],
+        ['Data Science', 'Marathon Match', 'COMPLETED'],
+        ['Development', 'First2Finish', 'COMPLETED'],
+        ['Design', 'Challenge', 'Cancelled - Zero Submissions'],
+    ])('shows the ended empty state for %s %s (%s)', (track, type, status) => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockMySubmissionCount = 0
+        mockChallenge = { ...mockChallenge, status, track, type }
+
+        renderPage('/opportunities/challenge/challenge-id?tab=mine')
+
+        const panel = within(screen.getByRole('tabpanel'))
+        expect(panel.getByText('Submission phase has ended'))
+            .toBeInTheDocument()
+        expect(panel.getByText('This challenge is no longer accepting submissions.'))
+            .toBeInTheDocument()
+        expect(panel.queryByRole('button', { name: 'Submit a solution' }))
+            .not.toBeInTheDocument()
+        expect(panel.getByRole('link', { name: 'Open Review App' }))
+            .toHaveAttribute('href', 'https://review.topcoder-dev.com/active-challenges/challenge-id/challenge-details')
+        expect(screen.getByRole('tab', { name: 'My Submissions' }))
+            .toHaveTextContent(/^My Submissions$/)
+    })
+
+    it.each(['Submission', 'Checkpoint Submission', 'Final Fix', 'Open'])(
+        'offers the empty-state upload action while %s is open',
+        async phase => {
+            mockProfile = { handle: 'coder', userId: 123 }
+            mockRegistration = { id: 'resource-id' }
+            mockChallenge = { ...mockChallenge, currentPhaseNames: ['Registration', phase], phases: [] }
+
+            renderPage('/opportunities/challenge/challenge-id?tab=mine')
+
+            const panel = within(screen.getByRole('tabpanel'))
+            expect(panel.getByText('You have no submissions yet'))
+                .toBeInTheDocument()
+            fireEvent.click(panel.getByRole('button', { name: 'Submit a solution' }))
+            await waitFor(() => expect(screen.getByText('Submission upload form'))
+                .toBeInTheDocument())
+        },
+    )
+
+    it.each(['Registration', 'Checkpoint Review', 'Review'])(
+        'keeps the empty state neutral without an upload action during %s',
+        phase => {
+            mockProfile = { handle: 'coder', userId: 123 }
+            mockRegistration = { id: 'resource-id' }
+            mockChallenge = { ...mockChallenge, currentPhaseNames: [phase], phases: [] }
+
+            renderPage('/opportunities/challenge/challenge-id?tab=mine')
+
+            const panel = within(screen.getByRole('tabpanel'))
+            expect(panel.getByText('Your submissions will appear here.'))
+                .toBeInTheDocument()
+            expect(panel.queryByText('Submission phase has ended'))
+                .not.toBeInTheDocument()
+            expect(panel.queryByRole('button', { name: 'Submit a solution' }))
+                .not.toBeInTheDocument()
+        },
+    )
+
+    it.each([0, undefined])('omits %s counts without hiding the challenge tabs', count => {
+        mockProfile = { handle: 'coder', userId: 123 }
+        mockRegistration = { id: 'resource-id' }
+        mockMySubmissionCount = count
+        mockChallenge = {
+            ...mockChallenge,
+            numOfPosts: count,
+            numOfRegistrants: count,
+            numOfSubmissions: count,
+        }
+
+        renderPage()
+
+        expect(screen.getAllByRole('tab')
+            .map(tab => tab.textContent))
+            .toEqual(['Requirements', 'Registrants', 'Submissions', 'My Submissions', 'Forum', 'Winners'])
+        fireEvent.click(screen.getByRole('tab', { name: 'Forum' }))
+        expect(screen.getByText('Forum content'))
+            .toBeInTheDocument()
     })
 
     it('keeps the Marathon graph only in the metadata-gated Dashboard tab', () => {
@@ -2011,6 +2100,7 @@ describe('ChallengeDetailsPage member flows', () => {
         mockProfile = { handle: 'viewer', userId: 123 }
         mockChallenge = {
             ...mockChallenge,
+            phases: [],
             status: 'COMPLETED',
             type: 'Marathon Match',
             winners: Array.from({ length: 6 }, (_value, index) => ({

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.module.scss
@@ -1089,7 +1089,20 @@
 }
 
 .mySubmissionsEmpty .emptyTab {
-    min-height: 250px;
+    justify-content: flex-start;
+    min-height: 0;
+    padding-bottom: 120px;
+
+    > svg {
+        background: rgba(22, 22, 22, .1);
+        height: 20px;
+        width: 20px;
+    }
+
+    > strong {
+        font-family: inherit;
+        margin-top: 16px;
+    }
 }
 
 @media (max-width: 1120px) {

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.submission-replacement.spec.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.submission-replacement.spec.tsx
@@ -232,7 +232,7 @@ describe('PM-5987 Design submission replacement without reloading', () => {
 
         await screen.findByText('You have no submissions yet')
         await waitFor(() => expect(screen.getByRole('tab', { name: /^My Submissions/ }))
-            .toHaveTextContent('My Submissions0'))
+            .toHaveTextContent(/^My Submissions$/))
         expect(screen.getByRole('tab', { name: /^Submissions/ }))
             .toHaveTextContent(`Submissions${OTHER_MEMBER_SUBMISSIONS}`)
         expect(screen.getByRole('button', { name: 'Unregister' }))

--- a/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ChallengeDetailsPage.tsx
@@ -50,6 +50,7 @@ import {
     challengeCatalogKey,
     ChallengePlacementPrize,
     challengePlacementPrizes,
+    challengeSubmissionIsOpen,
 } from '../components/challenge-card.utils'
 import {
     ChallengeAiReviewConfig,
@@ -100,6 +101,7 @@ import {
     ChallengeDetailTab,
     challengeDetailTabFromSearch,
 } from '../utils/challenge-detail-route.utils'
+import { ReactComponent as EmptyInfoIcon } from '../assets/empty-info.svg'
 import { ReactComponent as SortIcon } from '../assets/sort.svg'
 import medal1 from '../assets/medal-1.svg'
 import medal2 from '../assets/medal-2.svg'
@@ -313,7 +315,7 @@ function formatTimestamp(value?: string): string {
 /**
  * Renders the replacement challenge details route with lazy tab data, Markdown
  * table of contents, Review App rail, registration terms, Task-aware member
- * workflows, and Support reporting.
+ * workflows, positive tab counts, and Support reporting.
  *
  * @returns challenge detail page for `/opportunities/challenge/:challengeId`.
  * @throws Does not throw; request failures render in-page recovery states.
@@ -531,13 +533,15 @@ export const ChallengeDetailsPage: FC = () => {
     }
 
     /**
-     * Opens the Figma submission flow under the member's revalidated My Submissions tab.
+     * Opens the Figma submission flow under the member's revalidated My Submissions tab
+     * only while the challenge accepts submissions.
      *
      * @returns promise settled after selecting the tab, restoring registration state,
      * or redirecting an anonymous member to sign in.
      * @throws Does not throw.
      */
     const startSubmission = async (): Promise<void> => {
+        if (!challenge || !challengeSubmissionIsOpen(challenge)) return
         if (!memberId) {
             window.location.assign(authUrlLogin(window.location.href))
             return
@@ -783,7 +787,7 @@ export const ChallengeDetailsPage: FC = () => {
                             type='button'
                         >
                             {tab.label}
-                            {tab.count !== undefined && <span>{tab.count}</span>}
+                            {(tab.count ?? 0) > 0 && <span>{tab.count}</span>}
                         </button>
                     ))}
                 </div>
@@ -1227,7 +1231,7 @@ interface SubmissionsTabProps {
  * Loads and paginates submissions only after a submission tab is selected.
  *
  * @param props challenge, member scope, viewer identity, My Submissions flag, and submission callbacks.
- * @returns submission table/gallery or request state.
+ * @returns submission table/gallery, lifecycle-aware empty state, or request state.
  * @throws Does not throw; request failures render a retry action.
  */
 const SubmissionsTab: FC<SubmissionsTabProps> = props => {
@@ -1423,8 +1427,8 @@ const SubmissionsTab: FC<SubmissionsTabProps> = props => {
         if (props.mine) {
             return (
                 <MySubmissionsEmpty
+                    challenge={props.challenge}
                     onStartSubmission={props.onStartSubmission}
-                    reviewUrl={challengeReviewAppUrl(props.challenge.id)}
                 />
             )
         }
@@ -2357,44 +2361,57 @@ const WinnersTab: FC<{ challenge: ChallengeOpportunity, memberId?: string }> = p
 }
 
 /**
- * Renders the empty My Submissions state with its primary upload action.
+ * Renders the Figma empty My Submissions state for the challenge lifecycle.
+ * Completed or cancelled challenges explain that submissions have ended; other
+ * closed phases retain a neutral message. Only open submission phases offer upload.
  *
- * @param props optional upload action shown inside the empty state.
- * @returns empty-state panel.
+ * @param props owning challenge and optional callback that opens the upload flow.
+ * @returns empty-state panel with the Review App handoff and any available upload action.
  * @throws Does not throw.
  */
 const MySubmissionsEmpty: FC<{
+    challenge: ChallengeOpportunity
     onStartSubmission?: () => void
-    reviewUrl: string
-}> = props => (
-    <section className={styles.mySubmissionsEmpty}>
-        <div className={`${styles.submissionHeading} ${styles.mySubmissionHeading}`}>
-            <div>
-                <h2>My Submissions</h2>
-                <p>Manage your submissions or upload new.</p>
+}> = props => {
+    const submissionOpen = challengeSubmissionIsOpen(props.challenge)
+    const status = challengeCatalogKey(props.challenge.status)
+    const submissionEnded = status === 'completed' || status.startsWith('cancelled')
+
+    return (
+        <section className={styles.mySubmissionsEmpty}>
+            <div className={`${styles.submissionHeading} ${styles.mySubmissionHeading}`}>
+                <div>
+                    <h2>My Submissions</h2>
+                    <p>Manage your submissions or upload new.</p>
+                </div>
+                <a
+                    className={styles.reviewAppButton}
+                    href={challengeReviewAppUrl(props.challenge.id)}
+                    rel='noreferrer'
+                    target='_blank'
+                >
+                    Open Review App
+                    <IconOutline.ExternalLinkIcon aria-hidden='true' />
+                </a>
             </div>
-            <a
-                className={styles.reviewAppButton}
-                href={props.reviewUrl}
-                rel='noreferrer'
-                target='_blank'
-            >
-                Open Review App
-                <IconOutline.ExternalLinkIcon aria-hidden='true' />
-            </a>
-        </div>
-        <EmptyTab
-            action={(
-                <button onClick={props.onStartSubmission} type='button'>
-                    <IconOutline.UploadIcon />
-                    Submit a solution
-                </button>
-            )}
-            title='You have no submissions yet'
-            text='Upload a submission to compete in this challenge.'
-        />
-    </section>
-)
+            <EmptyTab
+                action={submissionOpen && props.onStartSubmission && (
+                    <button onClick={props.onStartSubmission} type='button'>
+                        <IconOutline.UploadIcon aria-hidden='true' />
+                        Submit a solution
+                    </button>
+                )}
+                icon={<EmptyInfoIcon aria-hidden='true' />}
+                title={submissionEnded ? 'Submission phase has ended' : 'You have no submissions yet'}
+                text={submissionEnded
+                    ? 'This challenge is no longer accepting submissions.'
+                    : submissionOpen
+                        ? 'Upload a submission to compete in this challenge.'
+                        : 'Your submissions will appear here.'}
+            />
+        </section>
+    )
+}
 
 /**
  * Renders the authentication handoff for a private member tab.
@@ -2428,20 +2445,21 @@ const TabError: FC<{ onRetry: () => void }> = props => (
 
 interface EmptyTabProps {
     action?: ReactNode
+    icon?: ReactNode
     text: string
     title?: string
 }
 
 /**
- * Renders a neutral empty-tab message and optional in-context action.
+ * Renders a neutral empty-tab message with an optional icon and in-context action.
  *
- * @param props title, text, and optional action.
+ * @param props title, text, optional replacement for the information icon, and optional action.
  * @returns empty-state callout.
  * @throws Does not throw.
  */
 const EmptyTab: FC<EmptyTabProps> = props => (
     <div className={styles.emptyTab}>
-        <IconOutline.InformationCircleIcon />
+        {props.icon ?? <IconOutline.InformationCircleIcon />}
         {props.title && <strong>{props.title}</strong>}
         <p>{props.text}</p>
         {props.action}

--- a/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.spec.tsx
+++ b/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.spec.tsx
@@ -235,6 +235,30 @@ describe('ReviewOpportunityDetailsPage', () => {
             .toBeInTheDocument()
     })
 
+    it('hides the zero application count while keeping the Applications tab available', () => {
+        mockUseSWR.mockReturnValue({
+            data: reviewFixture({ applications: [{ id: 'cancelled', status: 'CANCELLED' }] }),
+            isValidating: false,
+            mutate: jest.fn(),
+        })
+
+        renderPage()
+
+        const tab = screen.getByRole('tab', { name: 'Applications' })
+        expect(tab)
+            .toHaveTextContent(/^Applications$/)
+        fireEvent.click(tab)
+        expect(tab)
+            .toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('shows the positive count for visible reviewer applications', () => {
+        renderPage()
+
+        expect(screen.getByRole('tab', { name: 'Applications 2' }))
+            .toHaveTextContent(/^Applications2$/)
+    })
+
     it('sorts applications in both directions from the application-date header', () => {
         renderPage()
         fireEvent.click(screen.getByRole('tab', { name: /Applications/ }))

--- a/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.tsx
+++ b/src/apps/opportunities/src/pages/ReviewOpportunityDetailsPage.tsx
@@ -213,6 +213,7 @@ const MobileApplicationSort: FC<MobileApplicationSortProps> = props => (
  * Renders a public review opportunity with API-authoritative reviewer gating.
  * Non-reviewers receive the education card and an inactive CTA; reviewers do
  * not receive that card and can apply only when `canApply` is true.
+ * The Applications tab displays a count only when visible applications exist.
  *
  * @returns detail route for `/opportunities/review/:reviewOpportunityId`.
  * @throws Does not throw; API failures render an in-page state.
@@ -501,7 +502,7 @@ export const ReviewOpportunityDetailsPage: FC = () => {
                         type='button'
                     >
                         Applications
-                        <span>{applicationTotal}</span>
+                        {applicationTotal > 0 && <span>{applicationTotal}</span>}
                     </button>
                     <i aria-hidden='true' />
                 </div>


### PR DESCRIPTION
## Related JIRA Ticket:

https://topcoder.atlassian.net/browse/PM-6309

# What's in this PR?

Registered members with no submissions now see Daniela's completed-challenge message, “Submission phase has ended,” without a Submit a solution button. The panel follows the [Figma update](https://www.figma.com/design/ox68RqPcbhD7oJvU3TkhLP/Topcoder-Opportunities-Experience---Final-Aug-2026?node-id=14868-57021), reusing the existing information icon and empty-state component while retaining the Review App handoff.

- Apply the ended state across challenge tracks and cancelled challenges. Offer upload only during open submission phases; keep neutral copy during registration and gaps between submission rounds.
- Hide zero or unavailable count badges on Registrants, Submissions, My Submissions, Forum, and review opportunity Applications tabs. Keep the tabs usable and continue displaying positive counts.
- Update the opportunities documentation and regression coverage, including deleting the last submission and returning its tab to a label without a count.

## Validation

- `yarn lint` passes.
- `NODE_OPTIONS=--max-old-space-size=12288 yarn run build` passes with existing source-map, CSS-order, and bundle-size warnings.
- 136 tests pass across the challenge detail member flows, submission replacement, review details, challenge phase utilities, and challenge header suites. The local Jest command pins React and React DOM resolution to this worktree's dependencies because the shared installation otherwise resolves multiple React copies.
- Chromium checks of the rendered empty-state component and its real stylesheet pass at 1680px and 375px for both completed and active challenges, including icon size, spacing, centering, action visibility, and absence of horizontal overflow.
